### PR TITLE
Shorten overly long test name in MemberDependencyGraphBuilderTest

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -130,8 +130,7 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
-    void
-            buildDependencyGraph_explicitThisForwardReferenceToFieldWithBooleanFalseDefaultValue_noDeclarationDependency() {
+    void buildDependencyGraph_explicitThisForwardRefToFieldWithBooleanFalseDefault_noDeclarationDependency() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
                 Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_BOOLEAN_FALSE_DEFAULT_VALUE_MEMBERS);


### PR DESCRIPTION
### Motivation
- Keep test method signatures within line-length limits by shortening an excessively long test method name in `core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java` so it fits on one line.

### Description
- Renamed the test method `buildDependencyGraph_explicitThisForwardReferenceToFieldWithBooleanFalseDefaultValue_noDeclarationDependency` to `buildDependencyGraph_explicitThisForwardRefToFieldWithBooleanFalseDefault_noDeclarationDependency` without changing the test logic or assertions.

### Testing
- Attempted to run `./gradlew :core:test --tests io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.MemberDependencyGraphBuilderTest`, but `./gradlew` was not present in the environment.
- Attempted to run `mvn -pl core test -Dtest=MemberDependencyGraphBuilderTest`, but the build failed due to unresolved dependencies because the environment could not reach Maven Central (`Network is unreachable`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cde419c483259a8e29497c82dc54)