### PR TITLE
Skip declaration dependency for explicit-this refs to default/folded-default fields; add tests and update e2e expected

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.CtTypeCast;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtField;
@@ -90,18 +89,13 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
     }
 
     private static CtExpression<?> unwrapTypeCasts(@NonNull CtExpression<?> expression) {
-        CtExpression<?> currentExpression = expression;
-        while (currentExpression instanceof CtTypeCast<?> typeCastExpression) {
-            currentExpression = typeCastExpression.getExpression();
-        }
-
-        if (currentExpression instanceof CtUnaryOperator<?> unaryOperator
+        if (expression instanceof CtUnaryOperator<?> unaryOperator
                 && unaryOperator.getKind() == UnaryOperatorKind.NEG
                 && unaryOperator.getOperand() instanceof CtLiteral<?> operandLiteral
                 && isNumericZeroLiteral(operandLiteral.getValue())) {
             return operandLiteral;
         }
 
-        return currentExpression;
+        return expression;
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -2,9 +2,15 @@ package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireSourceStart;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.NonNull;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtTypeCast;
+import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtTypeMember;
 
@@ -18,6 +24,10 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
     public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
             @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
         if (!(dependentMember instanceof CtField<?> referencedField)) {
+            return Set.of();
+        }
+
+        if (!hasOrderSensitiveInitialization(referencedField)) {
             return Set.of();
         }
 
@@ -38,5 +48,60 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
                 .filter(field -> OrderDependentFieldReferenceUtils.hasExplicitThisReferenceTo(field, referencedField))
                 .map(field -> (CtTypeMember) field)
                 .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static boolean hasOrderSensitiveInitialization(@NonNull CtField<?> referencedField) {
+        CtExpression<?> defaultExpression = referencedField.getDefaultExpression();
+        if (defaultExpression == null) {
+            return false;
+        }
+
+        return !isExplicitDefaultValueInitializer(referencedField, defaultExpression);
+    }
+
+    private static boolean isExplicitDefaultValueInitializer(
+            @NonNull CtField<?> referencedField, @NonNull CtExpression<?> defaultExpression) {
+        CtExpression<?> foldedExpression = defaultExpression.partiallyEvaluate();
+        CtExpression<?> unwrappedExpression = unwrapTypeCasts(foldedExpression);
+        if (!(unwrappedExpression instanceof CtLiteral<?> literalExpression)) {
+            return false;
+        }
+
+        Object literalValue = literalExpression.getValue();
+        if (referencedField.getType().isPrimitive()) {
+            String primitiveTypeName = referencedField.getType().getQualifiedName();
+            return switch (primitiveTypeName) {
+                case "boolean" -> Objects.equals(Boolean.FALSE, literalValue);
+                case "char" -> literalValue instanceof Character characterValue && characterValue == 0;
+                case "byte", "short", "int", "long", "float", "double" -> isNumericZeroLiteral(literalValue);
+                default -> false;
+            };
+        }
+
+        return literalValue == null;
+    }
+
+    private static boolean isNumericZeroLiteral(Object literalValue) {
+        if (!(literalValue instanceof Number numericLiteral)) {
+            return false;
+        }
+
+        return numericLiteral.doubleValue() == 0D;
+    }
+
+    private static CtExpression<?> unwrapTypeCasts(@NonNull CtExpression<?> expression) {
+        CtExpression<?> currentExpression = expression;
+        while (currentExpression instanceof CtTypeCast<?> typeCastExpression) {
+            currentExpression = typeCastExpression.getExpression();
+        }
+
+        if (currentExpression instanceof CtUnaryOperator<?> unaryOperator
+                && unaryOperator.getKind() == UnaryOperatorKind.NEG
+                && unaryOperator.getOperand() instanceof CtLiteral<?> operandLiteral
+                && isNumericZeroLiteral(operandLiteral.getValue())) {
+            return operandLiteral;
+        }
+
+        return currentExpression;
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -268,9 +268,10 @@ class MemberDependencyGraphBuilderTest {
         private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(
                         "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceDefaultValueFixture.java");
-        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
-                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
-                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL);
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL);
         private static final Map<CtTypeMember, CompiledMemberGroup>
                 FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS = buildTypeMember2NaturalGroup(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
@@ -282,13 +283,15 @@ class MemberDependencyGraphBuilderTest {
         private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(
                         "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceImplicitDefaultValueFixture.java");
-        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
-                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
-                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL);
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL);
         private static final Map<CtTypeMember, CompiledMemberGroup>
-                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS = buildTypeMember2NaturalGroup(
-                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
-                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS =
+                        buildTypeMember2NaturalGroup(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                                MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
         private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS, "bravo");
@@ -296,13 +299,15 @@ class MemberDependencyGraphBuilderTest {
         private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(
                         "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceFoldedDefaultValueFixture.java");
-        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
-                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
-                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_URL);
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_URL);
         private static final Map<CtTypeMember, CompiledMemberGroup>
-                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_MEMBERS = buildTypeMember2NaturalGroup(
-                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
-                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_MEMBERS =
+                        buildTypeMember2NaturalGroup(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                                MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
         private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_MEMBERS, "bravo");

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -85,6 +85,51 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
+    void buildDependencyGraph_explicitThisForwardReferenceToFieldWithExplicitDefaultValue_noDeclarationDependency() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).isEmpty();
+    }
+
+    @Test
+    void buildDependencyGraph_explicitThisForwardReferenceToFieldWithImplicitDefaultValue_noDeclarationDependency() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).isEmpty();
+    }
+
+    @Test
+    void buildDependencyGraph_explicitThisForwardReferenceToFieldWithFoldedDefaultValue_noDeclarationDependency() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).isEmpty();
+    }
+
+    @Test
     void buildDependencyGraph_initializerBlockReferencesEarlierField_declarationDependencyEdgeCreated() {
         // Given
         MemberDependencyGraph memberDependencyGraph =
@@ -219,6 +264,48 @@ class MemberDependencyGraphBuilderTest {
         private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MEMBERS, "bravo");
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceDefaultValueFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS = buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS, "bravo");
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceImplicitDefaultValueFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS = buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS, "bravo");
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceFoldedDefaultValueFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_MEMBERS = buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FOLDED_DEFAULT_VALUE_MEMBERS, "bravo");
 
         private static final URL INITIALIZER_BLOCK_FIXTURE_URL = TestCaseResourceUtils.requireClasspathResourceUrl(
                 "/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java");

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
@@ -2,7 +2,6 @@ package e2e;
 
 public class FieldInitializerInstanceRefChainSample {
     int a = 0; // TODO Exception
-    int i = this.a + 17;
     int h = this.e + 1;
     int e = this.b + 3;
     int b = this.h + 9;
@@ -10,6 +9,7 @@ public class FieldInitializerInstanceRefChainSample {
     int d = this.g + 11;
     int f = this.g + 9;
     int g = 15;
+    int i = this.a + 17;
 
     public static void main(String[] args) {
         FieldInitializerInstanceRefChainSample sample = new FieldInitializerInstanceRefChainSample();

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java
@@ -1,8 +1,8 @@
 package e2e;
 
 public class FieldInitializerInstanceRefChainSample {
-    int i = this.a + 17;
     int a = 0; // TODO Exception
+    int i = this.a + 17;
     int h = this.e + 1;
     int e = this.b + 3;
     int b = this.h + 9;

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceDefaultValueFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceDefaultValueFixture.java
@@ -1,0 +1,8 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.fixtures;
+
+public class FieldInitializerExplicitThisForwardReferenceDefaultValueFixture {
+
+    private final int alpha = this.bravo + 1;
+
+    private final int bravo = 0;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceFoldedDefaultValueFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceFoldedDefaultValueFixture.java
@@ -1,0 +1,8 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.fixtures;
+
+public class FieldInitializerExplicitThisForwardReferenceFoldedDefaultValueFixture {
+
+    private final int alpha = this.bravo + 1;
+
+    private final int bravo = 2 - 2;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceImplicitDefaultValueFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceImplicitDefaultValueFixture.java
@@ -1,0 +1,8 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.fixtures;
+
+public class FieldInitializerExplicitThisForwardReferenceImplicitDefaultValueFixture {
+
+    private final int alpha = this.bravo + 1;
+
+    private int bravo;
+}


### PR DESCRIPTION
### Motivation
- Avoid creating declaration-order dependencies when a field referenced via `this.<field>` is effectively initialized to a language-default value, including cases where the initializer folds to a default (e.g. `2 - 2`).
- Make the dependency-graph behaviour consistent between explicit `= 0`, implicit default initialization, and folded-to-zero expressions so reordering rules can place default-initialized fields earlier.

### Description
- Update `ExplicitThisInitializerFieldDependencyProvider` to short-circuit when a referenced field has a non-order-sensitive initialization by evaluating `defaultExpression.partiallyEvaluate()` and detecting explicit default-value initializers via new helpers `hasOrderSensitiveInitialization`, `isExplicitDefaultValueInitializer`, `isNumericZeroLiteral`, and `unwrapTypeCasts`.
- Added three fixtures under `core/src/test/resources/.../explicit-this-forward-reference/`: `FieldInitializerExplicitThisForwardReferenceDefaultValueFixture.java`, `FieldInitializerExplicitThisForwardReferenceFoldedDefaultValueFixture.java`, and `FieldInitializerExplicitThisForwardReferenceImplicitDefaultValueFixture.java` to cover explicit `= 0`, folded-to-zero, and implicit-default cases.
- Added regression tests in `MemberDependencyGraphBuilderTest` asserting no declaration dependency is created for `default`, `folded default`, and `implicit default` cases (`buildDependencyGraph_explicitThisForwardReferenceToFieldWithExplicitDefaultValue_noDeclarationDependency`, `buildDependencyGraph_explicitThisForwardReferenceToFieldWithImplicitDefaultValue_noDeclarationDependency`, and `buildDependencyGraph_explicitThisForwardReferenceToFieldWithFoldedDefaultValue_noDeclarationDependency`).
- Updated the e2e expected output `core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/expected/FieldInitializerInstanceRefChainSample.java` to reflect the new ordering where the default-initialized field `a` appears before its dependent `i`.

### Testing
- Attempted to run the unit tests with `mvn -pl core test -Dtest=MemberDependencyGraphBuilderTest`, but the build failed due to inability to resolve `org.mockito:mockito-bom:5.21.0` from Maven Central (`Network is unreachable`), so automated tests could not complete in this environment.
- Added and committed the new tests and fixtures so CI should run them in a networked environment where Maven dependencies can be resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998933a57448325b03ed82a0c7462ea)