### PR TITLE
Simplify unary minus zero predicate in default initializer detection

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -26,7 +26,7 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
             return Set.of();
         }
 
-        if (!hasOrderSensitiveInitialization(referencedField)) {
+        if (isDefaultValueInitializer(referencedField)) {
             return Set.of();
         }
 
@@ -49,17 +49,12 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private static boolean hasOrderSensitiveInitialization(@NonNull CtField<?> referencedField) {
+    private static boolean isDefaultValueInitializer(@NonNull CtField<?> referencedField) {
         CtExpression<?> defaultExpression = referencedField.getDefaultExpression();
         if (defaultExpression == null) {
-            return false;
+            return true;
         }
 
-        return !isExplicitDefaultValueInitializer(referencedField, defaultExpression);
-    }
-
-    private static boolean isExplicitDefaultValueInitializer(
-            @NonNull CtField<?> referencedField, @NonNull CtExpression<?> defaultExpression) {
         CtExpression<?> foldedExpression = defaultExpression.partiallyEvaluate();
         if (isUnaryMinusZeroLiteral(foldedExpression)) {
             return true;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -79,11 +79,7 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
     }
 
     private static boolean isNumericZeroLiteral(Object literalValue) {
-        if (!(literalValue instanceof Number numericLiteral)) {
-            return false;
-        }
-
-        return numericLiteral.doubleValue() == 0D;
+        return literalValue instanceof Number numericLiteral && numericLiteral.doubleValue() == 0D;
     }
 
     private static boolean isUnaryMinusZeroLiteral(@NonNull CtExpression<?> expression) {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -61,8 +61,11 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
     private static boolean isExplicitDefaultValueInitializer(
             @NonNull CtField<?> referencedField, @NonNull CtExpression<?> defaultExpression) {
         CtExpression<?> foldedExpression = defaultExpression.partiallyEvaluate();
-        CtExpression<?> unwrappedExpression = unwrapTypeCasts(foldedExpression);
-        if (!(unwrappedExpression instanceof CtLiteral<?> literalExpression)) {
+        if (isUnaryMinusZeroLiteral(foldedExpression)) {
+            return true;
+        }
+
+        if (!(foldedExpression instanceof CtLiteral<?> literalExpression)) {
             return false;
         }
 
@@ -88,16 +91,10 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
         return numericLiteral.doubleValue() == 0D;
     }
 
-    private static CtExpression<?> unwrapTypeCasts(@NonNull CtExpression<?> expression) {
-        // The default path keeps literal expressions unchanged (boolean/char/null/0 etc.) and only normalizes
-        // one non-literal shape that still semantically means numeric zero: unary minus applied to literal zero.
-        if (expression instanceof CtUnaryOperator<?> unaryOperator
+    private static boolean isUnaryMinusZeroLiteral(@NonNull CtExpression<?> expression) {
+        return expression instanceof CtUnaryOperator<?> unaryOperator
                 && unaryOperator.getKind() == UnaryOperatorKind.NEG
                 && unaryOperator.getOperand() instanceof CtLiteral<?> operandLiteral
-                && isNumericZeroLiteral(operandLiteral.getValue())) {
-            return operandLiteral;
-        }
-
-        return expression;
+                && isNumericZeroLiteral(operandLiteral.getValue());
     }
 }


### PR DESCRIPTION
### Motivation
- Make detection of explicit default-value initializers clearer by treating the unary minus zero (`-0`) case explicitly and early.
- Remove the previous `unwrapTypeCasts` rewriting and replace it with a focused predicate to avoid hidden expression transformations.
- Address review feedback to simplify the `isUnaryMinusZeroLiteral` implementation to a single expression return.

### Description
- Updated `isExplicitDefaultValueInitializer` in `core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java` to return early when `isUnaryMinusZeroLiteral(foldedExpression)` is true.
- Removed the `unwrapTypeCasts` approach and replaced it with a predicate method `isUnaryMinusZeroLiteral(...)` that checks for a `NEG` unary operator applied to a numeric zero literal.
- Simplified `isUnaryMinusZeroLiteral` to a single expression-bodied boolean return while preserving the existing literal checks for boolean `false`, `char` zero, numeric zero, and `null` handling.
- Minor cleanup and commit to keep the refactor concise and maintain semantic parity with prior behavior.

### Testing
- Attempted to run the focused test: `mvn -pl core -Dtest=MemberDependencyGraphBuilderTest test`.
- Automated test run was blocked by environment network issues (could not resolve `org.mockito:mockito-bom:5.21.0` from Maven Central), so no project tests could be executed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999d55a5c888325a5ef5c18e365b4c7)