### PR TITLE
Handle explicit `this.field` forward references in field initializer ordering

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractReferencedFieldsDeclarationDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractReferencedFieldsDeclarationDependencyProvider.java
@@ -15,7 +15,7 @@ abstract class AbstractReferencedFieldsDeclarationDependencyProvider implements 
 
     @NonNull
     @Override
-    public final Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
+    public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
             @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
 
         Optional<CtElement> dependentAstRoot = resolveDependentAstRoot(dependentMember);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
@@ -1,6 +1,11 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireSourceStart;
+
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -11,15 +16,48 @@ import spoon.reflect.declaration.CtTypeMember;
  *
  * <p>If fieldB initializer references fieldA, then fieldA -> fieldB.
  */
-final class FieldInitializerDependencyProvider extends AbstractReferencedFieldsDeclarationDependencyProvider {
+final class FieldInitializerDependencyProvider implements MemberDependencyProvider {
 
     @NonNull
     @Override
-    protected Optional<CtElement> resolveDependentAstRoot(@NonNull CtTypeMember dependentMember) {
+    public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
+            @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
         if (!(dependentMember instanceof CtField<?> dependentField)) {
-            return Optional.empty();
+            return Set.of();
         }
 
+        Optional<CtElement> dependentAstRoot = resolveDependentAstRoot(dependentField);
+        if (dependentAstRoot.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<CtTypeMember> providers = new HashSet<>(OrderDependentFieldReferenceUtils.findReferencedFields(
+                dependentField, dependentAstRoot.get()));
+        providers.addAll(findEarlierThisQualifiedReferrers(dependentField));
+
+        return providers.stream()
+                .map(providerMember ->
+                        new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @NonNull
+    private static Optional<CtElement> resolveDependentAstRoot(@NonNull CtField<?> dependentField) {
         return Optional.ofNullable(dependentField.getDefaultExpression());
+    }
+
+    private static Set<CtTypeMember> findEarlierThisQualifiedReferrers(CtField<?> dependentField) {
+        int dependentFieldSourceStart = requireSourceStart(dependentField);
+
+        return dependentField.getDeclaringType().getTypeMembers().stream()
+                .filter(typeMember -> typeMember instanceof CtField<?>)
+                .filter(typeMember -> requireSourceStart(typeMember) < dependentFieldSourceStart)
+                .map(typeMember -> (CtField<?>) typeMember)
+                .filter(field -> field.getDefaultExpression() != null)
+                .filter(field -> OrderDependentFieldReferenceUtils.findExplicitThisReferencedFields(
+                                field, field.getDefaultExpression())
+                        .contains(dependentField))
+                .map(field -> (CtTypeMember) field)
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
@@ -31,12 +31,13 @@ final class FieldInitializerDependencyProvider extends AbstractReferencedFieldsD
             return Set.of();
         }
 
-        Set<CtTypeMember> providers = new HashSet<>(OrderDependentFieldReferenceUtils.findReferencedFields(
-                dependentMember, dependentAstRoot.get()));
+        Set<CtTypeMember> providers = new HashSet<>(
+                OrderDependentFieldReferenceUtils.findReferencedFields(dependentMember, dependentAstRoot.get()));
         providers.addAll(findEarlierThisQualifiedReferrers(dependentField));
 
         return providers.stream()
-                .map(providerMember -> new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
+                .map(providerMember ->
+                        new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
                 .collect(Collectors.toUnmodifiableSet());
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
@@ -1,6 +1,11 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireSourceStart;
+
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -15,11 +20,48 @@ final class FieldInitializerDependencyProvider extends AbstractReferencedFieldsD
 
     @NonNull
     @Override
+    public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
+            @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
+        if (!(dependentMember instanceof CtField<?> dependentField)) {
+            return Set.of();
+        }
+
+        Optional<CtElement> dependentAstRoot = resolveDependentAstRoot(dependentMember);
+        if (dependentAstRoot.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<CtTypeMember> providers = new HashSet<>(OrderDependentFieldReferenceUtils.findReferencedFields(
+                dependentMember, dependentAstRoot.get()));
+        providers.addAll(findEarlierThisQualifiedReferrers(dependentField));
+
+        return providers.stream()
+                .map(providerMember -> new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @NonNull
+    @Override
     protected Optional<CtElement> resolveDependentAstRoot(@NonNull CtTypeMember dependentMember) {
         if (!(dependentMember instanceof CtField<?> dependentField)) {
             return Optional.empty();
         }
 
         return Optional.ofNullable(dependentField.getDefaultExpression());
+    }
+
+    private static Set<CtTypeMember> findEarlierThisQualifiedReferrers(CtField<?> dependentField) {
+        int dependentFieldSourceStart = requireSourceStart(dependentField);
+
+        return dependentField.getDeclaringType().getTypeMembers().stream()
+                .filter(typeMember -> typeMember instanceof CtField<?>)
+                .filter(typeMember -> requireSourceStart(typeMember) < dependentFieldSourceStart)
+                .map(typeMember -> (CtField<?>) typeMember)
+                .filter(field -> field.getDefaultExpression() != null)
+                .filter(field -> OrderDependentFieldReferenceUtils.findExplicitThisReferencedFields(
+                                field, field.getDefaultExpression())
+                        .contains(dependentField))
+                .map(field -> (CtTypeMember) field)
+                .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/FieldInitializerDependencyProvider.java
@@ -26,36 +26,14 @@ final class FieldInitializerDependencyProvider implements MemberDependencyProvid
             return Set.of();
         }
 
-        Optional<CtElement> dependentAstRoot = resolveDependentAstRoot(dependentMember);
-        if (dependentAstRoot.isEmpty()) {
-            return Set.of();
-        }
-
-        Set<CtTypeMember> providers = new HashSet<>(
-                OrderDependentFieldReferenceUtils.findReferencedFields(dependentMember, dependentAstRoot.get()));
-        providers.addAll(findEarlierThisQualifiedReferrers(dependentField));
-
-        return providers.stream()
-                .map(providerMember ->
-                        new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    @NonNull
-    @Override
-    public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
-            @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
-        if (!(dependentMember instanceof CtField<?> dependentField)) {
-            return Set.of();
-        }
-
         Optional<CtElement> dependentAstRoot = resolveDependentAstRoot(dependentField);
         if (dependentAstRoot.isEmpty()) {
             return Set.of();
         }
 
-        Set<CtTypeMember> providers = new HashSet<>(OrderDependentFieldReferenceUtils.findReferencedFields(
-                dependentField, dependentAstRoot.get()));
+        Set<CtTypeMember> providers = new HashSet<>(
+                OrderDependentFieldReferenceUtils.findReferencedFields(dependentField, dependentAstRoot.get()));
+        // TODO Build a dedicated provider???
         providers.addAll(findEarlierThisQualifiedReferrers(dependentField));
 
         return providers.stream()
@@ -69,6 +47,7 @@ final class FieldInitializerDependencyProvider implements MemberDependencyProvid
         return Optional.ofNullable(dependentField.getDefaultExpression());
     }
 
+    // TODO Rename the dependentField parameter and add a comment
     private static Set<CtTypeMember> findEarlierThisQualifiedReferrers(CtField<?> dependentField) {
         int dependentFieldSourceStart = requireSourceStart(dependentField);
 
@@ -77,8 +56,8 @@ final class FieldInitializerDependencyProvider implements MemberDependencyProvid
                 .filter(typeMember -> requireSourceStart(typeMember) < dependentFieldSourceStart)
                 .map(typeMember -> (CtField<?>) typeMember)
                 .filter(field -> field.getDefaultExpression() != null)
-                .filter(field -> OrderDependentFieldReferenceUtils.findExplicitThisReferencedFields(
-                                field, field.getDefaultExpression())
+                .filter(field -> OrderDependentFieldReferenceUtils.findExplicitThisReferencedFields(field)
+                        // TODO Move into the findExplicitThisReferencedFields method
                         .contains(dependentField))
                 .map(field -> (CtTypeMember) field)
                 .collect(Collectors.toUnmodifiableSet());

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -103,7 +103,7 @@ final class OrderDependentFieldReferenceUtils {
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
                 .filter(Objects::nonNull)
-                .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
+                .filter(referencedField -> Objects.equals(referencedField.getDeclaringType(), declaringType))
                 .collect(Collectors.toUnmodifiableSet());
     }
 
@@ -146,7 +146,7 @@ final class OrderDependentFieldReferenceUtils {
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
                 .filter(Objects::nonNull)
-                .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
+                .filter(referencedField -> Objects.equals(referencedField.getDeclaringType(), declaringType))
                 .filter(additionalFieldFilter)
                 .collect(Collectors.toUnmodifiableSet());
     }
@@ -160,10 +160,6 @@ final class OrderDependentFieldReferenceUtils {
     }
 
     private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess) {
-        if (!(fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess)) {
-            return false;
-        }
-
-        return !thisAccess.isImplicit();
+        return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -10,6 +10,7 @@ import lombok.experimental.UtilityClass;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtFieldWrite;
+import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -93,6 +94,19 @@ final class OrderDependentFieldReferenceUtils {
         return collectDeclaringTypeFields(astRoot, declaringType, CtFieldRead.class, referencedField -> true);
     }
 
+    static Set<CtField<?>> findExplicitThisReferencedFields(
+            @NonNull CtTypeMember dependentMember, @NonNull CtElement dependentAstRoot) {
+        CtType<?> declaringType = requireDeclaringType(dependentMember);
+
+        return dependentAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class)).stream()
+                .filter(OrderDependentFieldReferenceUtils::isExplicitThisQualifiedAccess)
+                .map(CtFieldAccess::getVariable)
+                .map(CtFieldReference::getDeclaration)
+                .filter(Objects::nonNull)
+                .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
     static Set<CtField<?>> findWrittenFields(@NonNull CtTypeMember dependentMember, @NonNull CtElement astRoot) {
         CtType<?> declaringType = requireDeclaringType(dependentMember);
         return collectDeclaringTypeFields(astRoot, declaringType, CtFieldWrite.class, referencedField -> true);
@@ -143,5 +157,13 @@ final class OrderDependentFieldReferenceUtils {
                 (Class<? extends CtFieldAccess<?>>) rawFieldAccessClass;
 
         return new TypeFilter<>(typedFieldAccessClass);
+    }
+
+    private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess) {
+        if (!(fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess)) {
+            return false;
+        }
+
+        return !thisAccess.isImplicit();
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -94,6 +94,7 @@ final class OrderDependentFieldReferenceUtils {
         return collectDeclaringTypeFields(astRoot, declaringType, CtFieldRead.class, referencedField -> true);
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     static Set<CtField<?>> findExplicitThisReferencedFields(
             @NonNull CtTypeMember dependentMember, @NonNull CtElement dependentAstRoot) {
         CtType<?> declaringType = requireDeclaringType(dependentMember);
@@ -103,7 +104,7 @@ final class OrderDependentFieldReferenceUtils {
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
                 .filter(Objects::nonNull)
-                .filter(referencedField -> Objects.equals(referencedField.getDeclaringType(), declaringType))
+                .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
@@ -146,7 +147,7 @@ final class OrderDependentFieldReferenceUtils {
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
                 .filter(Objects::nonNull)
-                .filter(referencedField -> Objects.equals(referencedField.getDeclaringType(), declaringType))
+                .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
                 .filter(additionalFieldFilter)
                 .collect(Collectors.toUnmodifiableSet());
     }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -10,6 +10,7 @@ import lombok.experimental.UtilityClass;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtFieldWrite;
+import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -93,6 +94,21 @@ final class OrderDependentFieldReferenceUtils {
         return collectDeclaringTypeFields(astRoot, declaringType, CtFieldRead.class, referencedField -> true);
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    static Set<CtField<?>> findExplicitThisReferencedFields(
+            @NonNull CtTypeMember dependentMember, @NonNull CtElement dependentAstRoot) {
+        CtType<?> declaringType = requireDeclaringType(dependentMember);
+
+        return dependentAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class)).stream()
+                .filter(OrderDependentFieldReferenceUtils::isExplicitThisQualifiedAccess)
+                .map(CtFieldAccess::getVariable)
+                .map(CtFieldReference::getDeclaration)
+                .filter(Objects::nonNull)
+                .map(referencedField -> (CtField<?>) referencedField)
+                .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
     static Set<CtField<?>> findWrittenFields(@NonNull CtTypeMember dependentMember, @NonNull CtElement astRoot) {
         CtType<?> declaringType = requireDeclaringType(dependentMember);
         return collectDeclaringTypeFields(astRoot, declaringType, CtFieldWrite.class, referencedField -> true);
@@ -143,5 +159,9 @@ final class OrderDependentFieldReferenceUtils {
                 (Class<? extends CtFieldAccess<?>>) rawFieldAccessClass;
 
         return new TypeFilter<>(typedFieldAccessClass);
+    }
+
+    private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess) {
+        return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -95,10 +95,13 @@ final class OrderDependentFieldReferenceUtils {
     }
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    static Set<CtField<?>> findExplicitThisReferencedFields(
-            @NonNull CtTypeMember dependentMember, @NonNull CtElement dependentAstRoot) {
+    // TODO Return boolean, rename method, and compare with the referenced field
+    static Set<CtField<?>> findExplicitThisReferencedFields(@NonNull CtField<?> /* TODO Rename*/ dependentMember) {
+        /*TODO Rename*/
+        CtElement dependentAstRoot = dependentMember.getDefaultExpression();
         CtType<?> declaringType = requireDeclaringType(dependentMember);
 
+        // TODO Make a explanatory variable with the getElements result
         return dependentAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class)).stream()
                 .filter(OrderDependentFieldReferenceUtils::isExplicitThisQualifiedAccess)
                 .map(CtFieldAccess::getVariable)
@@ -134,6 +137,7 @@ final class OrderDependentFieldReferenceUtils {
     }
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    // TODO Rename
     private static Set<CtField<?>> collectDeclaringTypeFields(
             CtElement dependentAstRoot,
             CtType<?> declaringType,

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -104,6 +104,7 @@ final class OrderDependentFieldReferenceUtils {
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
                 .filter(Objects::nonNull)
+                .map(referencedField -> (CtField<?>) referencedField)
                 .filter(referencedField -> referencedField.getDeclaringType() == declaringType)
                 .collect(Collectors.toUnmodifiableSet());
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererComplexDependenciesTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererComplexDependenciesTest.java
@@ -87,6 +87,7 @@ class GroupMembersOrdererComplexDependenciesTest {
         List<String> providerKeysInOrderedResult = orderedAlphaKeys.stream()
                 .filter(Constants.PROVIDER_ALPHA_KEYS::contains)
                 .toList();
+        // TODO Flaky test
         assertThat(providerKeysInOrderedResult)
                 .containsExactly(
                         Constants.W_PROVIDER_ALPHA_KEY,

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -69,7 +69,6 @@ class MemberDependencyGraphBuilderTest {
         assertThat(directProviders).containsExactly(Constants.BRAVO_FIELD_MEMBER);
     }
 
-
     @Test
     void buildDependencyGraph_explicitThisForwardReference_preservesSourceDeclarationOrder() {
         // Given
@@ -203,7 +202,6 @@ class MemberDependencyGraphBuilderTest {
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(FIELD_INITIALIZER_MEMBERS, "BRAVO");
         private static final CtTypeMember ALPHA_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(FIELD_INITIALIZER_MEMBERS, "ALPHA");
-
 
         private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -69,6 +69,22 @@ class MemberDependencyGraphBuilderTest {
         assertThat(directProviders).containsExactly(Constants.BRAVO_FIELD_MEMBER);
     }
 
+
+    @Test
+    void buildDependencyGraph_explicitThisForwardReference_preservesSourceDeclarationOrder() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_THIS_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).containsExactly(Constants.EXPLICIT_THIS_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER);
+    }
+
     @Test
     void buildDependencyGraph_initializerBlockReferencesEarlierField_declarationDependencyEdgeCreated() {
         // Given
@@ -187,6 +203,24 @@ class MemberDependencyGraphBuilderTest {
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(FIELD_INITIALIZER_MEMBERS, "BRAVO");
         private static final CtTypeMember ALPHA_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(FIELD_INITIALIZER_MEMBERS, "ALPHA");
+
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerExplicitThisForwardReferenceFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MEMBERS = buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MEMBERS, "alpha");
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MEMBERS, "bravo");
 
         private static final URL INITIALIZER_BLOCK_FIXTURE_URL = TestCaseResourceUtils.requireClasspathResourceUrl(
                 "/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java");

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-chain/expected/FieldInitializerInstanceRefChainSample.java
@@ -9,7 +9,7 @@ public class FieldInitializerInstanceRefChainSample {
         FieldInitializerInstanceRefChainSample sample = new FieldInitializerInstanceRefChainSample();
         if (sample.a != 10 || sample.b != 3 || sample.c != 1) {
             throw new IllegalStateException(
-                "Unexpected field chain values: a=" + sample.a + ", b=" + sample.b + ", c=" + sample.c);
+                    "Unexpected field chain values: a=" + sample.a + ", b=" + sample.b + ", c=" + sample.c);
         }
     }
 }

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerExplicitThisForwardReferenceFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerExplicitThisForwardReferenceFixture.java
@@ -1,0 +1,8 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.fixtures;
+
+public class FieldInitializerExplicitThisForwardReferenceFixture {
+
+    private final int alpha = this.bravo + 1;
+
+    private final int bravo = 10;
+}


### PR DESCRIPTION
### Motivation

- Preserve source declaration order for field initializers when an earlier field explicitly references a later field via `this.field`, to avoid surprising runtime values after reordering.

### Description

- Treat explicit `this` qualified field accesses specially by adding `findExplicitThisReferencedFields` and `isExplicitThisQualifiedAccess` in `OrderDependentFieldReferenceUtils` to detect only explicit `this.field` usages.
- Make `AbstractReferencedFieldsDeclarationDependencyProvider#findDirectProviderEdges` overridable (removed `final`) so providers can customize declaration-edge collection logic for specific initializer kinds.
- Customize `FieldInitializerDependencyProvider` to combine normal referenced-field detection with earlier fields that explicitly reference the dependent via `this`, ensuring the provider declared earlier stays a provider even for forward-reference patterns (`alpha = this.bravo + 1`).
- Add a regression fixture `core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerExplicitThisForwardReferenceFixture.java` and a test in `MemberDependencyGraphBuilderTest` that asserts the preserved ordering for the explicit-`this` forward-reference case.

### Testing

- Added an automated unit test in `MemberDependencyGraphBuilderTest` validating the explicit-`this` forward-reference behavior (test code included in the change set).
- Attempted to run targeted tests with `mvn -pl core -Dtest=MemberDependencyGraphBuilderTest test -q -o`, but the build failed due to missing offline Maven artifacts (`org.mockito:mockito-bom:5.18.0`) in this environment, so the test could not be executed here.
- Attempted the broader E2E run with `mvn -pl core -Dtest=SourceProcessorE2EFixtureTest test -q`, which also failed due to network access to Maven Central being unavailable, so E2E validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699756a04fb08325aba573e19729fc54)