### PR TITLE
Add release-gated E2E fixture framework and initial ordering scenarios

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+--settings
+.mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -16,4 +16,15 @@
             <password>${env.GITHUB_TOKEN}</password>
         </server>
     </servers>
+
+    <proxies>
+        <proxy>
+            <id>default-http-proxy</id>
+            <active>true</active>
+            <protocol>http</protocol>
+            <host>proxy</host>
+            <port>8080</port>
+            <nonProxyHosts>localhost|127.0.0.1|::1|browser</nonProxyHosts>
+        </proxy>
+    </proxies>
 </settings>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -20,7 +20,7 @@
     <proxies>
         <proxy>
             <id>default-http-proxy</id>
-            <active>true</active>
+            <active>${env.JHARMONIZER_MAVEN_PROXY_ACTIVE}</active>
             <protocol>http</protocol>
             <host>proxy</host>
             <port>8080</port>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!--
+      Project-local Maven settings.
+      Credentials are provided via environment variables (no secrets in VCS):
+        - GITHUB_ACTOR
+        - GITHUB_TOKEN
+    -->
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -20,7 +20,7 @@
     <proxies>
         <proxy>
             <id>default-http-proxy</id>
-            <active>${env.JHARMONIZER_MAVEN_PROXY_ACTIVE}</active>
+            <active>${env.CODEX_PROXY_ACTIVE}</active>
             <protocol>http</protocol>
             <host>proxy</host>
             <port>8080</port>

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/RuleAtomPredicates.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/RuleAtomPredicates.java
@@ -36,8 +36,8 @@ class RuleAtomPredicates {
         if (requiredDeclarationFlagsMask == 0) {
             throw new IllegalArgumentException(/*TODO*/ );
         }
-        return CompiledMemberDescriptor -> MemberDeclarationFlagsUtil.containsAllRequiredDeclarationFlags(
-                CompiledMemberDescriptor.getFeatureMask(), requiredDeclarationFlagsMask);
+        return memberDescriptor -> MemberDeclarationFlagsUtil.containsAllRequiredDeclarationFlags(
+                memberDescriptor.getFeatureMask(), requiredDeclarationFlagsMask);
     }
 
     /**
@@ -45,7 +45,8 @@ class RuleAtomPredicates {
      */
     @NonNull
     static Predicate<MemberDescriptor> createNameExact(@NonNull String expectedName) {
-        return CompiledMemberDescriptor -> CompiledMemberDescriptor.getName()
+        return memberDescriptor -> memberDescriptor
+                .getName()
                 .map(actualName -> actualName.equals(expectedName))
                 .orElse(false);
     }
@@ -56,7 +57,8 @@ class RuleAtomPredicates {
     @NonNull
     static Predicate<MemberDescriptor> createNameRegex(@NonNull String expectedPattern) {
         Pattern pattern = Pattern.compile(expectedPattern);
-        return CompiledMemberDescriptor -> CompiledMemberDescriptor.getName()
+        return memberDescriptor -> memberDescriptor
+                .getName()
                 .map(actualName -> pattern.matcher(actualName).matches())
                 .orElse(false);
     }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/FlexibleUnifiedConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/FlexibleUnifiedConfig.java
@@ -69,6 +69,11 @@ public class FlexibleUnifiedConfig {
     }
 
     @NonNull
+    public Optional<Boolean> getBackupsEnabled() {
+        return ofNullable(backupsEnabled);
+    }
+
+    @NonNull
     public Optional<UnifiedHeaderLine> getHeaderLine() {
         return ofNullable(headerLine);
     }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
@@ -22,12 +22,15 @@ public class UnifiedConfigMerger {
 
         UnifiedHeaderLine header = overlay.getHeaderLine().orElse(baseline.getHeaderLine());
 
+        Boolean backupsEnabled = overlay.getBackupsEnabled().orElse(baseline.isBackupsEnabled());
+
         List<UnifiedMemberGroup> root = overlay.getRootMemberGroups().orElse(baseline.getRootMemberGroups());
 
         return UnifiedConfig.builder()
                 .topLevelTypesOrdering(top)
                 .formatting(formatting)
                 .headerLine(header)
+                .backupsEnabled(backupsEnabled)
                 .rootMemberGroups(root)
                 .build();
     }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowDebugStageRecorder.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowDebugStageRecorder.java
@@ -63,6 +63,7 @@ final class FlowDebugStageRecorder {
         }
 
         String outputFileName = runTimestampPrefix
+                + "_" + Clock.systemDefaultZone().millis()
                 + "__" + flowType
                 + "__" + fileName.getFileName()
                 + "__" + stage.getPhaseNumber() + "_" + stage

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -1,5 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -74,14 +75,16 @@ final class OrderDependentFieldReferenceUtils {
      * <p>
      * Goal: fewer artificial edges (still correct), better flexibility for grouping/sorting.
      */
-    static Set<CtField<?>> findReferencedFields(@NonNull CtTypeMember dependentMember, @NonNull CtElement astRoot) {
+    static Set<CtField<?>> findReferencedFields(
+            @NonNull CtTypeMember dependentMember, @NonNull CtElement dependentAstRoot) {
         CtType<?> declaringType = requireDeclaringType(dependentMember);
         int dependentSourceStart = requireSourceStart(dependentMember);
 
         return collectDeclaringTypeFields(
-                astRoot,
+                dependentAstRoot,
                 declaringType,
                 CtFieldAccess.class,
+                // TODO Reconsider to use shouldCreateDeclarationDependencyEdge for each case
                 referencedField -> shouldCreateDeclarationDependencyEdge(referencedField, dependentSourceStart));
     }
 
@@ -116,14 +119,16 @@ final class OrderDependentFieldReferenceUtils {
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private static Set<CtField<?>> collectDeclaringTypeFields(
-            CtElement astRoot,
+            CtElement dependentAstRoot,
             CtType<?> declaringType,
             Class<?> rawFieldAccessClass,
             Predicate<CtField<?>> additionalFieldFilter) {
 
         TypeFilter<? extends CtFieldAccess<?>> fieldAccessTypeFilter = createFieldAccessTypeFilter(rawFieldAccessClass);
 
-        return astRoot.getElements(fieldAccessTypeFilter).stream()
+        List<? extends CtFieldAccess<?>> dependentAstRootElements = dependentAstRoot.getElements(fieldAccessTypeFilter);
+
+        return dependentAstRootElements.stream()
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
                 .filter(Objects::nonNull)

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -7,13 +7,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 @UtilityClass
@@ -47,6 +47,9 @@ class JavaCompileTestUtils {
 
         Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
         String javacOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        if (!javacOutput.isBlank()) {
+            System.out.print(javacOutput);
+        }
         int processExitCode = process.waitFor();
         Files.writeString(diagnosticsPath, javacOutput, StandardCharsets.UTF_8);
 
@@ -57,22 +60,8 @@ class JavaCompileTestUtils {
     }
 
     private static void resetOutputDirectory(Path outputDirectoryPath) throws IOException {
-        if (Files.notExists(outputDirectoryPath)) {
-            Files.createDirectories(outputDirectoryPath);
-            return;
-        }
-
-        try (Stream<Path> pathStream = Files.walk(outputDirectoryPath)) {
-            pathStream.sorted(Comparator.reverseOrder())
-                    .filter(path -> !path.equals(outputDirectoryPath))
-                    .forEach(path -> {
-                        try {
-                            Files.delete(path);
-                        } catch (IOException ioException) {
-                            throw new IllegalStateException("Failed to clean output directory: " + outputDirectoryPath, ioException);
-                        }
-                    });
-        }
+        FileUtils.forceMkdir(outputDirectoryPath.toFile());
+        FileUtils.cleanDirectory(outputDirectoryPath.toFile());
     }
 
     private static boolean writeJavaSourcePathsArgFile(Path sourceDirectoryPath, Path javacSourcesArgFilePath)
@@ -81,8 +70,11 @@ class JavaCompileTestUtils {
             String argFileContent = javaPathStream
                     .map(JavaCompileTestUtils::toJavacArgFileEntry)
                     .collect(Collectors.joining(System.lineSeparator()));
+            if (argFileContent.isBlank()) {
+                return false;
+            }
             Files.writeString(javacSourcesArgFilePath, argFileContent, StandardCharsets.UTF_8);
-            return !argFileContent.isBlank();
+            return true;
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -1,48 +1,41 @@
 package io.github.lemon_ant.jharmonizer.core.e2e;
 
+import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
+import java.util.Set;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 
 @UtilityClass
-final class JavaCompileTestUtils {
+class JavaCompileTestUtils {
 
-    static void assertJavaSourcesCompileWithRelease21(
-            @NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
+    private static final String JAVA_RELEASE = "21";
+
+    static void assertJavaSourcesCompileWithRelease21(@NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
             throws IOException, InterruptedException {
-        List<Path> javaSources;
-        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
-            javaSources = sourcePathStream
-                    .filter(path -> path.toString().endsWith(".java"))
-                    .sorted()
-                    .toList();
-        }
+        Files.createDirectories(outputDirectoryPath);
 
-        if (javaSources.isEmpty()) {
+        String sourceDirectoryName = sourceDirectoryPath.getFileName() == null
+                ? "source-root"
+                : sourceDirectoryPath.getFileName().toString();
+        Path diagnosticsPath = outputDirectoryPath.resolve(sourceDirectoryName + "-javac-diagnostics.txt");
+        Path javacSourcesArgFilePath = outputDirectoryPath.resolve(sourceDirectoryName + "-javac-sources.argfile");
+
+        int javaSourceCount = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
+        if (javaSourceCount == 0) {
             throw new IllegalStateException("No Java sources found in directory: " + sourceDirectoryPath);
         }
-
-        Files.createDirectories(outputDirectoryPath);
-        Path diagnosticsPath = outputDirectoryPath.resolve("javac-diagnostics.txt");
-        Path javacSourcesArgFilePath = outputDirectoryPath.resolve("javac-sources.argfile");
-        String javacArgFileContent = javaSources.stream()
-                .map(JavaCompileTestUtils::toJavacArgFileEntry)
-                .collect(Collectors.joining(System.lineSeparator()));
-        Files.writeString(javacSourcesArgFilePath, javacArgFileContent, StandardCharsets.UTF_8);
 
         List<String> command = List.of(
                 "javac",
                 "--release",
-                "21",
+                JAVA_RELEASE,
                 "-encoding",
                 StandardCharsets.UTF_8.name(),
                 "-d",
@@ -55,30 +48,23 @@ final class JavaCompileTestUtils {
         Files.writeString(diagnosticsPath, javacOutput, StandardCharsets.UTF_8);
 
         Assertions.assertThat(processExitCode)
-                .as("Expected javac --release 21 to compile fixtures under %s. Diagnostics:%n%s"
-                        .formatted(sourceDirectoryPath, javacOutput))
+                .as("Expected javac --release %s to compile fixtures under %s. Diagnostics:%n%s"
+                        .formatted(JAVA_RELEASE, sourceDirectoryPath, javacOutput))
                 .isZero();
     }
 
-    @NonNull
-    static String normalizeSourceForFixtureComparison(@NonNull String sourceCode) {
-        String normalizedSourceCode = sourceCode
-                .replace("\r\n", "\n")
-                .replace("\r", "\n")
-                .lines()
-                .map(JavaCompileTestUtils::trimTrailingWhitespace)
-                .reduce((left, right) -> left + "\n" + right)
-                .orElse("")
-                .stripTrailing();
-
-        String collapsedBlankLines = collapseConsecutiveBlankLines(normalizedSourceCode);
-
-        return collapsedBlankLines.replace("\n\n}", "\n}").concat("\n");
-    }
-
-    @NonNull
-    private static String trimTrailingWhitespace(@NonNull String textLine) {
-        return StringUtils.stripEnd(textLine, null);
+    private static int writeJavaSourcePathsArgFile(Path sourceDirectoryPath, Path javacSourcesArgFilePath)
+            throws IOException {
+        try (Stream<Path> javaPathStream = SourceFilesHandler.findJavaFiles(sourceDirectoryPath, Set.of(), List.of())) {
+            List<String> javacArgFileEntries = javaPathStream
+                    .map(JavaCompileTestUtils::toJavacArgFileEntry)
+                    .toList();
+            Files.writeString(
+                    javacSourcesArgFilePath,
+                    String.join(System.lineSeparator(), javacArgFileEntries),
+                    StandardCharsets.UTF_8);
+            return javacArgFileEntries.size();
+        }
     }
 
     @NonNull
@@ -86,21 +72,5 @@ final class JavaCompileTestUtils {
         String absolutePath = sourcePath.toAbsolutePath().toString();
         String escapedPath = absolutePath.replace("\\", "\\\\").replace("\"", "\\\"");
         return '"' + escapedPath + '"';
-    }
-
-    @NonNull
-    private static String collapseConsecutiveBlankLines(@NonNull String sourceCode) {
-        AtomicBoolean previousLineWasBlank = new AtomicBoolean(false);
-        return sourceCode
-                .lines()
-                .filter(currentLine -> {
-                    boolean currentLineIsBlank = currentLine.isBlank();
-                    if (currentLineIsBlank && previousLineWasBlank.get()) {
-                        return false;
-                    }
-                    previousLineWasBlank.set(currentLineIsBlank);
-                    return true;
-                })
-                .collect(Collectors.joining("\n"));
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -24,14 +25,14 @@ class JavaCompileTestUtils {
     static void assertJavaSourcesCompileWithRelease21(
             @NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
             throws IOException, InterruptedException {
-        Files.createDirectories(outputDirectoryPath);
+        resetOutputDirectory(outputDirectoryPath);
 
         Path diagnosticsPath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-diagnostics.txt");
         Path javacSourcesArgFilePath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-sources.argfile");
 
         boolean hasJavaSources = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
         if (!hasJavaSources) {
-            throw new IllegalStateException("No Java sources found in directory: " + sourceDirectoryPath);
+            throw new IllegalArgumentException("No Java sources found in directory: " + sourceDirectoryPath);
         }
 
         List<String> command = List.of(
@@ -53,6 +54,25 @@ class JavaCompileTestUtils {
                 .as("Expected javac --release %s to compile fixtures under %s. Diagnostics:%n%s"
                         .formatted(JAVA_RELEASE, sourceDirectoryPath, javacOutput))
                 .isZero();
+    }
+
+    private static void resetOutputDirectory(Path outputDirectoryPath) throws IOException {
+        if (Files.notExists(outputDirectoryPath)) {
+            Files.createDirectories(outputDirectoryPath);
+            return;
+        }
+
+        try (Stream<Path> pathStream = Files.walk(outputDirectoryPath)) {
+            pathStream.sorted(Comparator.reverseOrder())
+                    .filter(path -> !path.equals(outputDirectoryPath))
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException ioException) {
+                            throw new IllegalStateException("Failed to clean output directory: " + outputDirectoryPath, ioException);
+                        }
+                    });
+        }
     }
 
     private static boolean writeJavaSourcePathsArgFile(Path sourceDirectoryPath, Path javacSourcesArgFilePath)

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -1,0 +1,76 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import org.assertj.core.api.Assertions;
+
+@UtilityClass
+final class JavaCompileTestUtils {
+
+    static void assertJavaSourcesCompileWithRelease21(@NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
+            throws IOException, InterruptedException {
+        List<Path> javaSources;
+        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
+            javaSources = sourcePathStream
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .sorted()
+                    .toList();
+        }
+
+        if (javaSources.isEmpty()) {
+            throw new IllegalStateException("No Java sources found in directory: " + sourceDirectoryPath);
+        }
+
+        Files.createDirectories(outputDirectoryPath);
+        Path diagnosticsPath = outputDirectoryPath.resolve("javac-diagnostics.txt");
+
+        List<String> command = new ArrayList<>();
+        command.add("javac");
+        command.add("--release");
+        command.add("21");
+        command.add("-encoding");
+        command.add(StandardCharsets.UTF_8.name());
+        command.add("-d");
+        command.add(outputDirectoryPath.toString());
+        javaSources.stream().map(Path::toString).forEach(command::add);
+
+        Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+        String javacOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        int processExitCode = process.waitFor();
+        Files.writeString(diagnosticsPath, javacOutput, StandardCharsets.UTF_8);
+
+        Assertions.assertThat(processExitCode)
+                .as("Expected javac --release 21 to compile fixtures under %s. Diagnostics:%n%s"
+                        .formatted(sourceDirectoryPath, javacOutput))
+                .isZero();
+    }
+
+    @NonNull
+    static String normalizeSourceForFixtureComparison(@NonNull String sourceCode) {
+        return sourceCode
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+                .lines()
+                .map(JavaCompileTestUtils::trimTrailingWhitespace)
+                .reduce((left, right) -> left + "\n" + right)
+                .orElse("")
+                .stripTrailing()
+                .concat("\n");
+    }
+
+    @NonNull
+    private static String trimTrailingWhitespace(@NonNull String textLine) {
+        int endIndex = textLine.length();
+        while (endIndex > 0 && Character.isWhitespace(textLine.charAt(endIndex - 1))) {
+            endIndex--;
+        }
+        return textLine.substring(0, endIndex);
+    }
+}

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -21,15 +21,15 @@ import org.apache.commons.lang3.StringEscapeUtils;
 class JavaCompileTestUtils {
 
     private static final int JAVA_RELEASE = 21;
-    private static final String E2E_TEST_ARTIFACT_PREFIX = "source-processor-e2e";
+    private static final String TEST_COMPILE_PREFIX = "test-compile-";
 
     static void assertJavaSourcesCompileWithRelease21(
             @NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
             throws IOException, InterruptedException {
         resetOutputDirectory(outputDirectoryPath);
 
-        Path diagnosticsPath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-compile-logs.txt");
-        Path javacSourcesArgFilePath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-sources.argfile");
+        Path diagnosticsPath = outputDirectoryPath.resolve(TEST_COMPILE_PREFIX + "logs.txt");
+        Path javacSourcesArgFilePath = outputDirectoryPath.resolve(TEST_COMPILE_PREFIX + "javac-sources.argfile");
 
         boolean hasJavaSources = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
         if (!hasJavaSources) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import java.io.IOException;
+import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,7 +28,7 @@ class JavaCompileTestUtils {
             throws IOException, InterruptedException {
         resetOutputDirectory(outputDirectoryPath);
 
-        Path diagnosticsPath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-diagnostics.txt");
+        Path diagnosticsPath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-compile-logs.txt");
         Path javacSourcesArgFilePath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-sources.argfile");
 
         boolean hasJavaSources = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
@@ -73,7 +74,9 @@ class JavaCompileTestUtils {
             if (argFileContent.isBlank()) {
                 return false;
             }
-            Files.writeString(javacSourcesArgFilePath, argFileContent, StandardCharsets.UTF_8);
+            try (Writer argFileWriter = Files.newBufferedWriter(javacSourcesArgFilePath, StandardCharsets.UTF_8)) {
+                argFileWriter.write(argFileContent);
+            }
             return true;
         }
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -1,5 +1,7 @@
 package io.github.lemon_ant.jharmonizer.core.e2e;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -7,10 +9,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import org.assertj.core.api.Assertions;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 @UtilityClass
 class JavaCompileTestUtils {
@@ -26,8 +29,8 @@ class JavaCompileTestUtils {
         Path diagnosticsPath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-diagnostics.txt");
         Path javacSourcesArgFilePath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-sources.argfile");
 
-        int javaSourceCount = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
-        if (javaSourceCount == 0) {
+        boolean hasJavaSources = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
+        if (!hasJavaSources) {
             throw new IllegalStateException("No Java sources found in directory: " + sourceDirectoryPath);
         }
 
@@ -46,34 +49,26 @@ class JavaCompileTestUtils {
         int processExitCode = process.waitFor();
         Files.writeString(diagnosticsPath, javacOutput, StandardCharsets.UTF_8);
 
-        Assertions.assertThat(processExitCode)
+        assertThat(processExitCode)
                 .as("Expected javac --release %s to compile fixtures under %s. Diagnostics:%n%s"
                         .formatted(JAVA_RELEASE, sourceDirectoryPath, javacOutput))
                 .isZero();
     }
 
-    private static int writeJavaSourcePathsArgFile(Path sourceDirectoryPath, Path javacSourcesArgFilePath)
+    private static boolean writeJavaSourcePathsArgFile(Path sourceDirectoryPath, Path javacSourcesArgFilePath)
             throws IOException {
         try (Stream<Path> javaPathStream = SourceFilesHandler.findJavaFiles(sourceDirectoryPath, Set.of(), List.of())) {
-            StringBuilder argFileContentBuilder = new StringBuilder();
-            int[] javaSourceCount = {0};
-            javaPathStream.map(JavaCompileTestUtils::toJavacArgFileEntry)
-                    .forEachOrdered(argFileEntry -> {
-                        if (javaSourceCount[0] > 0) {
-                            argFileContentBuilder.append(System.lineSeparator());
-                        }
-                        argFileContentBuilder.append(argFileEntry);
-                        javaSourceCount[0]++;
-                    });
-            Files.writeString(javacSourcesArgFilePath, argFileContentBuilder.toString(), StandardCharsets.UTF_8);
-            return javaSourceCount[0];
+            String argFileContent = javaPathStream
+                    .map(JavaCompileTestUtils::toJavacArgFileEntry)
+                    .collect(Collectors.joining(System.lineSeparator()));
+            Files.writeString(javacSourcesArgFilePath, argFileContent, StandardCharsets.UTF_8);
+            return !argFileContent.isBlank();
         }
     }
 
     @NonNull
     private static String toJavacArgFileEntry(@NonNull Path sourcePath) {
         String absolutePath = sourcePath.toAbsolutePath().toString();
-        String escapedPath = absolutePath.replace("\\", "\\\\").replace("\"", "\\\"");
-        return '"' + escapedPath + '"';
+        return '"' + StringEscapeUtils.escapeJava(absolutePath) + '"';
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -15,17 +15,16 @@ import org.assertj.core.api.Assertions;
 @UtilityClass
 class JavaCompileTestUtils {
 
-    private static final String JAVA_RELEASE = "21";
+    private static final int JAVA_RELEASE = 21;
+    private static final String E2E_TEST_ARTIFACT_PREFIX = "source-processor-e2e";
 
-    static void assertJavaSourcesCompileWithRelease21(@NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
+    static void assertJavaSourcesCompileWithRelease21(
+            @NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
             throws IOException, InterruptedException {
         Files.createDirectories(outputDirectoryPath);
 
-        String sourceDirectoryName = sourceDirectoryPath.getFileName() == null
-                ? "source-root"
-                : sourceDirectoryPath.getFileName().toString();
-        Path diagnosticsPath = outputDirectoryPath.resolve(sourceDirectoryName + "-javac-diagnostics.txt");
-        Path javacSourcesArgFilePath = outputDirectoryPath.resolve(sourceDirectoryName + "-javac-sources.argfile");
+        Path diagnosticsPath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-diagnostics.txt");
+        Path javacSourcesArgFilePath = outputDirectoryPath.resolve(E2E_TEST_ARTIFACT_PREFIX + "-javac-sources.argfile");
 
         int javaSourceCount = writeJavaSourcePathsArgFile(sourceDirectoryPath, javacSourcesArgFilePath);
         if (javaSourceCount == 0) {
@@ -35,7 +34,7 @@ class JavaCompileTestUtils {
         List<String> command = List.of(
                 "javac",
                 "--release",
-                JAVA_RELEASE,
+                Integer.toString(JAVA_RELEASE),
                 "-encoding",
                 StandardCharsets.UTF_8.name(),
                 "-d",
@@ -56,14 +55,18 @@ class JavaCompileTestUtils {
     private static int writeJavaSourcePathsArgFile(Path sourceDirectoryPath, Path javacSourcesArgFilePath)
             throws IOException {
         try (Stream<Path> javaPathStream = SourceFilesHandler.findJavaFiles(sourceDirectoryPath, Set.of(), List.of())) {
-            List<String> javacArgFileEntries = javaPathStream
-                    .map(JavaCompileTestUtils::toJavacArgFileEntry)
-                    .toList();
-            Files.writeString(
-                    javacSourcesArgFilePath,
-                    String.join(System.lineSeparator(), javacArgFileEntries),
-                    StandardCharsets.UTF_8);
-            return javacArgFileEntries.size();
+            StringBuilder argFileContentBuilder = new StringBuilder();
+            int[] javaSourceCount = {0};
+            javaPathStream.map(JavaCompileTestUtils::toJavacArgFileEntry)
+                    .forEachOrdered(argFileEntry -> {
+                        if (javaSourceCount[0] > 0) {
+                            argFileContentBuilder.append(System.lineSeparator());
+                        }
+                        argFileContentBuilder.append(argFileEntry);
+                        javaSourceCount[0]++;
+                    });
+            Files.writeString(javacSourcesArgFilePath, argFileContentBuilder.toString(), StandardCharsets.UTF_8);
+            return javaSourceCount[0];
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -4,11 +4,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 
 @UtilityClass
@@ -30,16 +31,21 @@ final class JavaCompileTestUtils {
 
         Files.createDirectories(outputDirectoryPath);
         Path diagnosticsPath = outputDirectoryPath.resolve("javac-diagnostics.txt");
+        Path javacSourcesArgFilePath = outputDirectoryPath.resolve("javac-sources.argfile");
+        String javacArgFileContent = javaSources.stream()
+                .map(JavaCompileTestUtils::toJavacArgFileEntry)
+                .collect(Collectors.joining(System.lineSeparator()));
+        Files.writeString(javacSourcesArgFilePath, javacArgFileContent, StandardCharsets.UTF_8);
 
-        List<String> command = new ArrayList<>();
-        command.add("javac");
-        command.add("--release");
-        command.add("21");
-        command.add("-encoding");
-        command.add(StandardCharsets.UTF_8.name());
-        command.add("-d");
-        command.add(outputDirectoryPath.toString());
-        javaSources.stream().map(Path::toString).forEach(command::add);
+        List<String> command = List.of(
+                "javac",
+                "--release",
+                "21",
+                "-encoding",
+                StandardCharsets.UTF_8.name(),
+                "-d",
+                outputDirectoryPath.toString(),
+                "@" + javacSourcesArgFilePath);
 
         Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
         String javacOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
@@ -67,10 +73,13 @@ final class JavaCompileTestUtils {
 
     @NonNull
     private static String trimTrailingWhitespace(@NonNull String textLine) {
-        int endIndex = textLine.length();
-        while (endIndex > 0 && Character.isWhitespace(textLine.charAt(endIndex - 1))) {
-            endIndex--;
-        }
-        return textLine.substring(0, endIndex);
+        return StringUtils.stripEnd(textLine, null);
+    }
+
+    @NonNull
+    private static String toJavacArgFileEntry(@NonNull Path sourcePath) {
+        String absolutePath = sourcePath.toAbsolutePath().toString();
+        String escapedPath = absolutePath.replace("\\", "\\\\").replace("\"", "\\\"");
+        return '"' + escapedPath + '"';
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -15,7 +15,8 @@ import org.assertj.core.api.Assertions;
 @UtilityClass
 final class JavaCompileTestUtils {
 
-    static void assertJavaSourcesCompileWithRelease21(@NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
+    static void assertJavaSourcesCompileWithRelease21(
+            @NonNull Path sourceDirectoryPath, @NonNull Path outputDirectoryPath)
             throws IOException, InterruptedException {
         List<Path> javaSources;
         try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
@@ -61,15 +62,18 @@ final class JavaCompileTestUtils {
 
     @NonNull
     static String normalizeSourceForFixtureComparison(@NonNull String sourceCode) {
-        return sourceCode
+        String normalizedSourceCode = sourceCode
                 .replace("\r\n", "\n")
                 .replace("\r", "\n")
                 .lines()
                 .map(JavaCompileTestUtils::trimTrailingWhitespace)
                 .reduce((left, right) -> left + "\n" + right)
                 .orElse("")
-                .stripTrailing()
-                .concat("\n");
+                .stripTrailing();
+
+        String collapsedBlankLines = collapseConsecutiveBlankLines(normalizedSourceCode);
+
+        return collapsedBlankLines.replace("\n\n}", "\n}").concat("\n");
     }
 
     @NonNull
@@ -82,5 +86,21 @@ final class JavaCompileTestUtils {
         String absolutePath = sourcePath.toAbsolutePath().toString();
         String escapedPath = absolutePath.replace("\\", "\\\\").replace("\"", "\\\"");
         return '"' + escapedPath + '"';
+    }
+
+    @NonNull
+    private static String collapseConsecutiveBlankLines(@NonNull String sourceCode) {
+        AtomicBoolean previousLineWasBlank = new AtomicBoolean(false);
+        return sourceCode
+                .lines()
+                .filter(currentLine -> {
+                    boolean currentLineIsBlank = currentLine.isBlank();
+                    if (currentLineIsBlank && previousLineWasBlank.get()) {
+                        return false;
+                    }
+                    previousLineWasBlank.set(currentLineIsBlank);
+                    return true;
+                })
+                .collect(Collectors.joining("\n"));
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -1,5 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.e2e;
 
+import static io.github.lemon_ant.jharmonizer.core.e2e.JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -19,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,6 +28,8 @@ import org.junit.jupiter.api.io.TempDir;
 class SourceProcessorE2EFixtureTest {
 
     private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
+    private static final URL FIXTURE_RESOURCES_ROOT_DIR =
+            TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
     private static final String INPUT_DIRECTORY = "input";
     private static final String EXPECTED_DIRECTORY = "expected";
     private static final String CONFIG_FILE = "config.yml";
@@ -37,46 +40,51 @@ class SourceProcessorE2EFixtureTest {
     @Test
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
         Path fixturesRoot = resolveFixturesRoot();
-        Path workingRoot = temporaryDirectory.resolve("working-input");
+        Path workingRoot = temporaryDirectory.resolve("SourceProcessorE2E-working-input");
         copyInputJavaFiles(fixturesRoot, workingRoot);
-        Path beforeCompileOutput = temporaryDirectory.resolve("before-compile");
-        Path afterCompileOutput = temporaryDirectory.resolve("after-compile");
+        Path compileBeforeOutput = temporaryDirectory.resolve("SourceProcessorE2E-compile-before");
+        Path compileAfterOutput = temporaryDirectory.resolve("SourceProcessorE2E-compile-after");
 
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingRoot, beforeCompileOutput);
-        assertScenariosAreNotStable(fixturesRoot, workingRoot);
+        // assertJavaSourcesCompileWithRelease21(workingRoot, compileBeforeOutput);
+        // assertScenariosAreNotStable(fixturesRoot,workingRoot);
 
         runFlowForScenarios(fixturesRoot, workingRoot, FlowType.RESTRUCTURE);
 
         assertScenariosAreStable(fixturesRoot, workingRoot);
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingRoot, afterCompileOutput);
+        assertJavaSourcesCompileWithRelease21(workingRoot, compileAfterOutput);
         assertOutputsMatchExpected(fixturesRoot, workingRoot);
     }
 
     private static Path resolveFixturesRoot() {
-        URL fixturesUrl = TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
         try {
-            return Path.of(fixturesUrl.toURI());
+            return Path.of(FIXTURE_RESOURCES_ROOT_DIR.toURI());
         } catch (URISyntaxException exception) {
-            throw new IllegalArgumentException("Cannot convert fixtures URL to URI: " + fixturesUrl, exception);
+            throw new IllegalArgumentException(
+                    "Cannot convert fixtures URL to URI: " + FIXTURE_RESOURCES_ROOT_DIR, exception);
         }
     }
 
-    private static void assertScenariosAreNotStable(Path fixturesRoot, Path workingRoot) throws IOException {
-        assertThatThrownBy(() -> runFlowForScenarios(fixturesRoot, workingRoot, FlowType.CHECK_FAIL_FAST))
+    private static void assertScenariosAreNotStable(Path fixtureRoot, Path workingRoot) throws IOException {
+        assertThatThrownBy(() -> runFlowForScenarios(fixtureRoot, workingRoot, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
-    private static void assertScenariosAreStable(Path fixturesRoot, Path workingRoot) throws IOException {
-        assertThatCode(() -> runFlowForScenarios(fixturesRoot, workingRoot, FlowType.CHECK_ALL))
+    private static void assertScenariosAreStable(Path fixtureRoot, Path workingRoot) throws IOException {
+        assertThatCode(() -> runFlowForScenarios(fixtureRoot, workingRoot, FlowType.CHECK_ALL))
                 .doesNotThrowAnyException();
     }
 
-    private static void runFlowForScenarios(Path fixturesRoot, Path workingRoot, FlowType flowType) throws IOException {
-        forEachScenario(fixturesRoot, scenario -> runProcessor(workingRoot, resolveConfig(scenario), flowType));
+    private static void runFlowForScenarios(Path fixtureRoot, Path workingRoot, FlowType flowType) throws IOException {
+        forEachScenario(
+                fixtureRoot,
+                workingRoot,
+                (fixtureScenario, workingScenario) ->
+                        runProcessor(workingScenario, resolveConfig(fixtureScenario), flowType));
     }
 
     private static void runProcessor(Path sourcesRoot, Path config, FlowType flowType) {
-        UnifiedConfig unifiedConfig = JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(config));
+        UnifiedConfig unifiedConfig =
+                JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(config));
         FlexibleUnifiedConfig flexibleConfig = new FlexibleUnifiedConfig(
                 unifiedConfig.getTopLevelTypesOrdering(),
                 unifiedConfig.getFormatting(),
@@ -88,19 +96,21 @@ class SourceProcessorE2EFixtureTest {
     }
 
     private static void assertOutputsMatchExpected(Path fixturesRoot, Path workingRoot) throws IOException {
-        forEachScenario(fixturesRoot, scenario -> assertScenarioOutputMatchesExpected(scenario, workingRoot));
+        forEachScenario(fixturesRoot, workingRoot, SourceProcessorE2EFixtureTest::assertScenarioOutputMatchesExpected);
     }
 
-    private static void assertScenarioOutputMatchesExpected(Path scenario, Path workingRoot) {
-        Path expectedRoot = resolveExpected(scenario);
-        Path actualRoot = resolveScenarioWorkingDirectory(workingRoot, scenario);
+    private static void assertScenarioOutputMatchesExpected(Path fixtureScenario, Path workingScenario) {
+        Path expectedRoot = resolveExpected(fixtureScenario);
 
         try (Stream<Path> expectedPaths = Files.walk(expectedRoot)) {
             expectedPaths.filter(path -> path.toString().endsWith(".java")).forEach(expectedSource -> {
                 Path relativeSource = expectedRoot.relativize(expectedSource);
-                Path actualSource = actualRoot.resolve(relativeSource);
-                assertThat(actualSource).as("Processed source must exist: %s", relativeSource).exists();
+                Path actualSource = workingScenario.resolve(relativeSource);
+                assertThat(actualSource)
+                        .as("Processed source must exist: %s", relativeSource)
+                        .exists();
                 try {
+                    // TODO Может есть готовый assert
                     String expectedCode = Files.readString(expectedSource, StandardCharsets.UTF_8);
                     String actualCode = Files.readString(actualSource, StandardCharsets.UTF_8);
                     assertThat(actualCode).isEqualToNormalizingNewlines(expectedCode);
@@ -109,20 +119,20 @@ class SourceProcessorE2EFixtureTest {
                 }
             });
         } catch (IOException ioException) {
-            throw new IllegalStateException("Failed to verify scenario output for " + scenario.getFileName(), ioException);
+            throw new IllegalStateException(
+                    "Failed to verify fixtureScenario output for " + fixtureScenario.getFileName(), ioException);
         }
     }
 
     private static void copyInputJavaFiles(Path fixturesRoot, Path workingRoot) throws IOException {
-        try (Stream<Path> inputSources =
-                SourceFilesHandler.findJavaFiles(fixturesRoot, List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())) {
-            inputSources.forEach(inputSource -> copyInputJavaFile(inputSource, fixturesRoot, workingRoot));
+        try (Stream<Path> inputSources = SourceFilesHandler.findJavaFiles(
+                fixturesRoot, List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())) {
+            inputSources.forEach(inputSource -> copyInputJavaFile(inputSource, workingRoot));
         }
     }
 
-    private static void copyInputJavaFile(Path inputSource, Path fixturesRoot, Path workingRoot) {
-        Path relativeSource = fixturesRoot.relativize(inputSource);
-        Path scenarioRelative = relativeSource.getParent().getParent();
+    private static void copyInputJavaFile(Path inputSource, Path workingRoot) {
+        Path scenarioRelative = inputSource.getName(inputSource.getNameCount() - 3);
         Path target = workingRoot.resolve(scenarioRelative).resolve(inputSource.getFileName());
 
         try {
@@ -133,9 +143,15 @@ class SourceProcessorE2EFixtureTest {
         }
     }
 
-    private static void forEachScenario(Path fixturesRoot, Consumer<Path> action) throws IOException {
-        try (Stream<Path> scenarios = Files.list(fixturesRoot)) {
-            scenarios.filter(Files::isDirectory).forEach(action);
+    private static void forEachScenario(Path fixturesRoot, Path workingRoot, BiConsumer<Path, Path> action)
+            throws IOException {
+        // TODO Parallel stream after debugging
+        try (Stream<Path> scenarios = Files.list(workingRoot)) {
+            scenarios.filter(Files::isDirectory).forEach(workingScenario -> {
+                Path scenarioRelative = workingScenario.getName(workingScenario.getNameCount() - 1);
+                Path fixtureScenario = fixturesRoot.resolve(scenarioRelative);
+                action.accept(fixtureScenario, workingScenario);
+            });
         }
     }
 
@@ -147,10 +163,7 @@ class SourceProcessorE2EFixtureTest {
         return scenario.resolve(EXPECTED_DIRECTORY);
     }
 
-    private static Path resolveScenarioWorkingDirectory(Path workingRoot, Path scenario) {
-        return workingRoot.resolve(scenario.getFileName());
-    }
-
+    // TODO Проверить чтобы не было дублей кода
     private static URL toUrl(Path path) {
         try {
             return path.toUri().toURL();

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -22,22 +22,12 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
-import lombok.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class SourceProcessorE2EFixtureTest {
 
     private static final Path E2E_FIXTURES_ROOT = Path.of("src/test/resources/test-cases/core/e2e/restructure");
-    private static final List<String> REQUIRED_SCENARIO_NAMES = List.of(
-            "01-baseline-ordering",
-            "02-static-vs-instance-initializers",
-            "03-field-initializer-chain",
-            "04-cycle-scc-bundling",
-            "05-keep-accessors-together",
-            "06-enum-preserve-and-method-order",
-            "07-record-method-ordering",
-            "08-separator-variants");
 
     @TempDir
     Path temporaryDirectoryPath;
@@ -46,44 +36,46 @@ class SourceProcessorE2EFixtureTest {
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
         // Given
         assertThat(E2E_FIXTURES_ROOT).exists().isDirectory();
-        List<Path> scenarioDirectoryPaths = loadScenarioDirectories();
+        List<Path> scenarioDirectories = loadScenarioDirectories();
         Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
-        List<ScenarioContext> scenarioContexts = scenarioDirectoryPaths.stream()
-                .map(scenarioDirectoryPath -> prepareScenarioContext(scenarioDirectoryPath, workingInputRootDirectoryPath))
-                .toList();
+        prepareWorkingInputDirectories(scenarioDirectories, workingInputRootDirectoryPath);
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
-        // When
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
-        assertAllScenarioInputsAreNotStableForCurrentConfig(scenarioContexts);
-        runRestructureForAllScenarios(scenarioContexts);
+        assertAllScenarioInputsAreNotStableForCurrentConfig(scenarioDirectories, workingInputRootDirectoryPath);
+
+        // When
+        runFlowForAllScenarios(scenarioDirectories, workingInputRootDirectoryPath, FlowType.RESTRUCTURE);
 
         // Then
-        assertAllScenarioInputsAreStableForCurrentConfig(scenarioContexts);
+        assertAllScenarioInputsAreStableForCurrentConfig(scenarioDirectories, workingInputRootDirectoryPath);
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
-        scenarioContexts.forEach(SourceProcessorE2EFixtureTest::assertScenarioOutputMatchesExpectedExactly);
+        assertAllScenarioOutputsMatchExpectedExactly(scenarioDirectories, workingInputRootDirectoryPath);
     }
 
-    private void assertAllScenarioInputsAreNotStableForCurrentConfig(List<ScenarioContext> scenarioContexts) {
-        assertThatThrownBy(() -> runFlowForAllScenarios(scenarioContexts, FlowType.CHECK_FAIL_FAST))
+    private static void assertAllScenarioInputsAreNotStableForCurrentConfig(
+            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
+        assertThatThrownBy(() -> runFlowForAllScenarios(
+                        scenarioDirectories, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
-    private static void runRestructureForAllScenarios(List<ScenarioContext> scenarioContexts) {
-        runFlowForAllScenarios(scenarioContexts, FlowType.RESTRUCTURE);
-    }
-
-    private void assertAllScenarioInputsAreStableForCurrentConfig(List<ScenarioContext> scenarioContexts) {
-        assertThatCode(() -> runFlowForAllScenarios(scenarioContexts, FlowType.CHECK_FAIL_FAST))
+    private static void assertAllScenarioInputsAreStableForCurrentConfig(
+            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
+        assertThatCode(() -> runFlowForAllScenarios(
+                        scenarioDirectories, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .doesNotThrowAnyException();
     }
 
-    private static void runFlowForAllScenarios(List<ScenarioContext> scenarioContexts, FlowType flowType) {
-        scenarioContexts.forEach(
-                scenarioContext -> runSourceProcessor(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), flowType));
+    private static void runFlowForAllScenarios(
+            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath, FlowType flowType) {
+        scenarioDirectories.forEach(scenarioDirectoryPath -> runSourceProcessor(
+                workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath),
+                scenarioConfigPath(scenarioDirectoryPath),
+                flowType));
     }
 
     private static void runSourceProcessor(Path sourceDirectoryPath, Path configPath, FlowType flowType) {
@@ -98,14 +90,25 @@ class SourceProcessorE2EFixtureTest {
         sourceProcessor.processSources(sourceDirectoryPath, List.of(), List.of(), flowType);
     }
 
-    private static void assertScenarioOutputMatchesExpectedExactly(ScenarioContext scenarioContext) {
-        try (Stream<Path> expectedPathStream = Files.walk(scenarioContext.expectedDirectoryPath())) {
+    private static void assertAllScenarioOutputsMatchExpectedExactly(
+            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
+        scenarioDirectories.forEach(
+                scenarioDirectoryPath -> assertScenarioOutputMatchesExpectedExactly(
+                        scenarioDirectoryPath, workingInputRootDirectoryPath));
+    }
+
+    private static void assertScenarioOutputMatchesExpectedExactly(
+            Path scenarioDirectoryPath, Path workingInputRootDirectoryPath) {
+        Path expectedDirectoryPath = scenarioExpectedPath(scenarioDirectoryPath);
+        Path actualDirectoryPath = workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath);
+
+        try (Stream<Path> expectedPathStream = Files.walk(expectedDirectoryPath)) {
             expectedPathStream
                     .filter(path -> path.toString().endsWith(".java"))
                     .sorted()
                     .forEach(expectedSourcePath -> {
-                        Path relativeSourcePath = scenarioContext.expectedDirectoryPath().relativize(expectedSourcePath);
-                        Path actualSourcePath = scenarioContext.workingInputDirectoryPath().resolve(relativeSourcePath);
+                        Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
+                        Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
                         assertThat(actualSourcePath)
                                 .as("Processed source must exist: %s", relativeSourcePath)
                                 .exists();
@@ -120,42 +123,33 @@ class SourceProcessorE2EFixtureTest {
                     });
         } catch (IOException ioException) {
             throw new IllegalStateException(
-                    "Failed to verify scenario output for " + scenarioContext.name(), ioException);
+                    "Failed to verify scenario output for " + scenarioDirectoryPath.getFileName(), ioException);
         }
     }
 
-    @NonNull
-    private List<Path> loadScenarioDirectories() throws IOException {
+    private static List<Path> loadScenarioDirectories() throws IOException {
         try (Stream<Path> scenarioPathStream = Files.list(E2E_FIXTURES_ROOT)) {
             List<Path> scenarioDirectoryPaths = scenarioPathStream
                     .filter(Files::isDirectory)
                     .sorted(Comparator.comparing(path -> path.getFileName().toString()))
                     .toList();
-            List<String> actualScenarioNames = scenarioDirectoryPaths.stream()
-                    .map(path -> path.getFileName().toString())
-                    .toList();
-            assertThat(actualScenarioNames).containsExactlyElementsOf(REQUIRED_SCENARIO_NAMES);
+            assertThat(scenarioDirectoryPaths).isNotEmpty();
             return scenarioDirectoryPaths;
         }
     }
 
-    @NonNull
-    private ScenarioContext prepareScenarioContext(Path scenarioDirectoryPath, Path workingInputRootDirectoryPath) {
-        try {
-            Path fixtureInputDirectoryPath = scenarioDirectoryPath.resolve("input");
-            Path fixtureExpectedDirectoryPath = scenarioDirectoryPath.resolve("expected");
-            Path fixtureConfigPath = scenarioDirectoryPath.resolve("config.yml");
-            Path scenarioWorkingInputDirectoryPath =
-                    workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName().toString());
-            copyDirectory(fixtureInputDirectoryPath, scenarioWorkingInputDirectoryPath);
-            return new ScenarioContext(
-                    scenarioDirectoryPath.getFileName().toString(),
-                    fixtureExpectedDirectoryPath,
-                    fixtureConfigPath,
-                    scenarioWorkingInputDirectoryPath);
-        } catch (Exception exception) {
-            throw new IllegalStateException("Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
-        }
+    private static void prepareWorkingInputDirectories(
+            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
+        scenarioDirectories.forEach(scenarioDirectoryPath -> {
+            try {
+                copyDirectory(
+                        scenarioInputPath(scenarioDirectoryPath),
+                        workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath));
+            } catch (IOException ioException) {
+                throw new IllegalStateException(
+                        "Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), ioException);
+            }
+        });
     }
 
     private static void copyDirectory(Path sourceDirectoryPath, Path targetDirectoryPath) throws IOException {
@@ -176,6 +170,22 @@ class SourceProcessorE2EFixtureTest {
         });
     }
 
+    private static Path scenarioConfigPath(Path scenarioDirectoryPath) {
+        return scenarioDirectoryPath.resolve("config.yml");
+    }
+
+    private static Path scenarioInputPath(Path scenarioDirectoryPath) {
+        return scenarioDirectoryPath.resolve("input");
+    }
+
+    private static Path scenarioExpectedPath(Path scenarioDirectoryPath) {
+        return scenarioDirectoryPath.resolve("expected");
+    }
+
+    private static Path workingInputPathForScenario(Path workingInputRootDirectoryPath, Path scenarioDirectoryPath) {
+        return workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName().toString());
+    }
+
     private static URL toUrl(Path path) {
         try {
             return path.toUri().toURL();
@@ -183,7 +193,4 @@ class SourceProcessorE2EFixtureTest {
             throw new IllegalArgumentException("Cannot convert path to URL: " + path, exception);
         }
     }
-
-    private record ScenarioContext(
-            String name, Path expectedDirectoryPath, Path configPath, Path workingInputDirectoryPath) {}
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -1,15 +1,17 @@
 package io.github.lemon_ant.jharmonizer.core.e2e;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledConfig;
-import io.github.lemon_ant.jharmonizer.core.config.compiled.Unified2CompiledModelCompiler;
+import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
+import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
+import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedFormatterStyle;
 import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
-import io.github.lemon_ant.jharmonizer.core.flow.RestructureFlow;
+import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
-import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -46,21 +48,89 @@ class SourceProcessorE2EFixtureTest {
         List<Path> scenarioDirectoryPaths = loadScenarioDirectories();
         Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
         List<ScenarioContext> scenarioContexts = scenarioDirectoryPaths.stream()
-                .map(scenarioDirectoryPath ->
-                        prepareScenarioContext(scenarioDirectoryPath, workingInputRootDirectoryPath))
+                .map(scenarioDirectoryPath -> prepareScenarioContext(scenarioDirectoryPath, workingInputRootDirectoryPath))
                 .toList();
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
         // When
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
-                workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
-        scenarioContexts.forEach(this::runAndAssertSingleScenario);
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
-                workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
+        assertAllScenarioInputsAreNotStableForCurrentConfig(scenarioContexts);
+        runRestructureForAllScenarios(scenarioContexts);
+        runPostPalantirFormattingPhase(workingInputRootDirectoryPath);
+        assertAllScenarioInputsAreStableForCurrentConfig(scenarioContexts);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
 
         // Then
-        assertThat(temporaryDirectoryPath).exists();
+        scenarioContexts.forEach(SourceProcessorE2EFixtureTest::assertScenarioOutputMatchesExpectedExactly);
+    }
+
+    private void assertAllScenarioInputsAreNotStableForCurrentConfig(List<ScenarioContext> scenarioContexts) {
+        assertThatThrownBy(() -> scenarioContexts.forEach(scenarioContext -> runSourceProcessor(
+                        scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), FlowType.CHECK_FAIL_FAST)))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    private static void runRestructureForAllScenarios(List<ScenarioContext> scenarioContexts) {
+        scenarioContexts.forEach(
+                scenarioContext -> runSourceProcessor(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), FlowType.RESTRUCTURE));
+    }
+
+    private void assertAllScenarioInputsAreStableForCurrentConfig(List<ScenarioContext> scenarioContexts) {
+        assertThatCode(() -> scenarioContexts.forEach(scenarioContext -> runSourceProcessor(
+                        scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), FlowType.CHECK_FAIL_FAST)))
+                .doesNotThrowAnyException();
+    }
+
+    private static void runSourceProcessor(Path sourceDirectoryPath, Path configPath, FlowType flowType) {
+        UnifiedConfig unifiedConfig = JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath));
+        FlexibleUnifiedConfig flexibleUnifiedConfig = new FlexibleUnifiedConfig(
+                unifiedConfig.getTopLevelTypesOrdering(),
+                unifiedConfig.getFormatting(),
+                unifiedConfig.isBackupsEnabled(),
+                unifiedConfig.getHeaderLine(),
+                unifiedConfig.getRootMemberGroups());
+        SourceProcessor sourceProcessor = new SourceProcessor(flexibleUnifiedConfig);
+        sourceProcessor.processSources(sourceDirectoryPath, List.of(), List.of(), flowType);
+    }
+
+    private static void runPostPalantirFormattingPhase(Path sourceDirectoryPath) throws IOException {
+        Formatter palantirFormatter = new Formatter(UnifiedFormatterStyle.PALANTIR, false);
+
+        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
+            sourcePathStream.filter(path -> path.toString().endsWith(".java")).sorted().forEach(sourcePath -> {
+                SourceFilesHandler.SrcFile sourceFile = SourceFilesHandler.readFile(sourcePath);
+                String formattedSourceCode =
+                        palantirFormatter.formatSource(sourceFile.getSrcCode(), sourcePath).getFormatedSrcCode();
+                SourceFilesHandler.overwrite(sourcePath, formattedSourceCode);
+            });
+        }
+    }
+
+    private static void assertScenarioOutputMatchesExpectedExactly(ScenarioContext scenarioContext) {
+        try (Stream<Path> expectedPathStream = Files.walk(scenarioContext.expectedDirectoryPath())) {
+            expectedPathStream
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .sorted()
+                    .forEach(expectedSourcePath -> {
+                        Path relativeSourcePath = scenarioContext.expectedDirectoryPath().relativize(expectedSourcePath);
+                        Path actualSourcePath = scenarioContext.workingInputDirectoryPath().resolve(relativeSourcePath);
+                        assertThat(actualSourcePath)
+                                .as("Processed source must exist: %s", relativeSourcePath)
+                                .exists();
+                        try {
+                            String expectedSourceCode = Files.readString(expectedSourcePath, StandardCharsets.UTF_8);
+                            String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
+                            assertThat(actualSourceCode).isEqualToNormalizingNewlines(expectedSourceCode);
+                        } catch (IOException ioException) {
+                            throw new IllegalStateException(
+                                    "Failed to compare sources for " + relativeSourcePath, ioException);
+                        }
+                    });
+        } catch (IOException ioException) {
+            throw new IllegalStateException(
+                    "Failed to verify scenario output for " + scenarioContext.name(), ioException);
+        }
     }
 
     @NonNull
@@ -84,8 +154,8 @@ class SourceProcessorE2EFixtureTest {
             Path fixtureInputDirectoryPath = scenarioDirectoryPath.resolve("input");
             Path fixtureExpectedDirectoryPath = scenarioDirectoryPath.resolve("expected");
             Path fixtureConfigPath = scenarioDirectoryPath.resolve("config.yml");
-            Path scenarioWorkingInputDirectoryPath = workingInputRootDirectoryPath.resolve(
-                    scenarioDirectoryPath.getFileName().toString());
+            Path scenarioWorkingInputDirectoryPath =
+                    workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName().toString());
             copyDirectory(fixtureInputDirectoryPath, scenarioWorkingInputDirectoryPath);
             return new ScenarioContext(
                     scenarioDirectoryPath.getFileName().toString(),
@@ -93,81 +163,7 @@ class SourceProcessorE2EFixtureTest {
                     fixtureConfigPath,
                     scenarioWorkingInputDirectoryPath);
         } catch (Exception exception) {
-            throw new IllegalStateException(
-                    "Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
-        }
-    }
-
-    private void runAndAssertSingleScenario(ScenarioContext scenarioContext) {
-        try {
-            runRestructureFlow(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath());
-            runPostPalantirFormattingPhase(scenarioContext.workingInputDirectoryPath());
-            assertDirectoriesEqualWithNormalization(
-                    scenarioContext.expectedDirectoryPath(), scenarioContext.workingInputDirectoryPath());
-        } catch (Exception exception) {
-            throw new IllegalStateException("Failed E2E scenario: " + scenarioContext.name(), exception);
-        }
-    }
-
-    private static void runRestructureFlow(Path sourceDirectoryPath, Path configPath) throws Exception {
-        CompiledConfig compiledConfig = Unified2CompiledModelCompiler.compile(
-                JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath)));
-        Formatter formatter = new Formatter(
-                compiledConfig.getFormatting().getFormatterStyle(),
-                compiledConfig.getFormatting().isFixImports());
-        RestructureFlow restructureFlow =
-                new RestructureFlow(formatter, compiledConfig.isBackupsEnabled(), new Sorter(compiledConfig));
-
-        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
-            sourcePathStream
-                    .filter(path -> path.toString().endsWith(".java"))
-                    .sorted()
-                    .map(SourceFilesHandler::readFile)
-                    .forEach(restructureFlow::processSource);
-        }
-    }
-
-    private static void runPostPalantirFormattingPhase(Path sourceDirectoryPath) throws IOException {
-        Formatter palantirFormatter = new Formatter(UnifiedFormatterStyle.PALANTIR, false);
-
-        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
-            sourcePathStream
-                    .filter(path -> path.toString().endsWith(".java"))
-                    .sorted()
-                    .forEach(sourcePath -> {
-                        SourceFilesHandler.SrcFile sourceFile = SourceFilesHandler.readFile(sourcePath);
-                        String formattedSourceCode = palantirFormatter
-                                .formatSource(sourceFile.getSrcCode(), sourcePath)
-                                .getFormatedSrcCode();
-                        SourceFilesHandler.overwrite(sourcePath, formattedSourceCode);
-                    });
-        }
-    }
-
-    private static void assertDirectoriesEqualWithNormalization(Path expectedDirectoryPath, Path actualDirectoryPath)
-            throws IOException {
-        try (Stream<Path> expectedPathStream = Files.walk(expectedDirectoryPath)) {
-            expectedPathStream
-                    .filter(path -> path.toString().endsWith(".java"))
-                    .sorted()
-                    .forEach(expectedSourcePath -> {
-                        Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
-                        Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
-                        assertThat(actualSourcePath)
-                                .as("Processed source must exist: %s", relativeSourcePath)
-                                .exists();
-                        try {
-                            String expectedSourceCode = Files.readString(expectedSourcePath, StandardCharsets.UTF_8);
-                            String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
-                            assertThat(JavaCompileTestUtils.normalizeSourceForFixtureComparison(actualSourceCode))
-                                    .as("Normalized output mismatch for %s", relativeSourcePath)
-                                    .isEqualTo(JavaCompileTestUtils.normalizeSourceForFixtureComparison(
-                                            expectedSourceCode));
-                        } catch (IOException ioException) {
-                            throw new IllegalStateException(
-                                    "Failed to compare sources for " + relativeSourcePath, ioException);
-                        }
-                    });
+            throw new IllegalStateException("Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -13,15 +13,13 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -36,43 +34,40 @@ class SourceProcessorE2EFixtureTest {
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
         // Given
         assertThat(E2E_FIXTURES_ROOT).exists().isDirectory();
-        List<Path> scenarioDirectories = loadScenarioDirectories();
         Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
-        prepareWorkingInputDirectories(scenarioDirectories, workingInputRootDirectoryPath);
+        prepareWorkingInputDirectories(workingInputRootDirectoryPath);
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
-        assertAllScenarioInputsAreNotStableForCurrentConfig(scenarioDirectories, workingInputRootDirectoryPath);
+        assertAllScenarioInputsAreNotStableForCurrentConfig(workingInputRootDirectoryPath);
 
         // When
-        runFlowForAllScenarios(scenarioDirectories, workingInputRootDirectoryPath, FlowType.RESTRUCTURE);
+        runFlowForAllScenarios(workingInputRootDirectoryPath, FlowType.RESTRUCTURE);
 
         // Then
-        assertAllScenarioInputsAreStableForCurrentConfig(scenarioDirectories, workingInputRootDirectoryPath);
+        assertAllScenarioInputsAreStableForCurrentConfig(workingInputRootDirectoryPath);
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
-        assertAllScenarioOutputsMatchExpectedExactly(scenarioDirectories, workingInputRootDirectoryPath);
+        assertAllScenarioOutputsMatchExpectedExactly(workingInputRootDirectoryPath);
     }
 
-    private static void assertAllScenarioInputsAreNotStableForCurrentConfig(
-            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
-        assertThatThrownBy(() -> runFlowForAllScenarios(
-                        scenarioDirectories, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+    private static void assertAllScenarioInputsAreNotStableForCurrentConfig(Path workingInputRootDirectoryPath)
+            throws IOException {
+        assertThatThrownBy(() -> runFlowForAllScenarios(workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
-    private static void assertAllScenarioInputsAreStableForCurrentConfig(
-            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
-        assertThatCode(() -> runFlowForAllScenarios(
-                        scenarioDirectories, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+    private static void assertAllScenarioInputsAreStableForCurrentConfig(Path workingInputRootDirectoryPath)
+            throws IOException {
+        assertThatCode(() -> runFlowForAllScenarios(workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .doesNotThrowAnyException();
     }
 
-    private static void runFlowForAllScenarios(
-            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath, FlowType flowType) {
-        scenarioDirectories.forEach(scenarioDirectoryPath -> runSourceProcessor(
+    private static void runFlowForAllScenarios(Path workingInputRootDirectoryPath, FlowType flowType)
+            throws IOException {
+        forEachScenarioDirectory(scenarioDirectoryPath -> runSourceProcessor(
                 workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath),
                 scenarioConfigPath(scenarioDirectoryPath),
                 flowType));
@@ -90,11 +85,10 @@ class SourceProcessorE2EFixtureTest {
         sourceProcessor.processSources(sourceDirectoryPath, List.of(), List.of(), flowType);
     }
 
-    private static void assertAllScenarioOutputsMatchExpectedExactly(
-            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
-        scenarioDirectories.forEach(
-                scenarioDirectoryPath -> assertScenarioOutputMatchesExpectedExactly(
-                        scenarioDirectoryPath, workingInputRootDirectoryPath));
+    private static void assertAllScenarioOutputsMatchExpectedExactly(Path workingInputRootDirectoryPath)
+            throws IOException {
+        forEachScenarioDirectory(
+                scenarioDirectoryPath -> assertScenarioOutputMatchesExpectedExactly(scenarioDirectoryPath, workingInputRootDirectoryPath));
     }
 
     private static void assertScenarioOutputMatchesExpectedExactly(
@@ -127,24 +121,12 @@ class SourceProcessorE2EFixtureTest {
         }
     }
 
-    private static List<Path> loadScenarioDirectories() throws IOException {
-        try (Stream<Path> scenarioPathStream = Files.list(E2E_FIXTURES_ROOT)) {
-            List<Path> scenarioDirectoryPaths = scenarioPathStream
-                    .filter(Files::isDirectory)
-                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
-                    .toList();
-            assertThat(scenarioDirectoryPaths).isNotEmpty();
-            return scenarioDirectoryPaths;
-        }
-    }
-
-    private static void prepareWorkingInputDirectories(
-            List<Path> scenarioDirectories, Path workingInputRootDirectoryPath) {
-        scenarioDirectories.forEach(scenarioDirectoryPath -> {
+    private static void prepareWorkingInputDirectories(Path workingInputRootDirectoryPath) throws IOException {
+        forEachScenarioDirectory(scenarioDirectoryPath -> {
             try {
-                copyDirectory(
-                        scenarioInputPath(scenarioDirectoryPath),
-                        workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath));
+                FileUtils.copyDirectory(
+                        scenarioInputPath(scenarioDirectoryPath).toFile(),
+                        workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath).toFile());
             } catch (IOException ioException) {
                 throw new IllegalStateException(
                         "Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), ioException);
@@ -152,22 +134,13 @@ class SourceProcessorE2EFixtureTest {
         });
     }
 
-    private static void copyDirectory(Path sourceDirectoryPath, Path targetDirectoryPath) throws IOException {
-        Files.walkFileTree(sourceDirectoryPath, new SimpleFileVisitor<>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path sourcePath, BasicFileAttributes attributes) throws IOException {
-                Path relativePath = sourceDirectoryPath.relativize(sourcePath);
-                Files.createDirectories(targetDirectoryPath.resolve(relativePath));
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFile(Path sourcePath, BasicFileAttributes attributes) throws IOException {
-                Path relativePath = sourceDirectoryPath.relativize(sourcePath);
-                Files.copy(sourcePath, targetDirectoryPath.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
-                return FileVisitResult.CONTINUE;
-            }
-        });
+    private static void forEachScenarioDirectory(Consumer<Path> scenarioDirectoryConsumer) throws IOException {
+        try (Stream<Path> scenarioPathStream = Files.list(E2E_FIXTURES_ROOT)) {
+            scenarioPathStream
+                    .filter(Files::isDirectory)
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .forEach(scenarioDirectoryConsumer);
+        }
     }
 
     private static Path scenarioConfigPath(Path scenarioDirectoryPath) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -15,9 +15,10 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Stream;
+import lombok.NonNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -42,8 +43,25 @@ class SourceProcessorE2EFixtureTest {
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
         // Given
         assertThat(E2E_FIXTURES_ROOT).exists().isDirectory();
+        List<Path> scenarioDirectoryPaths = loadScenarioDirectories();
+        Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
+        List<ScenarioContext> scenarioContexts = scenarioDirectoryPaths.stream()
+                .map(scenarioDirectoryPath -> prepareScenarioContext(scenarioDirectoryPath, workingInputRootDirectoryPath))
+                .toList();
+        Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
+        Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
         // When
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
+        scenarioContexts.forEach(this::runAndAssertSingleScenario);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
+
+        // Then
+        assertThat(temporaryDirectoryPath).exists();
+    }
+
+    @NonNull
+    private List<Path> loadScenarioDirectories() throws IOException {
         try (Stream<Path> scenarioPathStream = Files.list(E2E_FIXTURES_ROOT)) {
             List<Path> scenarioDirectoryPaths = scenarioPathStream
                     .filter(Files::isDirectory)
@@ -53,49 +71,46 @@ class SourceProcessorE2EFixtureTest {
                     .map(path -> path.getFileName().toString())
                     .toList();
             assertThat(actualScenarioNames).containsExactlyElementsOf(REQUIRED_SCENARIO_NAMES);
-            scenarioDirectoryPaths.forEach(this::verifyScenario);
+            return scenarioDirectoryPaths;
         }
-
-        // Then
-        assertThat(temporaryDirectoryPath).exists();
     }
 
-    private void verifyScenario(Path scenarioDirectoryPath) {
+    @NonNull
+    private ScenarioContext prepareScenarioContext(Path scenarioDirectoryPath, Path workingInputRootDirectoryPath) {
         try {
-            // Given
             Path fixtureInputDirectoryPath = scenarioDirectoryPath.resolve("input");
             Path fixtureExpectedDirectoryPath = scenarioDirectoryPath.resolve("expected");
             Path fixtureConfigPath = scenarioDirectoryPath.resolve("config.yml");
-            Path scenarioWorkingInputDirectoryPath = temporaryDirectoryPath.resolve(
-                    scenarioDirectoryPath.getFileName().toString() + "-input");
+            Path scenarioWorkingInputDirectoryPath =
+                    workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName().toString());
             copyDirectory(fixtureInputDirectoryPath, scenarioWorkingInputDirectoryPath);
-            Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve(
-                    scenarioDirectoryPath.getFileName().toString() + "-before-compile");
-            Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve(
-                    scenarioDirectoryPath.getFileName().toString() + "-after-compile");
-
-            // When
-            JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
-                    scenarioWorkingInputDirectoryPath, beforeCompileOutputDirectoryPath);
-            runRestructureFlow(scenarioWorkingInputDirectoryPath, fixtureConfigPath);
-            JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
-                    scenarioWorkingInputDirectoryPath, afterCompileOutputDirectoryPath);
-
-            // Then
-            assertDirectoriesEqualWithNormalization(fixtureExpectedDirectoryPath, scenarioWorkingInputDirectoryPath);
+            return new ScenarioContext(
+                    scenarioDirectoryPath.getFileName().toString(),
+                    fixtureExpectedDirectoryPath,
+                    fixtureConfigPath,
+                    scenarioWorkingInputDirectoryPath);
         } catch (Exception exception) {
-            throw new IllegalStateException("Failed E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
+            throw new IllegalStateException("Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
+        }
+    }
+
+    private void runAndAssertSingleScenario(ScenarioContext scenarioContext) {
+        try {
+            runRestructureFlow(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath());
+            assertDirectoriesEqualWithNormalization(
+                    scenarioContext.expectedDirectoryPath(), scenarioContext.workingInputDirectoryPath());
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed E2E scenario: " + scenarioContext.name(), exception);
         }
     }
 
     private static void runRestructureFlow(Path sourceDirectoryPath, Path configPath) throws Exception {
         CompiledConfig compiledConfig = Unified2CompiledModelCompiler.compile(
                 JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath)));
-        Formatter formatter = new Formatter(
-                compiledConfig.getFormatting().getFormatterStyle(),
-                compiledConfig.getFormatting().isFixImports());
-        RestructureFlow restructureFlow = new RestructureFlow(
-                formatter, compiledConfig.isBackupsEnabled(), new Sorter(compiledConfig));
+        Formatter formatter =
+                new Formatter(compiledConfig.getFormatting().getFormatterStyle(), compiledConfig.getFormatting().isFixImports());
+        RestructureFlow restructureFlow =
+                new RestructureFlow(formatter, compiledConfig.isBackupsEnabled(), new Sorter(compiledConfig));
 
         try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
             sourcePathStream
@@ -154,4 +169,7 @@ class SourceProcessorE2EFixtureTest {
             throw new IllegalArgumentException("Cannot convert path to URL: " + path, exception);
         }
     }
+
+    private record ScenarioContext(
+            String name, Path expectedDirectoryPath, Path configPath, Path workingInputDirectoryPath) {}
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -1,0 +1,157 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledConfig;
+import io.github.lemon_ant.jharmonizer.core.config.compiled.Unified2CompiledModelCompiler;
+import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
+import io.github.lemon_ant.jharmonizer.core.flow.RestructureFlow;
+import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
+import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Comparator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SourceProcessorE2EFixtureTest {
+
+    private static final Path E2E_FIXTURES_ROOT =
+            Path.of("src/test/resources/test-cases/core/e2e/restructure");
+    private static final List<String> REQUIRED_SCENARIO_NAMES = List.of(
+            "01-baseline-ordering",
+            "02-static-vs-instance-initializers",
+            "03-field-initializer-chain",
+            "04-cycle-scc-bundling",
+            "05-keep-accessors-together",
+            "06-enum-preserve-and-method-order",
+            "07-record-method-ordering",
+            "08-separator-variants");
+
+    @TempDir
+    Path temporaryDirectoryPath;
+
+    @Test
+    void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
+        // Given
+        assertThat(E2E_FIXTURES_ROOT).exists().isDirectory();
+
+        // When
+        try (Stream<Path> scenarioPathStream = Files.list(E2E_FIXTURES_ROOT)) {
+            List<Path> scenarioDirectoryPaths = scenarioPathStream
+                    .filter(Files::isDirectory)
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .toList();
+            List<String> actualScenarioNames = scenarioDirectoryPaths.stream()
+                    .map(path -> path.getFileName().toString())
+                    .toList();
+            assertThat(actualScenarioNames).containsExactlyElementsOf(REQUIRED_SCENARIO_NAMES);
+            scenarioDirectoryPaths.forEach(this::verifyScenario);
+        }
+
+        // Then
+        assertThat(temporaryDirectoryPath).exists();
+    }
+
+    private void verifyScenario(Path scenarioDirectoryPath) {
+        try {
+            // Given
+            Path fixtureInputDirectoryPath = scenarioDirectoryPath.resolve("input");
+            Path fixtureExpectedDirectoryPath = scenarioDirectoryPath.resolve("expected");
+            Path fixtureConfigPath = scenarioDirectoryPath.resolve("config.yml");
+            Path scenarioWorkingInputDirectoryPath = temporaryDirectoryPath.resolve(
+                    scenarioDirectoryPath.getFileName().toString() + "-input");
+            copyDirectory(fixtureInputDirectoryPath, scenarioWorkingInputDirectoryPath);
+            Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve(
+                    scenarioDirectoryPath.getFileName().toString() + "-before-compile");
+            Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve(
+                    scenarioDirectoryPath.getFileName().toString() + "-after-compile");
+
+            // When
+            JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
+                    scenarioWorkingInputDirectoryPath, beforeCompileOutputDirectoryPath);
+            runRestructureFlow(scenarioWorkingInputDirectoryPath, fixtureConfigPath);
+            JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
+                    scenarioWorkingInputDirectoryPath, afterCompileOutputDirectoryPath);
+
+            // Then
+            assertDirectoriesEqualWithNormalization(fixtureExpectedDirectoryPath, scenarioWorkingInputDirectoryPath);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
+        }
+    }
+
+    private static void runRestructureFlow(Path sourceDirectoryPath, Path configPath) throws Exception {
+        CompiledConfig compiledConfig = Unified2CompiledModelCompiler.compile(
+                JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath)));
+        Formatter formatter = new Formatter(
+                compiledConfig.getFormatting().getFormatterStyle(),
+                compiledConfig.getFormatting().isFixImports());
+        RestructureFlow restructureFlow = new RestructureFlow(
+                formatter, compiledConfig.isBackupsEnabled(), new Sorter(compiledConfig));
+
+        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
+            sourcePathStream
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .sorted()
+                    .map(SourceFilesHandler::readFile)
+                    .forEach(restructureFlow::processSource);
+        }
+    }
+
+    private static void assertDirectoriesEqualWithNormalization(Path expectedDirectoryPath, Path actualDirectoryPath)
+            throws IOException {
+        try (Stream<Path> expectedPathStream = Files.walk(expectedDirectoryPath)) {
+            expectedPathStream
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .sorted()
+                    .forEach(expectedSourcePath -> {
+                        Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
+                        Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
+                        assertThat(actualSourcePath)
+                                .as("Processed source must exist: %s", relativeSourcePath)
+                                .exists();
+                        try {
+                            String expectedSourceCode = Files.readString(expectedSourcePath, StandardCharsets.UTF_8);
+                            String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
+                            assertThat(JavaCompileTestUtils.normalizeSourceForFixtureComparison(actualSourceCode))
+                                    .as("Normalized output mismatch for %s", relativeSourcePath)
+                                    .isEqualTo(JavaCompileTestUtils.normalizeSourceForFixtureComparison(expectedSourceCode));
+                        } catch (IOException ioException) {
+                            throw new IllegalStateException(
+                                    "Failed to compare sources for " + relativeSourcePath, ioException);
+                        }
+                    });
+        }
+    }
+
+    private static void copyDirectory(Path sourceDirectoryPath, Path targetDirectoryPath) throws IOException {
+        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
+            for (Path sourcePath : sourcePathStream.sorted().toList()) {
+                Path relativePath = sourceDirectoryPath.relativize(sourcePath);
+                Path targetPath = targetDirectoryPath.resolve(relativePath);
+                if (Files.isDirectory(sourcePath)) {
+                    Files.createDirectories(targetPath);
+                } else {
+                    Files.createDirectories(targetPath.getParent());
+                    Files.copy(sourcePath, targetPath);
+                }
+            }
+        }
+    }
+
+    private static URL toUrl(Path path) {
+        try {
+            return path.toUri().toURL();
+        } catch (MalformedURLException exception) {
+            throw new IllegalArgumentException("Cannot convert path to URL: " + path, exception);
+        }
+    }
+}

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -8,16 +8,17 @@ import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfig;
-import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedFormatterStyle;
-import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
-import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
@@ -54,32 +55,35 @@ class SourceProcessorE2EFixtureTest {
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
         // When
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
+                workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
         assertAllScenarioInputsAreNotStableForCurrentConfig(scenarioContexts);
         runRestructureForAllScenarios(scenarioContexts);
-        runPostPalantirFormattingPhase(workingInputRootDirectoryPath);
-        assertAllScenarioInputsAreStableForCurrentConfig(scenarioContexts);
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
 
         // Then
+        assertAllScenarioInputsAreStableForCurrentConfig(scenarioContexts);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
+                workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
         scenarioContexts.forEach(SourceProcessorE2EFixtureTest::assertScenarioOutputMatchesExpectedExactly);
     }
 
     private void assertAllScenarioInputsAreNotStableForCurrentConfig(List<ScenarioContext> scenarioContexts) {
-        assertThatThrownBy(() -> scenarioContexts.forEach(scenarioContext -> runSourceProcessor(
-                        scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), FlowType.CHECK_FAIL_FAST)))
+        assertThatThrownBy(() -> runFlowForAllScenarios(scenarioContexts, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
     private static void runRestructureForAllScenarios(List<ScenarioContext> scenarioContexts) {
-        scenarioContexts.forEach(
-                scenarioContext -> runSourceProcessor(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), FlowType.RESTRUCTURE));
+        runFlowForAllScenarios(scenarioContexts, FlowType.RESTRUCTURE);
     }
 
     private void assertAllScenarioInputsAreStableForCurrentConfig(List<ScenarioContext> scenarioContexts) {
-        assertThatCode(() -> scenarioContexts.forEach(scenarioContext -> runSourceProcessor(
-                        scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), FlowType.CHECK_FAIL_FAST)))
+        assertThatCode(() -> runFlowForAllScenarios(scenarioContexts, FlowType.CHECK_FAIL_FAST))
                 .doesNotThrowAnyException();
+    }
+
+    private static void runFlowForAllScenarios(List<ScenarioContext> scenarioContexts, FlowType flowType) {
+        scenarioContexts.forEach(
+                scenarioContext -> runSourceProcessor(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath(), flowType));
     }
 
     private static void runSourceProcessor(Path sourceDirectoryPath, Path configPath, FlowType flowType) {
@@ -92,19 +96,6 @@ class SourceProcessorE2EFixtureTest {
                 unifiedConfig.getRootMemberGroups());
         SourceProcessor sourceProcessor = new SourceProcessor(flexibleUnifiedConfig);
         sourceProcessor.processSources(sourceDirectoryPath, List.of(), List.of(), flowType);
-    }
-
-    private static void runPostPalantirFormattingPhase(Path sourceDirectoryPath) throws IOException {
-        Formatter palantirFormatter = new Formatter(UnifiedFormatterStyle.PALANTIR, false);
-
-        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
-            sourcePathStream.filter(path -> path.toString().endsWith(".java")).sorted().forEach(sourcePath -> {
-                SourceFilesHandler.SrcFile sourceFile = SourceFilesHandler.readFile(sourcePath);
-                String formattedSourceCode =
-                        palantirFormatter.formatSource(sourceFile.getSrcCode(), sourcePath).getFormatedSrcCode();
-                SourceFilesHandler.overwrite(sourcePath, formattedSourceCode);
-            });
-        }
     }
 
     private static void assertScenarioOutputMatchesExpectedExactly(ScenarioContext scenarioContext) {
@@ -168,18 +159,21 @@ class SourceProcessorE2EFixtureTest {
     }
 
     private static void copyDirectory(Path sourceDirectoryPath, Path targetDirectoryPath) throws IOException {
-        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
-            for (Path sourcePath : sourcePathStream.sorted().toList()) {
+        Files.walkFileTree(sourceDirectoryPath, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path sourcePath, BasicFileAttributes attributes) throws IOException {
                 Path relativePath = sourceDirectoryPath.relativize(sourcePath);
-                Path targetPath = targetDirectoryPath.resolve(relativePath);
-                if (Files.isDirectory(sourcePath)) {
-                    Files.createDirectories(targetPath);
-                } else {
-                    Files.createDirectories(targetPath.getParent());
-                    Files.copy(sourcePath, targetPath);
-                }
+                Files.createDirectories(targetDirectoryPath.resolve(relativePath));
+                return FileVisitResult.CONTINUE;
             }
-        }
+
+            @Override
+            public FileVisitResult visitFile(Path sourcePath, BasicFileAttributes attributes) throws IOException {
+                Path relativePath = sourceDirectoryPath.relativize(sourcePath);
+                Files.copy(sourcePath, targetDirectoryPath.resolve(relativePath), StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     private static URL toUrl(Path path) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -39,6 +39,8 @@ class SourceProcessorE2EFixtureTest {
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
+        assertScenarioAuxiliaryFilesAreNotCopied(workingInputRootDirectoryPath);
+
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
         assertAllScenarioInputsAreNotStableForCurrentConfig(workingInputRootDirectoryPath);
@@ -119,6 +121,15 @@ class SourceProcessorE2EFixtureTest {
             throw new IllegalStateException(
                     "Failed to verify scenario output for " + scenarioDirectoryPath.getFileName(), ioException);
         }
+    }
+
+    private static void assertScenarioAuxiliaryFilesAreNotCopied(Path workingInputRootDirectoryPath) throws IOException {
+        forEachScenarioDirectory(scenarioDirectoryPath -> {
+            Path scenarioWorkingInputDirectoryPath =
+                    workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath);
+            assertThat(scenarioWorkingInputDirectoryPath.resolve("config.yml")).doesNotExist();
+            assertThat(scenarioWorkingInputDirectoryPath.resolve("expected")).doesNotExist();
+        });
     }
 
     private static void prepareWorkingInputDirectories(Path workingInputRootDirectoryPath) throws IOException {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -26,158 +26,129 @@ import org.junit.jupiter.api.io.TempDir;
 
 class SourceProcessorE2EFixtureTest {
 
-    private static final String E2E_FIXTURES_ROOT_RESOURCE_PATH = "/test-cases/core/e2e/restructure/";
-    private static final String INPUT_DIRECTORY_NAME = "input";
-    private static final String EXPECTED_DIRECTORY_NAME = "expected";
-    private static final String CONFIG_FILE_NAME = "config.yml";
+    private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
+    private static final String INPUT_DIRECTORY = "input";
+    private static final String EXPECTED_DIRECTORY = "expected";
+    private static final String CONFIG_FILE = "config.yml";
 
     @TempDir
-    Path temporaryDirectoryPath;
+    Path temporaryDirectory;
 
     @Test
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
-        // Given
-        Path e2eFixturesRootPath = resolveFixturesRootPath();
-        Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
-        copyOnlyInputJavaFiles(e2eFixturesRootPath, workingInputRootDirectoryPath);
-        Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
-        Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
+        Path fixturesRoot = resolveFixturesRoot();
+        Path workingRoot = temporaryDirectory.resolve("working-input");
+        copyInputJavaFiles(fixturesRoot, workingRoot);
+        Path beforeCompileOutput = temporaryDirectory.resolve("before-compile");
+        Path afterCompileOutput = temporaryDirectory.resolve("after-compile");
 
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
-                workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
-        assertAllScenarioInputsAreNotStableForCurrentConfig(e2eFixturesRootPath, workingInputRootDirectoryPath);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingRoot, beforeCompileOutput);
+        assertScenariosAreNotStable(fixturesRoot, workingRoot);
 
-        // When
-        runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.RESTRUCTURE);
+        runFlowForScenarios(fixturesRoot, workingRoot, FlowType.RESTRUCTURE);
 
-        // Then
-        assertAllScenarioInputsAreStableForCurrentConfig(e2eFixturesRootPath, workingInputRootDirectoryPath);
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
-                workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
-        assertAllScenarioOutputsMatchExpectedExactly(e2eFixturesRootPath, workingInputRootDirectoryPath);
+        assertScenariosAreStable(fixturesRoot, workingRoot);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingRoot, afterCompileOutput);
+        assertOutputsMatchExpected(fixturesRoot, workingRoot);
     }
 
-    private static Path resolveFixturesRootPath() {
-        URL fixturesRootUrl = TestCaseResourceUtils.requireClasspathDirectoryUrl(E2E_FIXTURES_ROOT_RESOURCE_PATH);
+    private static Path resolveFixturesRoot() {
+        URL fixturesUrl = TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
         try {
-            return Path.of(fixturesRootUrl.toURI());
+            return Path.of(fixturesUrl.toURI());
         } catch (URISyntaxException exception) {
-            throw new IllegalArgumentException("Cannot convert fixtures URL to URI: " + fixturesRootUrl, exception);
+            throw new IllegalArgumentException("Cannot convert fixtures URL to URI: " + fixturesUrl, exception);
         }
     }
 
-    private static void assertAllScenarioInputsAreNotStableForCurrentConfig(
-            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
-        assertThatThrownBy(() -> runFlowForAllScenarios(
-                        e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+    private static void assertScenariosAreNotStable(Path fixturesRoot, Path workingRoot) throws IOException {
+        assertThatThrownBy(() -> runFlowForScenarios(fixturesRoot, workingRoot, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
-    private static void assertAllScenarioInputsAreStableForCurrentConfig(
-            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
-        assertThatCode(() ->
-                        runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_ALL))
+    private static void assertScenariosAreStable(Path fixturesRoot, Path workingRoot) throws IOException {
+        assertThatCode(() -> runFlowForScenarios(fixturesRoot, workingRoot, FlowType.CHECK_ALL))
                 .doesNotThrowAnyException();
     }
 
-    private static void runFlowForAllScenarios(
-            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath, FlowType flowType) throws IOException {
-        forEachScenarioDirectory(
-                e2eFixturesRootPath,
-                scenarioDirectoryPath -> runSourceProcessor(
-                        workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath),
-                        scenarioConfigPath(scenarioDirectoryPath),
-                        flowType));
+    private static void runFlowForScenarios(Path fixturesRoot, Path workingRoot, FlowType flowType) throws IOException {
+        forEachScenario(fixturesRoot, scenario -> runProcessor(workingRoot, resolveConfig(scenario), flowType));
     }
 
-    private static void runSourceProcessor(Path sourceDirectoryPath, Path configPath, FlowType flowType) {
-        UnifiedConfig unifiedConfig =
-                JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath));
-        FlexibleUnifiedConfig flexibleUnifiedConfig = new FlexibleUnifiedConfig(
+    private static void runProcessor(Path sourcesRoot, Path config, FlowType flowType) {
+        UnifiedConfig unifiedConfig = JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(config));
+        FlexibleUnifiedConfig flexibleConfig = new FlexibleUnifiedConfig(
                 unifiedConfig.getTopLevelTypesOrdering(),
                 unifiedConfig.getFormatting(),
                 unifiedConfig.isBackupsEnabled(),
                 unifiedConfig.getHeaderLine(),
                 unifiedConfig.getRootMemberGroups());
-        SourceProcessor sourceProcessor = new SourceProcessor(flexibleUnifiedConfig);
-        sourceProcessor.processSources(sourceDirectoryPath, List.of(), List.of(), flowType);
+        SourceProcessor sourceProcessor = new SourceProcessor(flexibleConfig);
+        sourceProcessor.processSources(sourcesRoot, List.of(), List.of(), flowType);
     }
 
-    private static void assertAllScenarioOutputsMatchExpectedExactly(
-            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
-        forEachScenarioDirectory(
-                e2eFixturesRootPath,
-                scenarioDirectoryPath -> assertScenarioOutputMatchesExpectedExactly(
-                        scenarioDirectoryPath, workingInputRootDirectoryPath));
+    private static void assertOutputsMatchExpected(Path fixturesRoot, Path workingRoot) throws IOException {
+        forEachScenario(fixturesRoot, scenario -> assertScenarioOutputMatchesExpected(scenario, workingRoot));
     }
 
-    private static void assertScenarioOutputMatchesExpectedExactly(
-            Path scenarioDirectoryPath, Path workingInputRootDirectoryPath) {
-        Path expectedDirectoryPath = scenarioExpectedPath(scenarioDirectoryPath);
-        Path actualDirectoryPath = workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath);
+    private static void assertScenarioOutputMatchesExpected(Path scenario, Path workingRoot) {
+        Path expectedRoot = resolveExpected(scenario);
+        Path actualRoot = resolveScenarioWorkingDirectory(workingRoot, scenario);
 
-        try (Stream<Path> expectedPathStream = Files.walk(expectedDirectoryPath)) {
-            expectedPathStream.filter(path -> path.toString().endsWith(".java")).forEach(expectedSourcePath -> {
-                Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
-                Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
-                assertThat(actualSourcePath)
-                        .as("Processed source must exist: %s", relativeSourcePath)
-                        .exists();
+        try (Stream<Path> expectedPaths = Files.walk(expectedRoot)) {
+            expectedPaths.filter(path -> path.toString().endsWith(".java")).forEach(expectedSource -> {
+                Path relativeSource = expectedRoot.relativize(expectedSource);
+                Path actualSource = actualRoot.resolve(relativeSource);
+                assertThat(actualSource).as("Processed source must exist: %s", relativeSource).exists();
                 try {
-                    String expectedSourceCode = Files.readString(expectedSourcePath, StandardCharsets.UTF_8);
-                    String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
-                    assertThat(actualSourceCode).isEqualToNormalizingNewlines(expectedSourceCode);
+                    String expectedCode = Files.readString(expectedSource, StandardCharsets.UTF_8);
+                    String actualCode = Files.readString(actualSource, StandardCharsets.UTF_8);
+                    assertThat(actualCode).isEqualToNormalizingNewlines(expectedCode);
                 } catch (IOException ioException) {
-                    throw new IllegalStateException("Failed to compare sources for " + relativeSourcePath, ioException);
+                    throw new IllegalStateException("Failed to compare sources for " + relativeSource, ioException);
                 }
             });
         } catch (IOException ioException) {
-            throw new IllegalStateException(
-                    "Failed to verify scenario output for " + scenarioDirectoryPath.getFileName(), ioException);
+            throw new IllegalStateException("Failed to verify scenario output for " + scenario.getFileName(), ioException);
         }
     }
 
-    private static void copyOnlyInputJavaFiles(Path e2eFixturesRootPath, Path workingInputRootDirectoryPath)
-            throws IOException {
-        try (Stream<Path> inputJavaPathStream = SourceFilesHandler.findJavaFiles(
-                e2eFixturesRootPath, List.of("**/" + INPUT_DIRECTORY_NAME + "/*.java"), List.of())) {
-            inputJavaPathStream.forEach(inputJavaPath ->
-                    copyInputJavaFile(inputJavaPath, e2eFixturesRootPath, workingInputRootDirectoryPath));
+    private static void copyInputJavaFiles(Path fixturesRoot, Path workingRoot) throws IOException {
+        try (Stream<Path> inputSources =
+                SourceFilesHandler.findJavaFiles(fixturesRoot, List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())) {
+            inputSources.forEach(inputSource -> copyInputJavaFile(inputSource, fixturesRoot, workingRoot));
         }
     }
 
-    private static void copyInputJavaFile(
-            Path inputJavaPath, Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) {
-        Path relativeSourcePath = e2eFixturesRootPath.relativize(inputJavaPath);
-        Path scenarioRelativePath = relativeSourcePath.getParent().getParent();
-        Path targetPath =
-                workingInputRootDirectoryPath.resolve(scenarioRelativePath).resolve(inputJavaPath.getFileName());
+    private static void copyInputJavaFile(Path inputSource, Path fixturesRoot, Path workingRoot) {
+        Path relativeSource = fixturesRoot.relativize(inputSource);
+        Path scenarioRelative = relativeSource.getParent().getParent();
+        Path target = workingRoot.resolve(scenarioRelative).resolve(inputSource.getFileName());
 
         try {
-            Files.createDirectories(targetPath.getParent());
-            Files.copy(inputJavaPath, targetPath);
+            Files.createDirectories(target.getParent());
+            Files.copy(inputSource, target);
         } catch (IOException ioException) {
-            throw new IllegalStateException("Failed to copy scenario input file: " + inputJavaPath, ioException);
+            throw new IllegalStateException("Failed to copy scenario input file: " + inputSource, ioException);
         }
     }
 
-    private static void forEachScenarioDirectory(Path e2eFixturesRootPath, Consumer<Path> scenarioDirectoryConsumer)
-            throws IOException {
-        try (Stream<Path> scenarioPathStream = Files.list(e2eFixturesRootPath)) {
-            scenarioPathStream.filter(Files::isDirectory).forEach(scenarioDirectoryConsumer);
+    private static void forEachScenario(Path fixturesRoot, Consumer<Path> action) throws IOException {
+        try (Stream<Path> scenarios = Files.list(fixturesRoot)) {
+            scenarios.filter(Files::isDirectory).forEach(action);
         }
     }
 
-    private static Path scenarioConfigPath(Path scenarioDirectoryPath) {
-        return scenarioDirectoryPath.resolve(CONFIG_FILE_NAME);
+    private static Path resolveConfig(Path scenario) {
+        return scenario.resolve(CONFIG_FILE);
     }
 
-    private static Path scenarioExpectedPath(Path scenarioDirectoryPath) {
-        return scenarioDirectoryPath.resolve(EXPECTED_DIRECTORY_NAME);
+    private static Path resolveExpected(Path scenario) {
+        return scenario.resolve(EXPECTED_DIRECTORY);
     }
 
-    private static Path workingInputPathForScenario(Path workingInputRootDirectoryPath, Path scenarioDirectoryPath) {
-        return workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName());
+    private static Path resolveScenarioWorkingDirectory(Path workingRoot, Path scenario) {
+        return workingRoot.resolve(scenario.getFileName());
     }
 
     private static URL toUrl(Path path) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -40,13 +40,13 @@ class SourceProcessorE2EFixtureTest {
     @Test
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
         Path fixturesRoot = resolveFixturesRoot();
-        Path workingRoot = temporaryDirectory.resolve("SourceProcessorE2E-working-input");
+        Path workingRoot = temporaryDirectory.resolve("SourceProcessorE2E-working-dir");
         copyInputJavaFiles(fixturesRoot, workingRoot);
         Path compileBeforeOutput = temporaryDirectory.resolve("SourceProcessorE2E-compile-before");
         Path compileAfterOutput = temporaryDirectory.resolve("SourceProcessorE2E-compile-after");
 
-        // assertJavaSourcesCompileWithRelease21(workingRoot, compileBeforeOutput);
-        // assertScenariosAreNotStable(fixturesRoot,workingRoot);
+        assertJavaSourcesCompileWithRelease21(workingRoot, compileBeforeOutput);
+        assertScenariosAreNotStable(fixturesRoot, workingRoot);
 
         runFlowForScenarios(fixturesRoot, workingRoot, FlowType.RESTRUCTURE);
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -10,13 +10,14 @@ import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
+import io.github.lemon_ant.jharmonizer.core.testutils.TestCaseResourceUtils;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -25,8 +26,10 @@ import org.junit.jupiter.api.io.TempDir;
 
 class SourceProcessorE2EFixtureTest {
 
-    private static final Path E2E_FIXTURES_ROOT = Path.of("src/test/resources/test-cases/core/e2e/restructure");
+    private static final String E2E_FIXTURES_ROOT_RESOURCE_PATH = "/test-cases/core/e2e/restructure/";
     private static final String INPUT_DIRECTORY_NAME = "input";
+    private static final String EXPECTED_DIRECTORY_NAME = "expected";
+    private static final String CONFIG_FILE_NAME = "config.yml";
 
     @TempDir
     Path temporaryDirectoryPath;
@@ -34,41 +37,50 @@ class SourceProcessorE2EFixtureTest {
     @Test
     void processFixtureScenarios_allScenarios_matchExpectedAndCompileAfter() throws Exception {
         // Given
-        assertThat(E2E_FIXTURES_ROOT).exists().isDirectory();
+        Path e2eFixturesRootPath = resolveFixturesRootPath();
         Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
-        copyOnlyInputJavaFiles(workingInputRootDirectoryPath);
+        copyOnlyInputJavaFiles(e2eFixturesRootPath, workingInputRootDirectoryPath);
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
-        assertAllScenarioInputsAreNotStableForCurrentConfig(workingInputRootDirectoryPath);
+        assertAllScenarioInputsAreNotStableForCurrentConfig(e2eFixturesRootPath, workingInputRootDirectoryPath);
 
         // When
-        runFlowForAllScenarios(workingInputRootDirectoryPath, FlowType.RESTRUCTURE);
+        runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.RESTRUCTURE);
 
         // Then
-        assertAllScenarioInputsAreStableForCurrentConfig(workingInputRootDirectoryPath);
+        assertAllScenarioInputsAreStableForCurrentConfig(e2eFixturesRootPath, workingInputRootDirectoryPath);
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
-        assertAllScenarioOutputsMatchExpectedExactly(workingInputRootDirectoryPath);
+        assertAllScenarioOutputsMatchExpectedExactly(e2eFixturesRootPath, workingInputRootDirectoryPath);
     }
 
-    private static void assertAllScenarioInputsAreNotStableForCurrentConfig(Path workingInputRootDirectoryPath)
-            throws IOException {
-        assertThatThrownBy(() -> runFlowForAllScenarios(workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+    private static Path resolveFixturesRootPath() {
+        URL fixturesRootUrl = TestCaseResourceUtils.requireClasspathDirectoryUrl(E2E_FIXTURES_ROOT_RESOURCE_PATH);
+        try {
+            return Path.of(fixturesRootUrl.toURI());
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException("Cannot convert fixtures URL to URI: " + fixturesRootUrl, exception);
+        }
+    }
+
+    private static void assertAllScenarioInputsAreNotStableForCurrentConfig(
+            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
+        assertThatThrownBy(() -> runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
-    private static void assertAllScenarioInputsAreStableForCurrentConfig(Path workingInputRootDirectoryPath)
-            throws IOException {
-        assertThatCode(() -> runFlowForAllScenarios(workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+    private static void assertAllScenarioInputsAreStableForCurrentConfig(
+            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
+        assertThatCode(() -> runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .doesNotThrowAnyException();
     }
 
-    private static void runFlowForAllScenarios(Path workingInputRootDirectoryPath, FlowType flowType)
+    private static void runFlowForAllScenarios(Path e2eFixturesRootPath, Path workingInputRootDirectoryPath, FlowType flowType)
             throws IOException {
-        forEachScenarioDirectory(scenarioDirectoryPath -> runSourceProcessor(
+        forEachScenarioDirectory(e2eFixturesRootPath, scenarioDirectoryPath -> runSourceProcessor(
                 workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath),
                 scenarioConfigPath(scenarioDirectoryPath),
                 flowType));
@@ -86,10 +98,12 @@ class SourceProcessorE2EFixtureTest {
         sourceProcessor.processSources(sourceDirectoryPath, List.of(), List.of(), flowType);
     }
 
-    private static void assertAllScenarioOutputsMatchExpectedExactly(Path workingInputRootDirectoryPath)
-            throws IOException {
+    private static void assertAllScenarioOutputsMatchExpectedExactly(
+            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
         forEachScenarioDirectory(
-                scenarioDirectoryPath -> assertScenarioOutputMatchesExpectedExactly(scenarioDirectoryPath, workingInputRootDirectoryPath));
+                e2eFixturesRootPath,
+                scenarioDirectoryPath -> assertScenarioOutputMatchesExpectedExactly(
+                        scenarioDirectoryPath, workingInputRootDirectoryPath));
     }
 
     private static void assertScenarioOutputMatchesExpectedExactly(
@@ -100,7 +114,6 @@ class SourceProcessorE2EFixtureTest {
         try (Stream<Path> expectedPathStream = Files.walk(expectedDirectoryPath)) {
             expectedPathStream
                     .filter(path -> path.toString().endsWith(".java"))
-                    .sorted()
                     .forEach(expectedSourcePath -> {
                         Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
                         Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
@@ -122,25 +135,20 @@ class SourceProcessorE2EFixtureTest {
         }
     }
 
-    private static void copyOnlyInputJavaFiles(Path workingInputRootDirectoryPath) throws IOException {
+    private static void copyOnlyInputJavaFiles(Path e2eFixturesRootPath, Path workingInputRootDirectoryPath)
+            throws IOException {
         try (Stream<Path> inputJavaPathStream = SourceFilesHandler.findJavaFiles(
-                E2E_FIXTURES_ROOT,
-                List.of("**/" + INPUT_DIRECTORY_NAME + "/**/*.java"),
+                e2eFixturesRootPath,
+                List.of("**/" + INPUT_DIRECTORY_NAME + "/*.java"),
                 List.of())) {
-            inputJavaPathStream.sorted().forEach(inputJavaPath -> copyInputJavaFile(inputJavaPath, workingInputRootDirectoryPath));
+            inputJavaPathStream.forEach(inputJavaPath -> copyInputJavaFile(inputJavaPath, e2eFixturesRootPath, workingInputRootDirectoryPath));
         }
     }
 
-    private static void copyInputJavaFile(Path inputJavaPath, Path workingInputRootDirectoryPath) {
-        Path relativeSourcePath = E2E_FIXTURES_ROOT.relativize(inputJavaPath);
-        int inputDirectoryIndex = findInputDirectorySegmentIndex(relativeSourcePath);
-        if (inputDirectoryIndex <= 0 || inputDirectoryIndex >= relativeSourcePath.getNameCount() - 1) {
-            throw new IllegalArgumentException("Invalid input java path: " + inputJavaPath);
-        }
-
-        Path scenarioRelativePath = relativeSourcePath.subpath(0, inputDirectoryIndex);
-        Path sourcePathRelativeToInput = relativeSourcePath.subpath(inputDirectoryIndex + 1, relativeSourcePath.getNameCount());
-        Path targetPath = workingInputRootDirectoryPath.resolve(scenarioRelativePath).resolve(sourcePathRelativeToInput);
+    private static void copyInputJavaFile(Path inputJavaPath, Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) {
+        Path relativeSourcePath = e2eFixturesRootPath.relativize(inputJavaPath);
+        Path scenarioRelativePath = relativeSourcePath.getParent().getParent();
+        Path targetPath = workingInputRootDirectoryPath.resolve(scenarioRelativePath).resolve(inputJavaPath.getFileName());
 
         try {
             Files.createDirectories(targetPath.getParent());
@@ -150,34 +158,25 @@ class SourceProcessorE2EFixtureTest {
         }
     }
 
-    private static int findInputDirectorySegmentIndex(Path relativeSourcePath) {
-        for (int index = 0; index < relativeSourcePath.getNameCount(); index++) {
-            if (INPUT_DIRECTORY_NAME.equals(relativeSourcePath.getName(index).toString())) {
-                return index;
-            }
-        }
-        return -1;
-    }
-
-    private static void forEachScenarioDirectory(Consumer<Path> scenarioDirectoryConsumer) throws IOException {
-        try (Stream<Path> scenarioPathStream = Files.list(E2E_FIXTURES_ROOT)) {
+    private static void forEachScenarioDirectory(Path e2eFixturesRootPath, Consumer<Path> scenarioDirectoryConsumer)
+            throws IOException {
+        try (Stream<Path> scenarioPathStream = Files.list(e2eFixturesRootPath)) {
             scenarioPathStream
                     .filter(Files::isDirectory)
-                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
                     .forEach(scenarioDirectoryConsumer);
         }
     }
 
     private static Path scenarioConfigPath(Path scenarioDirectoryPath) {
-        return scenarioDirectoryPath.resolve("config.yml");
+        return scenarioDirectoryPath.resolve(CONFIG_FILE_NAME);
     }
 
     private static Path scenarioExpectedPath(Path scenarioDirectoryPath) {
-        return scenarioDirectoryPath.resolve("expected");
+        return scenarioDirectoryPath.resolve(EXPECTED_DIRECTORY_NAME);
     }
 
     private static Path workingInputPathForScenario(Path workingInputRootDirectoryPath, Path scenarioDirectoryPath) {
-        return workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName().toString());
+        return workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName());
     }
 
     private static URL toUrl(Path path) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledConfig;
 import io.github.lemon_ant.jharmonizer.core.config.compiled.Unified2CompiledModelCompiler;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
+import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedFormatterStyle;
 import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.RestructureFlow;
 import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
@@ -100,6 +101,7 @@ class SourceProcessorE2EFixtureTest {
     private void runAndAssertSingleScenario(ScenarioContext scenarioContext) {
         try {
             runRestructureFlow(scenarioContext.workingInputDirectoryPath(), scenarioContext.configPath());
+            runPostPalantirFormattingPhase(scenarioContext.workingInputDirectoryPath());
             assertDirectoriesEqualWithNormalization(
                     scenarioContext.expectedDirectoryPath(), scenarioContext.workingInputDirectoryPath());
         } catch (Exception exception) {
@@ -122,6 +124,23 @@ class SourceProcessorE2EFixtureTest {
                     .sorted()
                     .map(SourceFilesHandler::readFile)
                     .forEach(restructureFlow::processSource);
+        }
+    }
+
+    private static void runPostPalantirFormattingPhase(Path sourceDirectoryPath) throws IOException {
+        Formatter palantirFormatter = new Formatter(UnifiedFormatterStyle.PALANTIR, false);
+
+        try (Stream<Path> sourcePathStream = Files.walk(sourceDirectoryPath)) {
+            sourcePathStream
+                    .filter(path -> path.toString().endsWith(".java"))
+                    .sorted()
+                    .forEach(sourcePath -> {
+                        SourceFilesHandler.SrcFile sourceFile = SourceFilesHandler.readFile(sourcePath);
+                        String formattedSourceCode = palantirFormatter
+                                .formatSource(sourceFile.getSrcCode(), sourcePath)
+                                .getFormatedSrcCode();
+                        SourceFilesHandler.overwrite(sourcePath, formattedSourceCode);
+                    });
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -24,8 +24,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 class SourceProcessorE2EFixtureTest {
 
-    private static final Path E2E_FIXTURES_ROOT =
-            Path.of("src/test/resources/test-cases/core/e2e/restructure");
+    private static final Path E2E_FIXTURES_ROOT = Path.of("src/test/resources/test-cases/core/e2e/restructure");
     private static final List<String> REQUIRED_SCENARIO_NAMES = List.of(
             "01-baseline-ordering",
             "02-static-vs-instance-initializers",
@@ -46,15 +45,18 @@ class SourceProcessorE2EFixtureTest {
         List<Path> scenarioDirectoryPaths = loadScenarioDirectories();
         Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
         List<ScenarioContext> scenarioContexts = scenarioDirectoryPaths.stream()
-                .map(scenarioDirectoryPath -> prepareScenarioContext(scenarioDirectoryPath, workingInputRootDirectoryPath))
+                .map(scenarioDirectoryPath ->
+                        prepareScenarioContext(scenarioDirectoryPath, workingInputRootDirectoryPath))
                 .toList();
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
 
         // When
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
+                workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
         scenarioContexts.forEach(this::runAndAssertSingleScenario);
-        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
+        JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
+                workingInputRootDirectoryPath, afterCompileOutputDirectoryPath);
 
         // Then
         assertThat(temporaryDirectoryPath).exists();
@@ -81,8 +83,8 @@ class SourceProcessorE2EFixtureTest {
             Path fixtureInputDirectoryPath = scenarioDirectoryPath.resolve("input");
             Path fixtureExpectedDirectoryPath = scenarioDirectoryPath.resolve("expected");
             Path fixtureConfigPath = scenarioDirectoryPath.resolve("config.yml");
-            Path scenarioWorkingInputDirectoryPath =
-                    workingInputRootDirectoryPath.resolve(scenarioDirectoryPath.getFileName().toString());
+            Path scenarioWorkingInputDirectoryPath = workingInputRootDirectoryPath.resolve(
+                    scenarioDirectoryPath.getFileName().toString());
             copyDirectory(fixtureInputDirectoryPath, scenarioWorkingInputDirectoryPath);
             return new ScenarioContext(
                     scenarioDirectoryPath.getFileName().toString(),
@@ -90,7 +92,8 @@ class SourceProcessorE2EFixtureTest {
                     fixtureConfigPath,
                     scenarioWorkingInputDirectoryPath);
         } catch (Exception exception) {
-            throw new IllegalStateException("Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
+            throw new IllegalStateException(
+                    "Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), exception);
         }
     }
 
@@ -107,8 +110,9 @@ class SourceProcessorE2EFixtureTest {
     private static void runRestructureFlow(Path sourceDirectoryPath, Path configPath) throws Exception {
         CompiledConfig compiledConfig = Unified2CompiledModelCompiler.compile(
                 JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath)));
-        Formatter formatter =
-                new Formatter(compiledConfig.getFormatting().getFormatterStyle(), compiledConfig.getFormatting().isFixImports());
+        Formatter formatter = new Formatter(
+                compiledConfig.getFormatting().getFormatterStyle(),
+                compiledConfig.getFormatting().isFixImports());
         RestructureFlow restructureFlow =
                 new RestructureFlow(formatter, compiledConfig.isBackupsEnabled(), new Sorter(compiledConfig));
 
@@ -138,7 +142,8 @@ class SourceProcessorE2EFixtureTest {
                             String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
                             assertThat(JavaCompileTestUtils.normalizeSourceForFixtureComparison(actualSourceCode))
                                     .as("Normalized output mismatch for %s", relativeSourcePath)
-                                    .isEqualTo(JavaCompileTestUtils.normalizeSourceForFixtureComparison(expectedSourceCode));
+                                    .isEqualTo(JavaCompileTestUtils.normalizeSourceForFixtureComparison(
+                                            expectedSourceCode));
                         } catch (IOException ioException) {
                             throw new IllegalStateException(
                                     "Failed to compare sources for " + relativeSourcePath, ioException);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -8,6 +8,7 @@ import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfig;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -19,13 +20,13 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
-import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class SourceProcessorE2EFixtureTest {
 
     private static final Path E2E_FIXTURES_ROOT = Path.of("src/test/resources/test-cases/core/e2e/restructure");
+    private static final String INPUT_DIRECTORY_NAME = "input";
 
     @TempDir
     Path temporaryDirectoryPath;
@@ -35,11 +36,9 @@ class SourceProcessorE2EFixtureTest {
         // Given
         assertThat(E2E_FIXTURES_ROOT).exists().isDirectory();
         Path workingInputRootDirectoryPath = temporaryDirectoryPath.resolve("working-input");
-        prepareWorkingInputDirectories(workingInputRootDirectoryPath);
+        copyOnlyInputJavaFiles(workingInputRootDirectoryPath);
         Path beforeCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("before-compile");
         Path afterCompileOutputDirectoryPath = temporaryDirectoryPath.resolve("after-compile");
-
-        assertScenarioAuxiliaryFilesAreNotCopied(workingInputRootDirectoryPath);
 
         JavaCompileTestUtils.assertJavaSourcesCompileWithRelease21(
                 workingInputRootDirectoryPath, beforeCompileOutputDirectoryPath);
@@ -123,26 +122,41 @@ class SourceProcessorE2EFixtureTest {
         }
     }
 
-    private static void assertScenarioAuxiliaryFilesAreNotCopied(Path workingInputRootDirectoryPath) throws IOException {
-        forEachScenarioDirectory(scenarioDirectoryPath -> {
-            Path scenarioWorkingInputDirectoryPath =
-                    workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath);
-            assertThat(scenarioWorkingInputDirectoryPath.resolve("config.yml")).doesNotExist();
-            assertThat(scenarioWorkingInputDirectoryPath.resolve("expected")).doesNotExist();
-        });
+    private static void copyOnlyInputJavaFiles(Path workingInputRootDirectoryPath) throws IOException {
+        try (Stream<Path> inputJavaPathStream = SourceFilesHandler.findJavaFiles(
+                E2E_FIXTURES_ROOT,
+                List.of("**/" + INPUT_DIRECTORY_NAME + "/**/*.java"),
+                List.of())) {
+            inputJavaPathStream.sorted().forEach(inputJavaPath -> copyInputJavaFile(inputJavaPath, workingInputRootDirectoryPath));
+        }
     }
 
-    private static void prepareWorkingInputDirectories(Path workingInputRootDirectoryPath) throws IOException {
-        forEachScenarioDirectory(scenarioDirectoryPath -> {
-            try {
-                FileUtils.copyDirectory(
-                        scenarioInputPath(scenarioDirectoryPath).toFile(),
-                        workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath).toFile());
-            } catch (IOException ioException) {
-                throw new IllegalStateException(
-                        "Failed to prepare E2E scenario: " + scenarioDirectoryPath.getFileName(), ioException);
+    private static void copyInputJavaFile(Path inputJavaPath, Path workingInputRootDirectoryPath) {
+        Path relativeSourcePath = E2E_FIXTURES_ROOT.relativize(inputJavaPath);
+        int inputDirectoryIndex = findInputDirectorySegmentIndex(relativeSourcePath);
+        if (inputDirectoryIndex <= 0 || inputDirectoryIndex >= relativeSourcePath.getNameCount() - 1) {
+            throw new IllegalArgumentException("Invalid input java path: " + inputJavaPath);
+        }
+
+        Path scenarioRelativePath = relativeSourcePath.subpath(0, inputDirectoryIndex);
+        Path sourcePathRelativeToInput = relativeSourcePath.subpath(inputDirectoryIndex + 1, relativeSourcePath.getNameCount());
+        Path targetPath = workingInputRootDirectoryPath.resolve(scenarioRelativePath).resolve(sourcePathRelativeToInput);
+
+        try {
+            Files.createDirectories(targetPath.getParent());
+            Files.copy(inputJavaPath, targetPath);
+        } catch (IOException ioException) {
+            throw new IllegalStateException("Failed to copy scenario input file: " + inputJavaPath, ioException);
+        }
+    }
+
+    private static int findInputDirectorySegmentIndex(Path relativeSourcePath) {
+        for (int index = 0; index < relativeSourcePath.getNameCount(); index++) {
+            if (INPUT_DIRECTORY_NAME.equals(relativeSourcePath.getName(index).toString())) {
+                return index;
             }
-        });
+        }
+        return -1;
     }
 
     private static void forEachScenarioDirectory(Consumer<Path> scenarioDirectoryConsumer) throws IOException {
@@ -156,10 +170,6 @@ class SourceProcessorE2EFixtureTest {
 
     private static Path scenarioConfigPath(Path scenarioDirectoryPath) {
         return scenarioDirectoryPath.resolve("config.yml");
-    }
-
-    private static Path scenarioInputPath(Path scenarioDirectoryPath) {
-        return scenarioDirectoryPath.resolve("input");
     }
 
     private static Path scenarioExpectedPath(Path scenarioDirectoryPath) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -68,26 +68,31 @@ class SourceProcessorE2EFixtureTest {
 
     private static void assertAllScenarioInputsAreNotStableForCurrentConfig(
             Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
-        assertThatThrownBy(() -> runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+        assertThatThrownBy(() -> runFlowForAllScenarios(
+                        e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(RuntimeException.class);
     }
 
     private static void assertAllScenarioInputsAreStableForCurrentConfig(
             Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) throws IOException {
-        assertThatCode(() -> runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_FAIL_FAST))
+        assertThatCode(() ->
+                        runFlowForAllScenarios(e2eFixturesRootPath, workingInputRootDirectoryPath, FlowType.CHECK_ALL))
                 .doesNotThrowAnyException();
     }
 
-    private static void runFlowForAllScenarios(Path e2eFixturesRootPath, Path workingInputRootDirectoryPath, FlowType flowType)
-            throws IOException {
-        forEachScenarioDirectory(e2eFixturesRootPath, scenarioDirectoryPath -> runSourceProcessor(
-                workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath),
-                scenarioConfigPath(scenarioDirectoryPath),
-                flowType));
+    private static void runFlowForAllScenarios(
+            Path e2eFixturesRootPath, Path workingInputRootDirectoryPath, FlowType flowType) throws IOException {
+        forEachScenarioDirectory(
+                e2eFixturesRootPath,
+                scenarioDirectoryPath -> runSourceProcessor(
+                        workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath),
+                        scenarioConfigPath(scenarioDirectoryPath),
+                        flowType));
     }
 
     private static void runSourceProcessor(Path sourceDirectoryPath, Path configPath, FlowType flowType) {
-        UnifiedConfig unifiedConfig = JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath));
+        UnifiedConfig unifiedConfig =
+                JHarmonizerConfigurationManager.parseUnifiedConfigFromClasspathResource(toUrl(configPath));
         FlexibleUnifiedConfig flexibleUnifiedConfig = new FlexibleUnifiedConfig(
                 unifiedConfig.getTopLevelTypesOrdering(),
                 unifiedConfig.getFormatting(),
@@ -112,23 +117,20 @@ class SourceProcessorE2EFixtureTest {
         Path actualDirectoryPath = workingInputPathForScenario(workingInputRootDirectoryPath, scenarioDirectoryPath);
 
         try (Stream<Path> expectedPathStream = Files.walk(expectedDirectoryPath)) {
-            expectedPathStream
-                    .filter(path -> path.toString().endsWith(".java"))
-                    .forEach(expectedSourcePath -> {
-                        Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
-                        Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
-                        assertThat(actualSourcePath)
-                                .as("Processed source must exist: %s", relativeSourcePath)
-                                .exists();
-                        try {
-                            String expectedSourceCode = Files.readString(expectedSourcePath, StandardCharsets.UTF_8);
-                            String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
-                            assertThat(actualSourceCode).isEqualToNormalizingNewlines(expectedSourceCode);
-                        } catch (IOException ioException) {
-                            throw new IllegalStateException(
-                                    "Failed to compare sources for " + relativeSourcePath, ioException);
-                        }
-                    });
+            expectedPathStream.filter(path -> path.toString().endsWith(".java")).forEach(expectedSourcePath -> {
+                Path relativeSourcePath = expectedDirectoryPath.relativize(expectedSourcePath);
+                Path actualSourcePath = actualDirectoryPath.resolve(relativeSourcePath);
+                assertThat(actualSourcePath)
+                        .as("Processed source must exist: %s", relativeSourcePath)
+                        .exists();
+                try {
+                    String expectedSourceCode = Files.readString(expectedSourcePath, StandardCharsets.UTF_8);
+                    String actualSourceCode = Files.readString(actualSourcePath, StandardCharsets.UTF_8);
+                    assertThat(actualSourceCode).isEqualToNormalizingNewlines(expectedSourceCode);
+                } catch (IOException ioException) {
+                    throw new IllegalStateException("Failed to compare sources for " + relativeSourcePath, ioException);
+                }
+            });
         } catch (IOException ioException) {
             throw new IllegalStateException(
                     "Failed to verify scenario output for " + scenarioDirectoryPath.getFileName(), ioException);
@@ -138,17 +140,18 @@ class SourceProcessorE2EFixtureTest {
     private static void copyOnlyInputJavaFiles(Path e2eFixturesRootPath, Path workingInputRootDirectoryPath)
             throws IOException {
         try (Stream<Path> inputJavaPathStream = SourceFilesHandler.findJavaFiles(
-                e2eFixturesRootPath,
-                List.of("**/" + INPUT_DIRECTORY_NAME + "/*.java"),
-                List.of())) {
-            inputJavaPathStream.forEach(inputJavaPath -> copyInputJavaFile(inputJavaPath, e2eFixturesRootPath, workingInputRootDirectoryPath));
+                e2eFixturesRootPath, List.of("**/" + INPUT_DIRECTORY_NAME + "/*.java"), List.of())) {
+            inputJavaPathStream.forEach(inputJavaPath ->
+                    copyInputJavaFile(inputJavaPath, e2eFixturesRootPath, workingInputRootDirectoryPath));
         }
     }
 
-    private static void copyInputJavaFile(Path inputJavaPath, Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) {
+    private static void copyInputJavaFile(
+            Path inputJavaPath, Path e2eFixturesRootPath, Path workingInputRootDirectoryPath) {
         Path relativeSourcePath = e2eFixturesRootPath.relativize(inputJavaPath);
         Path scenarioRelativePath = relativeSourcePath.getParent().getParent();
-        Path targetPath = workingInputRootDirectoryPath.resolve(scenarioRelativePath).resolve(inputJavaPath.getFileName());
+        Path targetPath =
+                workingInputRootDirectoryPath.resolve(scenarioRelativePath).resolve(inputJavaPath.getFileName());
 
         try {
             Files.createDirectories(targetPath.getParent());
@@ -161,9 +164,7 @@ class SourceProcessorE2EFixtureTest {
     private static void forEachScenarioDirectory(Path e2eFixturesRootPath, Consumer<Path> scenarioDirectoryConsumer)
             throws IOException {
         try (Stream<Path> scenarioPathStream = Files.list(e2eFixturesRootPath)) {
-            scenarioPathStream
-                    .filter(Files::isDirectory)
-                    .forEach(scenarioDirectoryConsumer);
+            scenarioPathStream.filter(Files::isDirectory).forEach(scenarioDirectoryConsumer);
         }
     }
 

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/config.yml
@@ -1,0 +1,33 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Baseline
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Fields
+        separator: new-line
+        sort-keys: alpha
+        includes: field
+      - name: Initializers
+        separator: new-line
+        sort-keys: preserve
+        includes: initializer
+      - name: Methods
+        separator: new-line
+        sort-keys: alpha
+        includes: method
+      - name: Nested types
+        separator: new-line
+        sort-keys: alpha
+        includes: [ class ]

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/config.yml
@@ -1,6 +1,6 @@
 formatting:
   fix-imports: false
-  formatter-style: NONE
+  formatter-style: PALANTIR
 backups-enabled: false
 header-line:
   character: "-"

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/expected/BaselineOrderingSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/expected/BaselineOrderingSample.java
@@ -1,0 +1,17 @@
+package e2e;
+
+public class BaselineOrderingSample {
+    int a = 1;
+
+    int b = 2;
+
+    static {
+        int x = 1;
+    }
+
+    void alpha() {}
+
+    void zeta() {}
+
+    class Nested {}
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/expected/BaselineOrderingSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/expected/BaselineOrderingSample.java
@@ -5,18 +5,13 @@ public class BaselineOrderingSample {
     int a = 1;
     int b = 2;
 
-
     static {
         int x = 1;
     }
-
 
     void alpha() {}
 
     void zeta() {}
 
-
     class Nested {}
-
-
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/expected/BaselineOrderingSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/expected/BaselineOrderingSample.java
@@ -1,17 +1,22 @@
 package e2e;
 
 public class BaselineOrderingSample {
-    int a = 1;
 
+    int a = 1;
     int b = 2;
+
 
     static {
         int x = 1;
     }
 
+
     void alpha() {}
 
     void zeta() {}
 
+
     class Nested {}
+
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/input/BaselineOrderingSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/input/BaselineOrderingSample.java
@@ -1,0 +1,17 @@
+package e2e;
+
+public class BaselineOrderingSample {
+    void zeta() {}
+
+    class Nested {}
+
+    int b = 2;
+
+    static {
+        int x = 1;
+    }
+
+    int a = 1;
+
+    void alpha() {}
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/config.yml
@@ -1,0 +1,26 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Initializers
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Static initializers
+        separator: none
+        sort-keys: preserve
+        includes: [ static, initializer ]
+      - name: Instance initializers
+        separator: none
+        sort-keys: preserve
+        includes: [ initializer ]
+        excludes: [ static ]

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/config.yml
@@ -1,6 +1,6 @@
 formatting:
   fix-imports: false
-  formatter-style: NONE
+  formatter-style: PALANTIR
 backups-enabled: false
 header-line:
   character: "-"

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/expected/StaticInstanceInitializerSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/expected/StaticInstanceInitializerSample.java
@@ -1,0 +1,11 @@
+package e2e;
+
+public class StaticInstanceInitializerSample {
+    static {
+        int staticValue = 2;
+    }
+
+    {
+        int instance = 1;
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/expected/StaticInstanceInitializerSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/expected/StaticInstanceInitializerSample.java
@@ -1,12 +1,11 @@
 package e2e;
 
 public class StaticInstanceInitializerSample {
-    {
-        int instance = 1;
-    }
-
     static {
         int staticValue = 2;
     }
 
+    {
+        int instance = 1;
+    }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/expected/StaticInstanceInitializerSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/expected/StaticInstanceInitializerSample.java
@@ -1,11 +1,12 @@
 package e2e;
 
 public class StaticInstanceInitializerSample {
+    {
+        int instance = 1;
+    }
+
     static {
         int staticValue = 2;
     }
 
-    {
-        int instance = 1;
-    }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/input/StaticInstanceInitializerSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/input/StaticInstanceInitializerSample.java
@@ -1,0 +1,11 @@
+package e2e;
+
+public class StaticInstanceInitializerSample {
+    {
+        int instance = 1;
+    }
+
+    static {
+        int staticValue = 2;
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/config.yml
@@ -1,0 +1,21 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Fields only
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Fields
+        separator: none
+        sort-keys: preserve
+        includes: field

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/config.yml
@@ -1,6 +1,6 @@
 formatting:
   fix-imports: false
-  formatter-style: NONE
+  formatter-style: PALANTIR
 backups-enabled: false
 header-line:
   character: "-"
@@ -17,5 +17,5 @@ type-members-ordering:
     groups:
       - name: Fields
         separator: none
-        sort-keys: preserve
+        sort-keys: alpha
         includes: field

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
@@ -1,7 +1,8 @@
 package e2e;
 
 public class FieldInitializerChainSample {
+    int c = this.b + 1;
     int a = 1;
     int b = this.a + 1;
-    int c = this.b + 1;
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
@@ -1,0 +1,7 @@
+package e2e;
+
+public class FieldInitializerChainSample {
+    int a = 1;
+    int b = this.a + 1;
+    int c = this.b + 1;
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
@@ -4,5 +4,4 @@ public class FieldInitializerChainSample {
     int c = this.b + 1;
     int a = 1;
     int b = this.a + 1;
-
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerChainSample.java
@@ -1,7 +1,7 @@
 package e2e;
 
 public class FieldInitializerChainSample {
-    int c = this.b + 1;
-    int a = 1;
-    int b = this.a + 1;
+    int a = this.b + 1;
+    int b = this.c + 1;
+    int c = this.a + 1;
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/input/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/input/FieldInitializerChainSample.java
@@ -2,6 +2,6 @@ package e2e;
 
 public class FieldInitializerChainSample {
     int c = this.b + 1;
-    int a = 1;
     int b = this.a + 1;
+    int a = 1;
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/input/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/input/FieldInitializerChainSample.java
@@ -1,7 +1,7 @@
 package e2e;
 
 public class FieldInitializerChainSample {
-    int c = this.b + 1;
-    int b = this.a + 1;
-    int a = 1;
+    int a = this.b + 1;
+    int b = this.c + 1;
+    int c = this.a + 1;
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/input/FieldInitializerChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/input/FieldInitializerChainSample.java
@@ -1,0 +1,7 @@
+package e2e;
+
+public class FieldInitializerChainSample {
+    int c = this.b + 1;
+    int a = 1;
+    int b = this.a + 1;
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/config.yml
@@ -1,0 +1,21 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Fields only
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Fields
+        separator: none
+        sort-keys: preserve
+        includes: field

--- a/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/expected/FieldCycleSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/expected/FieldCycleSample.java
@@ -4,4 +4,5 @@ public class FieldCycleSample {
     int b = this.c + 1;
     int a = this.b + 1;
     int c = this.a + 1;
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/expected/FieldCycleSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/expected/FieldCycleSample.java
@@ -1,0 +1,7 @@
+package e2e;
+
+public class FieldCycleSample {
+    int b = this.c + 1;
+    int a = this.b + 1;
+    int c = this.a + 1;
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/input/FieldCycleSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/input/FieldCycleSample.java
@@ -1,0 +1,7 @@
+package e2e;
+
+public class FieldCycleSample {
+    int b = this.c + 1;
+    int a = this.b + 1;
+    int c = this.a + 1;
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/config.yml
@@ -1,0 +1,26 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Methods
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Fields
+        separator: none
+        sort-keys: preserve
+        includes: field
+      - name: Methods
+        separator: none
+        keepAccessorsTogether: true
+        sort-keys: alpha
+        includes: method

--- a/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/expected/AccessorBundleSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/expected/AccessorBundleSample.java
@@ -1,0 +1,17 @@
+package e2e;
+
+public class AccessorBundleSample {
+    int value;
+
+    String alpha() {
+        return "alpha";
+    }
+
+    int getValue() {
+        return value;
+    }
+
+    void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/expected/AccessorBundleSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/expected/AccessorBundleSample.java
@@ -14,4 +14,5 @@ public class AccessorBundleSample {
     void setValue(int value) {
         this.value = value;
     }
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/input/AccessorBundleSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/input/AccessorBundleSample.java
@@ -1,0 +1,17 @@
+package e2e;
+
+public class AccessorBundleSample {
+    int value;
+
+    String alpha() {
+        return "alpha";
+    }
+
+    void setValue(int value) {
+        this.value = value;
+    }
+
+    int getValue() {
+        return value;
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/config.yml
@@ -1,0 +1,25 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ enum ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Enum ordering
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Enum constants
+        separator: none
+        sort-keys: preserve
+        includes: enum-constant
+      - name: Methods
+        separator: new-line
+        sort-keys: alpha
+        includes: method

--- a/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/expected/EnumScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/expected/EnumScenario.java
@@ -7,4 +7,5 @@ public enum EnumScenario {
     void alpha() {}
 
     void beta() {}
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/expected/EnumScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/expected/EnumScenario.java
@@ -1,0 +1,10 @@
+package e2e;
+
+public enum EnumScenario {
+    BETA,
+    ALPHA;
+
+    void alpha() {}
+
+    void beta() {}
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/input/EnumScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/input/EnumScenario.java
@@ -1,0 +1,10 @@
+package e2e;
+
+public enum EnumScenario {
+    BETA,
+    ALPHA;
+
+    void beta() {}
+
+    void alpha() {}
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/config.yml
@@ -1,0 +1,25 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ record ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Record ordering
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Record components
+        separator: none
+        sort-keys: preserve
+        includes: record-component
+      - name: Methods
+        separator: none
+        sort-keys: alpha
+        includes: method

--- a/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/expected/RecordScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/expected/RecordScenario.java
@@ -8,4 +8,5 @@ public record RecordScenario(int value) {
     String zeta() {
         return "z";
     }
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/expected/RecordScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/expected/RecordScenario.java
@@ -1,0 +1,11 @@
+package e2e;
+
+public record RecordScenario(int value) {
+    String alpha() {
+        return "a";
+    }
+
+    String zeta() {
+        return "z";
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/input/RecordScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/input/RecordScenario.java
@@ -1,0 +1,11 @@
+package e2e;
+
+public record RecordScenario(int value) {
+    String zeta() {
+        return "z";
+    }
+
+    String alpha() {
+        return "a";
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/config.yml
@@ -1,0 +1,25 @@
+formatting:
+  fix-imports: false
+  formatter-style: NONE
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 0
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Separator contract
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Header fields
+        separator: header
+        sort-keys: alpha
+        includes: field
+      - name: New line methods
+        separator: new-line
+        sort-keys: alpha
+        includes: method

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
@@ -1,7 +1,7 @@
 package e2e;
 
 public class SeparatorScenario {
-    // Header fields
+// Header fields
     int a = 1;
     int z = 2;
 

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
@@ -1,7 +1,7 @@
 package e2e;
 
 public class SeparatorScenario {
-// Header fields
+    // Header fields
     int a = 1;
     int z = 2;
 

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
@@ -1,0 +1,11 @@
+package e2e;
+
+public class SeparatorScenario {
+    //----------------------------------------
+    int a = 1;
+
+    int z = 2;
+
+    void alpha() {}
+    void gamma() {}
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/SeparatorScenario.java
@@ -1,11 +1,13 @@
 package e2e;
 
 public class SeparatorScenario {
-    //----------------------------------------
+// Header fields
     int a = 1;
-
     int z = 2;
 
+
     void alpha() {}
+
     void gamma() {}
+
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/input/SeparatorScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/input/SeparatorScenario.java
@@ -1,0 +1,8 @@
+package e2e;
+
+public class SeparatorScenario {
+    void gamma() {}
+    void alpha() {}
+    int z = 2;
+    int a = 1;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <repositories>
         <repository>
             <releases>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </releases>
             <snapshots>
                 <enabled>true</enabled>


### PR DESCRIPTION
### Motivation

- Provide a release-quality E2E layer that guarantees fixtures are well-formed and that processed output compiles with `--release 21`. 
- Make it easy to add more ordering scenarios and to assert exact output normalization (EOL, trailing spaces, UTF-8) as part of CI-grade tests.

### Description

- Added an E2E test driver `core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java` that discovers scenarios under `src/test/resources/test-cases/core/e2e/restructure`, enforces an initial required scenario set, runs the restructure flow with scenario `config.yml`, and compares normalized outputs against `expected/**` files.
- Added compile and normalization utilities in `core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java` that invoke `javac --release 21` (captures diagnostics) and normalize source text by converting EOLs, trimming trailing whitespace, and enforcing a final newline.
- Introduced 8 initial E2E scenarios under `core/src/test/resources/test-cases/core/e2e/restructure/<NN>-name/` with the required layout `input/**`, `expected/**`, `config.yml` covering the requested cases: baseline ordering, static/instance initializers, field initializer chain, cycle (SCC) bundling, `keepAccessorsTogether`, enum constants + method ordering, record method ordering, and separator variants.

### Testing

- Attempted to run the new test via Maven with `mvn -pl core -Dtest=SourceProcessorE2EFixtureTest test`, but the Maven invocation failed early due to external repository resolution (`403` from `https://maven.pkg.github.com` resolving `org.mockito:mockito-bom`), so the framework-level JUnit execution could not complete.
- Independently validated the core guarantees by compiling all new fixture Java sources with `javac --release 21` for both `input` and `expected` trees using a script; the `javac` checks succeeded for all 8 scenarios and diagnostics were recorded when invoked by the helper.
- Small local `javac` checks were used while authoring fixtures to avoid illegal forward-reference errors (fixtures were adjusted to use explicit `this.` where necessary).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f405c364483259b9e73d45e0d3a79)