### PR TITLE
Update e2e fixture mains to assert full field initialization for cases 03 and 09

### DIFF
--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/expected/FieldInitializerVarRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/expected/FieldInitializerVarRefChainSample.java
@@ -1,15 +1,15 @@
 package e2e;
 
 public class FieldInitializerVarRefChainSample {
-    int a = 12;
-    int h = 1;
-    int d = h + 3;
-    int b = d + 9;
-    int c = 5;
-    int e = 15;
-    int g = 25;
-    int f = 21 + g;
-    int i = g + 27;
+    int a = 12; // literal 12; independent constant field
+    int h = 1; // literal 1; anchor for the h -> d -> b dependency chain
+    int d = h + 3; // expects 4; depends on h, so h must stay before d
+    int b = d + 9; // expects 13; depends on d, so d must stay before b
+    int c = 5; // literal 5; independent constant field
+    int e = 15; // literal 15; independent constant field
+    int g = 25; // literal 25; independent constant field
+    int f = 21 + g; // expects 46; depends on g, so g must stay before f
+    int i = g + 27; // expects 52; depends on g, so g must stay before i
 
     public static void main(String[] args) {
         FieldInitializerVarRefChainSample sample = new FieldInitializerVarRefChainSample();

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/expected/FieldInitializerVarRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/expected/FieldInitializerVarRefChainSample.java
@@ -13,9 +13,35 @@ public class FieldInitializerVarRefChainSample {
 
     public static void main(String[] args) {
         FieldInitializerVarRefChainSample sample = new FieldInitializerVarRefChainSample();
-        if (sample.b != 13 || sample.d != 4 || sample.h != 1) {
+        if (sample.a != 12
+                || sample.b != 13
+                || sample.c != 5
+                || sample.d != 4
+                || sample.e != 15
+                || sample.f != 46
+                || sample.g != 25
+                || sample.h != 1
+                || sample.i != 52) {
             throw new IllegalStateException(
-                    "Unexpected field chain values: b=" + sample.b + ", d=" + sample.d + ", h=" + sample.h);
+                    "Unexpected field values after initialization:"
+                            + " a="
+                            + sample.a
+                            + ", b="
+                            + sample.b
+                            + ", c="
+                            + sample.c
+                            + ", d="
+                            + sample.d
+                            + ", e="
+                            + sample.e
+                            + ", f="
+                            + sample.f
+                            + ", g="
+                            + sample.g
+                            + ", h="
+                            + sample.h
+                            + ", i="
+                            + sample.i);
         }
     }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/expected/FieldInitializerVarRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/expected/FieldInitializerVarRefChainSample.java
@@ -22,26 +22,25 @@ public class FieldInitializerVarRefChainSample {
                 || sample.g != 25
                 || sample.h != 1
                 || sample.i != 52) {
-            throw new IllegalStateException(
-                    "Unexpected field values after initialization:"
-                            + " a="
-                            + sample.a
-                            + ", b="
-                            + sample.b
-                            + ", c="
-                            + sample.c
-                            + ", d="
-                            + sample.d
-                            + ", e="
-                            + sample.e
-                            + ", f="
-                            + sample.f
-                            + ", g="
-                            + sample.g
-                            + ", h="
-                            + sample.h
-                            + ", i="
-                            + sample.i);
+            throw new IllegalStateException("Unexpected field values after initialization:"
+                    + " a="
+                    + sample.a
+                    + ", b="
+                    + sample.b
+                    + ", c="
+                    + sample.c
+                    + ", d="
+                    + sample.d
+                    + ", e="
+                    + sample.e
+                    + ", f="
+                    + sample.f
+                    + ", g="
+                    + sample.g
+                    + ", h="
+                    + sample.h
+                    + ", i="
+                    + sample.i);
         }
     }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/input/FieldInitializerVarRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/input/FieldInitializerVarRefChainSample.java
@@ -13,9 +13,35 @@ public class FieldInitializerVarRefChainSample {
 
     public static void main(String[] args) {
         FieldInitializerVarRefChainSample sample = new FieldInitializerVarRefChainSample();
-        if (sample.b != 13 || sample.d != 4 || sample.h != 1) {
+        if (sample.a != 12
+                || sample.b != 13
+                || sample.c != 5
+                || sample.d != 4
+                || sample.e != 15
+                || sample.f != 46
+                || sample.g != 25
+                || sample.h != 1
+                || sample.i != 52) {
             throw new IllegalStateException(
-                    "Unexpected field chain values: b=" + sample.b + ", d=" + sample.d + ", h=" + sample.h);
+                    "Unexpected field values after initialization:"
+                            + " a="
+                            + sample.a
+                            + ", b="
+                            + sample.b
+                            + ", c="
+                            + sample.c
+                            + ", d="
+                            + sample.d
+                            + ", e="
+                            + sample.e
+                            + ", f="
+                            + sample.f
+                            + ", g="
+                            + sample.g
+                            + ", h="
+                            + sample.h
+                            + ", i="
+                            + sample.i);
         }
     }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/input/FieldInitializerVarRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/input/FieldInitializerVarRefChainSample.java
@@ -1,15 +1,15 @@
 package e2e;
 
 public class FieldInitializerVarRefChainSample {
-    int g = 25;
-    int i = g + 27;
-    int f = 21 + g;
-    int e = 15;
-    int h = 1;
-    int d = h + 3;
-    int b = d + 9;
-    int c = 5;
-    int a = 12;
+    int g = 25; // literal 25; independent constant field
+    int i = g + 27; // expects 52; depends on g, so g must stay before i
+    int f = 21 + g; // expects 46; depends on g, so g must stay before f
+    int e = 15; // literal 15; independent constant field
+    int h = 1; // literal 1; anchor for the h -> d -> b dependency chain
+    int d = h + 3; // expects 4; depends on h, so h must stay before d
+    int b = d + 9; // expects 13; depends on d, so d must stay before b
+    int c = 5; // literal 5; independent constant field
+    int a = 12; // literal 12; independent constant field
 
     public static void main(String[] args) {
         FieldInitializerVarRefChainSample sample = new FieldInitializerVarRefChainSample();

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
@@ -22,26 +22,25 @@ public class FieldInitializerInstanceRefChainSample {
                 || sample.g != 15
                 || sample.h != 1
                 || sample.i != 17) {
-            throw new IllegalStateException(
-                    "Unexpected field values after initialization:"
-                            + " a="
-                            + sample.a
-                            + ", b="
-                            + sample.b
-                            + ", c="
-                            + sample.c
-                            + ", d="
-                            + sample.d
-                            + ", e="
-                            + sample.e
-                            + ", f="
-                            + sample.f
-                            + ", g="
-                            + sample.g
-                            + ", h="
-                            + sample.h
-                            + ", i="
-                            + sample.i);
+            throw new IllegalStateException("Unexpected field values after initialization:"
+                    + " a="
+                    + sample.a
+                    + ", b="
+                    + sample.b
+                    + ", c="
+                    + sample.c
+                    + ", d="
+                    + sample.d
+                    + ", e="
+                    + sample.e
+                    + ", f="
+                    + sample.f
+                    + ", g="
+                    + sample.g
+                    + ", h="
+                    + sample.h
+                    + ", i="
+                    + sample.i);
         }
     }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
@@ -13,9 +13,35 @@ public class FieldInitializerInstanceRefChainSample {
 
     public static void main(String[] args) {
         FieldInitializerInstanceRefChainSample sample = new FieldInitializerInstanceRefChainSample();
-        if (sample.b != 10 || sample.e != 3 || sample.h != 1) {
+        if (sample.a != 0
+                || sample.b != 10
+                || sample.c != 8
+                || sample.d != 11
+                || sample.e != 3
+                || sample.f != 9
+                || sample.g != 15
+                || sample.h != 1
+                || sample.i != 17) {
             throw new IllegalStateException(
-                    "Unexpected field chain values: b=" + sample.b + ", e=" + sample.e + ", h=" + sample.h);
+                    "Unexpected field values after initialization:"
+                            + " a="
+                            + sample.a
+                            + ", b="
+                            + sample.b
+                            + ", c="
+                            + sample.c
+                            + ", d="
+                            + sample.d
+                            + ", e="
+                            + sample.e
+                            + ", f="
+                            + sample.f
+                            + ", g="
+                            + sample.g
+                            + ", h="
+                            + sample.h
+                            + ", i="
+                            + sample.i);
         }
     }
 }

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
@@ -1,15 +1,15 @@
 package e2e;
 
 public class FieldInitializerInstanceRefChainSample {
-    int i = this.a + 17;
-    int a = 0; // TODO Exception
-    int h = this.e + 1;
-    int e = this.b + 3;
-    int b = this.h + 9;
-    int c = e + 5;
-    int d = this.g + 11;
-    int f = this.g + 9;
-    int g = 15;
+    int i = this.a + 17; // a is default 0 here, so i initializes to 17 (forward ref)
+    int a = 0; // explicit 0; same value as default, included for clarity
+    int h = this.e + 1; // e is default 0 here, so h initializes to 1 (forward ref)
+    int e = this.b + 3; // b is default 0 here, so e initializes to 3 (forward ref)
+    int b = this.h + 9; // h is already 1, so b becomes 10
+    int c = e + 5; // e is already 3, so c becomes 8
+    int d = this.g + 11; // g is default 0 here, so d initializes to 11 (forward ref)
+    int f = this.g + 9; // g is default 0 here, so f initializes to 9 (forward ref)
+    int g = 15; // literal 15; later assignment does not recalc d/f
 
     public static void main(String[] args) {
         FieldInitializerInstanceRefChainSample sample = new FieldInitializerInstanceRefChainSample();

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/input/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/input/FieldInitializerInstanceRefChainSample.java
@@ -1,15 +1,15 @@
 package e2e;
 
 public class FieldInitializerInstanceRefChainSample {
-    int h = this.e + 1;
-    int e = this.b + 3;
-    int b = this.h + 9;
-    int c = e + 5;
-    int f = this.g + 9;
-    int d = this.g + 11;
-    int g = 15;
-    int i = this.a + 17;
-    int a  = 0; // TODO Exception
+    int h = this.e + 1; // e is default 0 here, so h initializes to 1 (forward ref)
+    int e = this.b + 3; // b is default 0 here, so e initializes to 3 (forward ref)
+    int b = this.h + 9; // h is already 1, so b becomes 10
+    int c = e + 5; // e is already 3, so c becomes 8
+    int f = this.g + 9; // g is default 0 here, so f initializes to 9 (forward ref)
+    int d = this.g + 11; // g is default 0 here, so d initializes to 11 (forward ref)
+    int g = 15; // literal 15; later assignment does not recalc d/f
+    int i = this.a + 17; // a is default 0 here, so i initializes to 17 (forward ref)
+    int a = 0; // explicit 0; same value as default, included for clarity
 
     public static void main(String[] args) {
         FieldInitializerInstanceRefChainSample sample = new FieldInitializerInstanceRefChainSample();

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/input/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/input/FieldInitializerInstanceRefChainSample.java
@@ -13,9 +13,35 @@ public class FieldInitializerInstanceRefChainSample {
 
     public static void main(String[] args) {
         FieldInitializerInstanceRefChainSample sample = new FieldInitializerInstanceRefChainSample();
-        if (sample.b != 10 || sample.e != 3 || sample.h != 1) {
+        if (sample.a != 0
+                || sample.b != 10
+                || sample.c != 8
+                || sample.d != 11
+                || sample.e != 3
+                || sample.f != 9
+                || sample.g != 15
+                || sample.h != 1
+                || sample.i != 17) {
             throw new IllegalStateException(
-                "Unexpected field chain values: b=" + sample.b + ", e=" + sample.e + ", h=" + sample.h);
+                    "Unexpected field values after initialization:"
+                            + " a="
+                            + sample.a
+                            + ", b="
+                            + sample.b
+                            + ", c="
+                            + sample.c
+                            + ", d="
+                            + sample.d
+                            + ", e="
+                            + sample.e
+                            + ", f="
+                            + sample.f
+                            + ", g="
+                            + sample.g
+                            + ", h="
+                            + sample.h
+                            + ", i="
+                            + sample.i);
         }
     }
 }


### PR DESCRIPTION
### Motivation
- E2E fixture `main` methods for restructure scenarios 03 and 09 validated only a small subset of fields and became out-of-date after tests/initialization logic changed, so they needed to be extended to check the full internal state after object construction. 

### Description
- Updated `input` and `expected` sources for scenario 03 at `core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/` to assert every field (`a..i`) in `main` and to produce a detailed state snapshot on failure. 
- Updated `input` and `expected` sources for scenario 09 at `core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/` to assert every field (`a..i`) in `main` and to produce a detailed state snapshot on failure. 
- Error messages were expanded to include all field values to make debugging test failures easier and to ensure `input` and `expected` remain comparable by the E2E fixture runner. 

### Testing
- Ran `mvn -pl core -Dtest=SourceProcessorE2EFixtureTest test` to validate the change, but the build failed to resolve `org.mockito:mockito-bom:5.21.0` due to network connectivity in this environment, so the test run did not complete. 
- No other automated test runs were possible in this environment due to the same dependency resolution/network limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699892983d6483258145a1faa821c247)