### PR TITLE
Unify explicit forward-reference dependency handling for instance and static fields

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -53,7 +53,10 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
 
     protected final boolean hasExplicitThisReferenceTo(
             @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        return hasExplicitQualifiedReferenceTo(referrerField, referencedField, this::isExplicitThisQualifiedAccess);
+        return hasExplicitQualifiedReferenceTo(
+                referrerField,
+                referencedField,
+                AbstractExplicitInitializerForwardReferenceDependencyProvider::isExplicitThisQualifiedAccess);
     }
 
     protected final boolean hasExplicitDeclaringTypeReferenceTo(
@@ -67,10 +70,11 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                         isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType));
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private boolean hasExplicitQualifiedReferenceTo(
-            @NonNull CtField<?> referrerField,
-            @NonNull CtField<?> referencedField,
-            @NonNull BiPredicate<CtFieldAccess<?>, CtType<?>> qualifierMatcher) {
+            CtField<?> referrerField,
+            CtField<?> referencedField,
+            BiPredicate<CtFieldAccess<?>, CtType<?>> qualifierMatcher) {
         CtElement referrerAstRoot = referrerField.getDefaultExpression();
         if (referrerAstRoot == null) {
             return false;
@@ -96,6 +100,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
         return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private static boolean isExplicitDeclaringTypeQualifiedAccess(
             CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
         if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {
@@ -106,7 +111,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                 && typeAccess.getAccessedType().getTypeDeclaration() == declaringType;
     }
 
-    private Set<CtTypeMember> findEarlierReferrerFieldsWithExplicitReferenceTo(@NonNull CtField<?> referencedField) {
+    private Set<CtTypeMember> findEarlierReferrerFieldsWithExplicitReferenceTo(CtField<?> referencedField) {
         int referencedFieldSourceStart = requireSourceStart(referencedField);
 
         return referencedField.getDeclaringType().getTypeMembers().stream()
@@ -120,7 +125,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private static boolean isDefaultValueInitializer(@NonNull CtField<?> referencedField) {
+    private static boolean isDefaultValueInitializer(CtField<?> referencedField) {
         CtExpression<?> defaultExpression = referencedField.getDefaultExpression();
         if (defaultExpression == null) {
             return true;
@@ -133,7 +138,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                         .orElse(false);
     }
 
-    private static <T> Optional<CtLiteral<T>> castLiteralExpression(@NonNull CtExpression<T> expression) {
+    private static <T> Optional<CtLiteral<T>> castLiteralExpression(CtExpression<T> expression) {
         if (expression instanceof CtLiteral<T> literalExpression) {
             return Optional.of(literalExpression);
         }
@@ -141,7 +146,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
         return Optional.empty();
     }
 
-    private static boolean isDefaultLiteralValue(@NonNull CtField<?> referencedField, Object literalValue) {
+    private static boolean isDefaultLiteralValue(CtField<?> referencedField, Object literalValue) {
         if (!referencedField.getType().isPrimitive()) {
             return literalValue == null;
         }
@@ -149,7 +154,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
         return isDefaultPrimitiveLiteralValue(referencedField.getType().getQualifiedName(), literalValue);
     }
 
-    private static boolean isDefaultPrimitiveLiteralValue(@NonNull String primitiveTypeName, Object literalValue) {
+    private static boolean isDefaultPrimitiveLiteralValue(String primitiveTypeName, Object literalValue) {
         return switch (primitiveTypeName) {
             case "boolean" -> Objects.equals(Boolean.FALSE, literalValue);
             case "char" -> literalValue instanceof Character characterValue && characterValue == 0;
@@ -162,7 +167,7 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
         return literalValue instanceof Number numericLiteral && numericLiteral.doubleValue() == 0D;
     }
 
-    private static boolean isUnaryMinusZeroLiteral(@NonNull CtExpression<?> expression) {
+    private static boolean isUnaryMinusZeroLiteral(CtExpression<?> expression) {
         return expression instanceof CtUnaryOperator<?> unaryOperator
                 && unaryOperator.getKind() == UnaryOperatorKind.NEG
                 && unaryOperator.getOperand() instanceof CtLiteral<?> operandLiteral

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -51,13 +51,11 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
     protected abstract boolean hasExplicitReferenceTo(
             @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField);
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     protected final boolean hasExplicitThisReferenceTo(
             @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
         return hasExplicitQualifiedReferenceTo(referrerField, referencedField, this::isExplicitThisQualifiedAccess);
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     protected final boolean hasExplicitDeclaringTypeReferenceTo(
             @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
         CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
@@ -69,7 +67,6 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                         isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType));
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private boolean hasExplicitQualifiedReferenceTo(
             @NonNull CtField<?> referrerField,
             @NonNull CtField<?> referencedField,
@@ -99,7 +96,6 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
         return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     private static boolean isExplicitDeclaringTypeQualifiedAccess(
             CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
         if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -19,6 +19,7 @@ import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.reference.CtFieldReference;
 import spoon.reflect.visitor.filter.TypeFilter;
 
@@ -70,8 +71,6 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                 .filter(fieldAccess -> qualifierMatcher.test(fieldAccess, referrerDeclaringType))
                 .map(CtFieldAccess::getVariable)
                 .map(CtFieldReference::getDeclaration)
-                .filter(Objects::nonNull)
-                .map(declaredField -> (CtField<?>) declaredField)
                 .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
     }
 
@@ -83,7 +82,6 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                 .filter(typeMember -> requireSourceStart(typeMember) < referencedFieldSourceStart)
                 .map(typeMember -> (CtField<?>) typeMember)
                 .filter(this::isSupportedReferrerField)
-                .filter(field -> field.getDefaultExpression() != null)
                 .filter(referrerField -> hasExplicitReferenceTo(referrerField, referencedField))
                 .map(field -> (CtTypeMember) field)
                 .collect(Collectors.toUnmodifiableSet());
@@ -136,5 +134,9 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                 && unaryOperator.getKind() == UnaryOperatorKind.NEG
                 && unaryOperator.getOperand() instanceof CtLiteral<?> operandLiteral
                 && isNumericZeroLiteral(operandLiteral.getValue());
+    }
+
+    protected static boolean isStaticField(@NonNull CtField<?> field) {
+        return field.getModifiers().contains(ModifierKind.STATIC);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -1,18 +1,28 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireDeclaringType;
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireSourceStart;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtThisAccess;
+import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.UnaryOperatorKind;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.reference.CtFieldReference;
+import spoon.reflect.visitor.filter.TypeFilter;
 
 abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider implements MemberDependencyProvider {
 
@@ -40,6 +50,65 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
 
     protected abstract boolean hasExplicitReferenceTo(
             @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField);
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    protected final boolean hasExplicitThisReferenceTo(
+            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
+        return hasExplicitQualifiedReferenceTo(referrerField, referencedField, this::isExplicitThisQualifiedAccess);
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    protected final boolean hasExplicitDeclaringTypeReferenceTo(
+            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
+        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
+
+        return hasExplicitQualifiedReferenceTo(
+                referrerField,
+                referencedField,
+                (fieldAccess, ignoredDeclaringType) ->
+                        isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType));
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private boolean hasExplicitQualifiedReferenceTo(
+            @NonNull CtField<?> referrerField,
+            @NonNull CtField<?> referencedField,
+            @NonNull BiPredicate<CtFieldAccess<?>, CtType<?>> qualifierMatcher) {
+        CtElement referrerAstRoot = referrerField.getDefaultExpression();
+        if (referrerAstRoot == null) {
+            return false;
+        }
+
+        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
+        if (referencedField.getDeclaringType() != referrerDeclaringType) {
+            return false;
+        }
+
+        List<CtFieldAccess<?>> fieldAccesses = referrerAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class));
+
+        return fieldAccesses.stream()
+                .filter(fieldAccess -> qualifierMatcher.test(fieldAccess, referrerDeclaringType))
+                .map(CtFieldAccess::getVariable)
+                .map(CtFieldReference::getDeclaration)
+                .filter(Objects::nonNull)
+                .map(declaredField -> (CtField<?>) declaredField)
+                .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
+    }
+
+    private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess, CtType<?> ignoredDeclaringType) {
+        return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private static boolean isExplicitDeclaringTypeQualifiedAccess(
+            CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
+        if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {
+            return false;
+        }
+
+        return typeAccess.getAccessedType() != null
+                && typeAccess.getAccessedType().getTypeDeclaration() == declaringType;
+    }
 
     private Set<CtTypeMember> findEarlierReferrerFieldsWithExplicitReferenceTo(@NonNull CtField<?> referencedField) {
         int referencedFieldSourceStart = requireSourceStart(referencedField);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -5,11 +5,8 @@ import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiPredicate;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.NonNull;
-import lombok.experimental.UtilityClass;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtUnaryOperator;
@@ -17,27 +14,48 @@ import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtTypeMember;
 
-@UtilityClass
-final class ExplicitInitializerForwardReferenceDependencyUtils {
+abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider implements MemberDependencyProvider {
 
-    static Set<CtTypeMember> findEarlierFieldsWithReferenceTo(
-            @NonNull CtField<?> referencedField,
-            @NonNull Predicate<CtField<?>> additionalReferrerFilter,
-            @NonNull BiPredicate<CtField<?>, CtField<?>> hasExplicitReferencePredicate) {
+    @NonNull
+    @Override
+    public final Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
+            @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
+        if (!(dependentMember instanceof CtField<?> referencedField) || !isSupportedReferencedField(referencedField)) {
+            return Set.of();
+        }
+
+        if (isDefaultValueInitializer(referencedField)) {
+            return Set.of();
+        }
+
+        return findEarlierReferrerFieldsWithExplicitReferenceTo(referencedField).stream()
+                .map(providerMember ->
+                        new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    protected abstract boolean isSupportedReferencedField(@NonNull CtField<?> referencedField);
+
+    protected abstract boolean isSupportedReferrerField(@NonNull CtField<?> referrerField);
+
+    protected abstract boolean hasExplicitReferenceTo(
+            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField);
+
+    private Set<CtTypeMember> findEarlierReferrerFieldsWithExplicitReferenceTo(@NonNull CtField<?> referencedField) {
         int referencedFieldSourceStart = requireSourceStart(referencedField);
 
         return referencedField.getDeclaringType().getTypeMembers().stream()
                 .filter(typeMember -> typeMember instanceof CtField<?>)
                 .filter(typeMember -> requireSourceStart(typeMember) < referencedFieldSourceStart)
                 .map(typeMember -> (CtField<?>) typeMember)
-                .filter(additionalReferrerFilter)
+                .filter(this::isSupportedReferrerField)
                 .filter(field -> field.getDefaultExpression() != null)
-                .filter(referrerField -> hasExplicitReferencePredicate.test(referrerField, referencedField))
+                .filter(referrerField -> hasExplicitReferenceTo(referrerField, referencedField))
                 .map(field -> (CtTypeMember) field)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    static boolean isDefaultValueInitializer(@NonNull CtField<?> referencedField) {
+    private static boolean isDefaultValueInitializer(@NonNull CtField<?> referencedField) {
         CtExpression<?> defaultExpression = referencedField.getDefaultExpression();
         if (defaultExpression == null) {
             return true;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -13,8 +13,6 @@ import lombok.NonNull;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtLiteral;
-import spoon.reflect.code.CtThisAccess;
-import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.UnaryOperatorKind;
 import spoon.reflect.declaration.CtElement;
@@ -51,27 +49,8 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
     protected abstract boolean hasExplicitReferenceTo(
             @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField);
 
-    protected final boolean hasExplicitThisReferenceTo(
-            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        return hasExplicitQualifiedReferenceTo(
-                referrerField,
-                referencedField,
-                AbstractExplicitInitializerForwardReferenceDependencyProvider::isExplicitThisQualifiedAccess);
-    }
-
-    protected final boolean hasExplicitDeclaringTypeReferenceTo(
-            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
-
-        return hasExplicitQualifiedReferenceTo(
-                referrerField,
-                referencedField,
-                (fieldAccess, ignoredDeclaringType) ->
-                        isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType));
-    }
-
     @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private boolean hasExplicitQualifiedReferenceTo(
+    protected boolean hasExplicitQualifiedReferenceTo(
             CtField<?> referrerField,
             CtField<?> referencedField,
             BiPredicate<CtFieldAccess<?>, CtType<?>> qualifierMatcher) {
@@ -94,21 +73,6 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
                 .filter(Objects::nonNull)
                 .map(declaredField -> (CtField<?>) declaredField)
                 .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
-    }
-
-    private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess, CtType<?> ignoredDeclaringType) {
-        return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
-    }
-
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private static boolean isExplicitDeclaringTypeQualifiedAccess(
-            CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
-        if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {
-            return false;
-        }
-
-        return typeAccess.getAccessedType() != null
-                && typeAccess.getAccessedType().getTypeDeclaration() == declaringType;
     }
 
     private Set<CtTypeMember> findEarlierReferrerFieldsWithExplicitReferenceTo(CtField<?> referencedField) {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
@@ -27,6 +27,6 @@ final class ExplicitDeclaringTypeInitializerFieldDependencyProvider
 
     @Override
     protected boolean hasExplicitReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        return OrderDependentFieldReferenceUtils.hasExplicitDeclaringTypeReferenceTo(referrerField, referencedField);
+        return hasExplicitDeclaringTypeReferenceTo(referrerField, referencedField);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
@@ -5,17 +5,23 @@ import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtTypeMember;
+import spoon.reflect.declaration.ModifierKind;
 
 /**
- * Provides declaration dependencies created by explicit {@code this.<field>} references in field initializers.
+ * Provides declaration dependencies created by explicit {@code <DeclaringType>.<field>} references in static field
+ * initializers.
  */
-final class ExplicitThisInitializerFieldDependencyProvider implements MemberDependencyProvider {
+final class ExplicitDeclaringTypeInitializerFieldDependencyProvider implements MemberDependencyProvider {
+
+    private static boolean isStaticField(@NonNull CtField<?> field) {
+        return field.getModifiers().contains(ModifierKind.STATIC);
+    }
 
     @NonNull
     @Override
     public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
             @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
-        if (!(dependentMember instanceof CtField<?> referencedField)) {
+        if (!(dependentMember instanceof CtField<?> referencedField) || !isStaticField(referencedField)) {
             return Set.of();
         }
 
@@ -25,8 +31,8 @@ final class ExplicitThisInitializerFieldDependencyProvider implements MemberDepe
 
         return ExplicitInitializerForwardReferenceDependencyUtils.findEarlierFieldsWithReferenceTo(
                         referencedField,
-                        ignoredField -> true,
-                        OrderDependentFieldReferenceUtils::hasExplicitThisReferenceTo)
+                        ExplicitDeclaringTypeInitializerFieldDependencyProvider::isStaticField,
+                        OrderDependentFieldReferenceUtils::hasExplicitDeclaringTypeReferenceTo)
                 .stream()
                 .map(providerMember ->
                         new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
@@ -1,41 +1,32 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.declaration.ModifierKind;
 
 /**
  * Provides declaration dependencies created by explicit {@code <DeclaringType>.<field>} references in static field
  * initializers.
  */
-final class ExplicitDeclaringTypeInitializerFieldDependencyProvider implements MemberDependencyProvider {
+final class ExplicitDeclaringTypeInitializerFieldDependencyProvider
+        extends AbstractExplicitInitializerForwardReferenceDependencyProvider {
 
     private static boolean isStaticField(@NonNull CtField<?> field) {
         return field.getModifiers().contains(ModifierKind.STATIC);
     }
 
-    @NonNull
     @Override
-    public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
-            @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
-        if (!(dependentMember instanceof CtField<?> referencedField) || !isStaticField(referencedField)) {
-            return Set.of();
-        }
+    protected boolean isSupportedReferencedField(@NonNull CtField<?> referencedField) {
+        return isStaticField(referencedField);
+    }
 
-        if (ExplicitInitializerForwardReferenceDependencyUtils.isDefaultValueInitializer(referencedField)) {
-            return Set.of();
-        }
+    @Override
+    protected boolean isSupportedReferrerField(@NonNull CtField<?> referrerField) {
+        return isStaticField(referrerField);
+    }
 
-        return ExplicitInitializerForwardReferenceDependencyUtils.findEarlierFieldsWithReferenceTo(
-                        referencedField,
-                        ExplicitDeclaringTypeInitializerFieldDependencyProvider::isStaticField,
-                        OrderDependentFieldReferenceUtils::hasExplicitDeclaringTypeReferenceTo)
-                .stream()
-                .map(providerMember ->
-                        new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
-                .collect(Collectors.toUnmodifiableSet());
+    @Override
+    protected boolean hasExplicitReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
+        return OrderDependentFieldReferenceUtils.hasExplicitDeclaringTypeReferenceTo(referrerField, referencedField);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
@@ -7,7 +7,6 @@ import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.ModifierKind;
 
 /**
  * Provides declaration dependencies created by explicit {@code <DeclaringType>.<field>} references in static field
@@ -15,10 +14,6 @@ import spoon.reflect.declaration.ModifierKind;
  */
 final class ExplicitDeclaringTypeInitializerFieldDependencyProvider
         extends AbstractExplicitInitializerForwardReferenceDependencyProvider {
-
-    private static boolean isStaticField(@NonNull CtField<?> field) {
-        return field.getModifiers().contains(ModifierKind.STATIC);
-    }
 
     @Override
     protected boolean isSupportedReferencedField(@NonNull CtField<?> referencedField) {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
@@ -1,7 +1,12 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireDeclaringType;
+
 import lombok.NonNull;
+import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.ModifierKind;
 
 /**
@@ -27,6 +32,23 @@ final class ExplicitDeclaringTypeInitializerFieldDependencyProvider
 
     @Override
     protected boolean hasExplicitReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        return hasExplicitDeclaringTypeReferenceTo(referrerField, referencedField);
+        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
+
+        return hasExplicitQualifiedReferenceTo(
+                referrerField,
+                referencedField,
+                (fieldAccess, ignoredDeclaringType) ->
+                        isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType));
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private static boolean isExplicitDeclaringTypeQualifiedAccess(
+            CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
+        if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {
+            return false;
+        }
+
+        return typeAccess.getAccessedType() != null
+                && typeAccess.getAccessedType().getTypeDeclaration() == declaringType;
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitInitializerForwardReferenceDependencyUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitInitializerForwardReferenceDependencyUtils.java
@@ -1,0 +1,88 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
+
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.OrderDependentFieldReferenceUtils.requireSourceStart;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtLiteral;
+import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.UnaryOperatorKind;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtTypeMember;
+
+@UtilityClass
+final class ExplicitInitializerForwardReferenceDependencyUtils {
+
+    static Set<CtTypeMember> findEarlierFieldsWithReferenceTo(
+            @NonNull CtField<?> referencedField,
+            @NonNull Predicate<CtField<?>> additionalReferrerFilter,
+            @NonNull BiPredicate<CtField<?>, CtField<?>> hasExplicitReferencePredicate) {
+        int referencedFieldSourceStart = requireSourceStart(referencedField);
+
+        return referencedField.getDeclaringType().getTypeMembers().stream()
+                .filter(typeMember -> typeMember instanceof CtField<?>)
+                .filter(typeMember -> requireSourceStart(typeMember) < referencedFieldSourceStart)
+                .map(typeMember -> (CtField<?>) typeMember)
+                .filter(additionalReferrerFilter)
+                .filter(field -> field.getDefaultExpression() != null)
+                .filter(referrerField -> hasExplicitReferencePredicate.test(referrerField, referencedField))
+                .map(field -> (CtTypeMember) field)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    static boolean isDefaultValueInitializer(@NonNull CtField<?> referencedField) {
+        CtExpression<?> defaultExpression = referencedField.getDefaultExpression();
+        if (defaultExpression == null) {
+            return true;
+        }
+
+        CtExpression<?> foldedExpression = defaultExpression.partiallyEvaluate();
+        return isUnaryMinusZeroLiteral(foldedExpression)
+                || castLiteralExpression(foldedExpression)
+                        .map(literalExpression -> isDefaultLiteralValue(referencedField, literalExpression.getValue()))
+                        .orElse(false);
+    }
+
+    private static <T> Optional<CtLiteral<T>> castLiteralExpression(@NonNull CtExpression<T> expression) {
+        if (expression instanceof CtLiteral<T> literalExpression) {
+            return Optional.of(literalExpression);
+        }
+
+        return Optional.empty();
+    }
+
+    private static boolean isDefaultLiteralValue(@NonNull CtField<?> referencedField, Object literalValue) {
+        if (!referencedField.getType().isPrimitive()) {
+            return literalValue == null;
+        }
+
+        return isDefaultPrimitiveLiteralValue(referencedField.getType().getQualifiedName(), literalValue);
+    }
+
+    private static boolean isDefaultPrimitiveLiteralValue(@NonNull String primitiveTypeName, Object literalValue) {
+        return switch (primitiveTypeName) {
+            case "boolean" -> Objects.equals(Boolean.FALSE, literalValue);
+            case "char" -> literalValue instanceof Character characterValue && characterValue == 0;
+            case "byte", "short", "int", "long", "float", "double" -> isNumericZeroLiteral(literalValue);
+            default -> false;
+        };
+    }
+
+    private static boolean isNumericZeroLiteral(Object literalValue) {
+        return literalValue instanceof Number numericLiteral && numericLiteral.doubleValue() == 0D;
+    }
+
+    private static boolean isUnaryMinusZeroLiteral(@NonNull CtExpression<?> expression) {
+        return expression instanceof CtUnaryOperator<?> unaryOperator
+                && unaryOperator.getKind() == UnaryOperatorKind.NEG
+                && unaryOperator.getOperand() instanceof CtLiteral<?> operandLiteral
+                && isNumericZeroLiteral(operandLiteral.getValue());
+    }
+}

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -14,7 +14,7 @@ final class ExplicitThisInitializerFieldDependencyProvider
 
     @Override
     protected boolean isSupportedReferencedField(@NonNull CtField<?> referencedField) {
-        return true;
+        return !isStaticField(referencedField);
     }
 
     @Override

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -21,6 +21,6 @@ final class ExplicitThisInitializerFieldDependencyProvider
 
     @Override
     protected boolean hasExplicitReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        return OrderDependentFieldReferenceUtils.hasExplicitThisReferenceTo(referrerField, referencedField);
+        return hasExplicitThisReferenceTo(referrerField, referencedField);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -1,7 +1,10 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
 import lombok.NonNull;
+import spoon.reflect.code.CtFieldAccess;
+import spoon.reflect.code.CtThisAccess;
 import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.CtType;
 
 /**
  * Provides declaration dependencies created by explicit {@code this.<field>} references in field initializers.
@@ -21,6 +24,13 @@ final class ExplicitThisInitializerFieldDependencyProvider
 
     @Override
     protected boolean hasExplicitReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        return hasExplicitThisReferenceTo(referrerField, referencedField);
+        return hasExplicitQualifiedReferenceTo(
+                referrerField,
+                referencedField,
+                ExplicitThisInitializerFieldDependencyProvider::isExplicitThisQualifiedAccess);
+    }
+
+    private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess, CtType<?> ignoredDeclaringType) {
+        return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitThisInitializerFieldDependencyProvider.java
@@ -1,35 +1,26 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.NonNull;
 import spoon.reflect.declaration.CtField;
-import spoon.reflect.declaration.CtTypeMember;
 
 /**
  * Provides declaration dependencies created by explicit {@code this.<field>} references in field initializers.
  */
-final class ExplicitThisInitializerFieldDependencyProvider implements MemberDependencyProvider {
+final class ExplicitThisInitializerFieldDependencyProvider
+        extends AbstractExplicitInitializerForwardReferenceDependencyProvider {
 
-    @NonNull
     @Override
-    public Set<@NonNull MemberDependencyArc> findDirectProviderEdges(
-            @NonNull CtTypeMember dependentMember, boolean keepAccessorsTogether) {
-        if (!(dependentMember instanceof CtField<?> referencedField)) {
-            return Set.of();
-        }
+    protected boolean isSupportedReferencedField(@NonNull CtField<?> referencedField) {
+        return true;
+    }
 
-        if (ExplicitInitializerForwardReferenceDependencyUtils.isDefaultValueInitializer(referencedField)) {
-            return Set.of();
-        }
+    @Override
+    protected boolean isSupportedReferrerField(@NonNull CtField<?> referrerField) {
+        return true;
+    }
 
-        return ExplicitInitializerForwardReferenceDependencyUtils.findEarlierFieldsWithReferenceTo(
-                        referencedField,
-                        ignoredField -> true,
-                        OrderDependentFieldReferenceUtils::hasExplicitThisReferenceTo)
-                .stream()
-                .map(providerMember ->
-                        new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
-                .collect(Collectors.toUnmodifiableSet());
+    @Override
+    protected boolean hasExplicitReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
+        return OrderDependentFieldReferenceUtils.hasExplicitThisReferenceTo(referrerField, referencedField);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilder.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilder.java
@@ -22,6 +22,7 @@ public class MemberDependencyGraphBuilder {
             new BlankFinalDefiniteAssignmentDependencyProvider(),
             new FieldInitializerBackwardReferenceDependencyProvider(),
             new ExplicitThisInitializerFieldDependencyProvider(),
+            new ExplicitDeclaringTypeInitializerFieldDependencyProvider(),
             new InitializerBlockDependencyProvider());
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -135,5 +135,4 @@ final class OrderDependentFieldReferenceUtils {
                 .filter(additionalFieldFilter)
                 .collect(Collectors.toUnmodifiableSet());
     }
-
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -11,6 +11,7 @@ import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtFieldWrite;
 import spoon.reflect.code.CtThisAccess;
+import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -117,6 +118,30 @@ final class OrderDependentFieldReferenceUtils {
                 .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
     }
 
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    static boolean hasExplicitDeclaringTypeReferenceTo(
+            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
+        CtElement referrerAstRoot = referrerField.getDefaultExpression();
+        if (referrerAstRoot == null) {
+            return false;
+        }
+
+        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
+        if (referencedField.getDeclaringType() != referrerDeclaringType) {
+            return false;
+        }
+
+        List<CtFieldAccess<?>> fieldAccesses = referrerAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class));
+
+        return fieldAccesses.stream()
+                .filter(fieldAccess -> isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType))
+                .map(CtFieldAccess::getVariable)
+                .map(CtFieldReference::getDeclaration)
+                .filter(Objects::nonNull)
+                .map(declaredField -> (CtField<?>) declaredField)
+                .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
+    }
+
     static Set<CtField<?>> findWrittenFields(@NonNull CtTypeMember dependentMember, @NonNull CtElement astRoot) {
         CtType<?> declaringType = requireDeclaringType(dependentMember);
         return collectReferencedDeclaringTypeFields(
@@ -162,5 +187,15 @@ final class OrderDependentFieldReferenceUtils {
 
     private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess) {
         return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private static boolean isExplicitDeclaringTypeQualifiedAccess(CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
+        if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {
+            return false;
+        }
+
+        return typeAccess.getAccessedType() != null
+                && typeAccess.getAccessedType().getTypeDeclaration() == declaringType;
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/OrderDependentFieldReferenceUtils.java
@@ -10,8 +10,6 @@ import lombok.experimental.UtilityClass;
 import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtFieldWrite;
-import spoon.reflect.code.CtThisAccess;
-import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -95,53 +93,6 @@ final class OrderDependentFieldReferenceUtils {
         return collectReferencedDeclaringTypeFields(astRoot, declaringType, CtFieldRead.class, referencedField -> true);
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    static boolean hasExplicitThisReferenceTo(@NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        CtElement referrerAstRoot = referrerField.getDefaultExpression();
-        if (referrerAstRoot == null) {
-            return false;
-        }
-
-        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
-        if (referencedField.getDeclaringType() != referrerDeclaringType) {
-            return false;
-        }
-
-        List<CtFieldAccess<?>> fieldAccesses = referrerAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class));
-
-        return fieldAccesses.stream()
-                .filter(OrderDependentFieldReferenceUtils::isExplicitThisQualifiedAccess)
-                .map(CtFieldAccess::getVariable)
-                .map(CtFieldReference::getDeclaration)
-                .filter(Objects::nonNull)
-                .map(declaredField -> (CtField<?>) declaredField)
-                .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
-    }
-
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    static boolean hasExplicitDeclaringTypeReferenceTo(
-            @NonNull CtField<?> referrerField, @NonNull CtField<?> referencedField) {
-        CtElement referrerAstRoot = referrerField.getDefaultExpression();
-        if (referrerAstRoot == null) {
-            return false;
-        }
-
-        CtType<?> referrerDeclaringType = requireDeclaringType(referrerField);
-        if (referencedField.getDeclaringType() != referrerDeclaringType) {
-            return false;
-        }
-
-        List<CtFieldAccess<?>> fieldAccesses = referrerAstRoot.getElements(new TypeFilter<>(CtFieldAccess.class));
-
-        return fieldAccesses.stream()
-                .filter(fieldAccess -> isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType))
-                .map(CtFieldAccess::getVariable)
-                .map(CtFieldReference::getDeclaration)
-                .filter(Objects::nonNull)
-                .map(declaredField -> (CtField<?>) declaredField)
-                .anyMatch(candidateReferencedField -> candidateReferencedField == referencedField);
-    }
-
     static Set<CtField<?>> findWrittenFields(@NonNull CtTypeMember dependentMember, @NonNull CtElement astRoot) {
         CtType<?> declaringType = requireDeclaringType(dependentMember);
         return collectReferencedDeclaringTypeFields(
@@ -185,17 +136,4 @@ final class OrderDependentFieldReferenceUtils {
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private static boolean isExplicitThisQualifiedAccess(CtFieldAccess<?> fieldAccess) {
-        return fieldAccess.getTarget() instanceof CtThisAccess<?> thisAccess && !thisAccess.isImplicit();
-    }
-
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private static boolean isExplicitDeclaringTypeQualifiedAccess(CtFieldAccess<?> fieldAccess, CtType<?> declaringType) {
-        if (!(fieldAccess.getTarget() instanceof CtTypeAccess<?> typeAccess) || typeAccess.isImplicit()) {
-            return false;
-        }
-
-        return typeAccess.getAccessedType() != null
-                && typeAccess.getAccessedType().getTypeDeclaration() == declaringType;
-    }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -189,6 +189,22 @@ class MemberDependencyGraphBuilderTest {
         assertThat(directProviders).isEmpty();
     }
 
+
+    @Test
+    void buildDependencyGraph_explicitDeclaringTypeForwardReference_preservesSourceDeclarationOrder() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).containsExactly(Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER);
+    }
+
     @Test
     void buildDependencyGraph_initializerBlockReferencesEarlierField_declarationDependencyEdgeCreated() {
         // Given
@@ -439,6 +455,24 @@ class MemberDependencyGraphBuilderTest {
         private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_MINUS_ZERO_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MINUS_ZERO_DEFAULT_VALUE_MEMBERS, "bravo");
+
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS = buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS, "alpha");
+        private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS, "bravo");
 
         private static final URL INITIALIZER_BLOCK_FIXTURE_URL = TestCaseResourceUtils.requireClasspathResourceUrl(
                 "/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java");

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -205,6 +205,52 @@ class MemberDependencyGraphBuilderTest {
         assertThat(directProviders).containsExactly(Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER);
     }
 
+
+    @Test
+    void buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithExplicitDefaultValue_noDeclarationDependency() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).isEmpty();
+    }
+
+    @Test
+    void buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithImplicitDefaultValue_noDeclarationDependency() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).isEmpty();
+    }
+
+    @Test
+    void buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithNullDefaultValue_noDeclarationDependency() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).isEmpty();
+    }
+
     @Test
     void buildDependencyGraph_initializerBlockReferencesEarlierField_declarationDependencyEdgeCreated() {
         // Given
@@ -473,6 +519,58 @@ class MemberDependencyGraphBuilderTest {
         private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS, "bravo");
+
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceDefaultValueFixture.java");
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS =
+                        buildTypeMember2NaturalGroup(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                                MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS, "bravo");
+
+        private static final URL
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL =
+                        TestCaseResourceUtils.requireClasspathResourceUrl(
+                                "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceImplicitDefaultValueFixture.java");
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS =
+                        buildTypeMember2NaturalGroup(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                                MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember
+                EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                        SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS,
+                                "bravo");
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture.java");
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_MEMBERS =
+                        buildTypeMember2NaturalGroup(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
+                                MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_MEMBERS, "bravo");
 
         private static final URL INITIALIZER_BLOCK_FIXTURE_URL = TestCaseResourceUtils.requireClasspathResourceUrl(
                 "/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java");

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -189,7 +189,6 @@ class MemberDependencyGraphBuilderTest {
         assertThat(directProviders).isEmpty();
     }
 
-
     @Test
     void buildDependencyGraph_explicitDeclaringTypeForwardReference_preservesSourceDeclarationOrder() {
         // Given
@@ -202,12 +201,13 @@ class MemberDependencyGraphBuilderTest {
                 EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
 
         // Then
-        assertThat(directProviders).containsExactly(Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER);
+        assertThat(directProviders)
+                .containsExactly(Constants.EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_ALPHA_FIELD_MEMBER);
     }
 
-
     @Test
-    void buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithExplicitDefaultValue_noDeclarationDependency() {
+    void
+            buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithExplicitDefaultValue_noDeclarationDependency() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
                 Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_MEMBERS);
@@ -222,7 +222,8 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
-    void buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithImplicitDefaultValue_noDeclarationDependency() {
+    void
+            buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithImplicitDefaultValue_noDeclarationDependency() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
                 Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS);
@@ -237,7 +238,8 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
-    void buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithNullDefaultValue_noDeclarationDependency() {
+    void
+            buildDependencyGraph_explicitDeclaringTypeForwardReferenceToFieldWithNullDefaultValue_noDeclarationDependency() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
                 Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_MEMBERS);
@@ -502,7 +504,6 @@ class MemberDependencyGraphBuilderTest {
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MINUS_ZERO_DEFAULT_VALUE_MEMBERS, "bravo");
 
-
         private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(
                         "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceFixture.java");
@@ -519,7 +520,6 @@ class MemberDependencyGraphBuilderTest {
         private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS, "bravo");
-
 
         private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_DEFAULT_VALUE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(
@@ -556,9 +556,10 @@ class MemberDependencyGraphBuilderTest {
                                 FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_IMPLICIT_DEFAULT_VALUE_MEMBERS,
                                 "bravo");
 
-        private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_URL =
-                TestCaseResourceUtils.requireClasspathResourceUrl(
-                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture.java");
+        private static final URL
+                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_URL =
+                        TestCaseResourceUtils.requireClasspathResourceUrl(
+                                "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture.java");
         private static final CtType<?>
                 FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_MAIN_TYPE =
                         SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
@@ -568,9 +569,11 @@ class MemberDependencyGraphBuilderTest {
                         buildTypeMember2NaturalGroup(
                                 FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_FIXTURE_MAIN_TYPE,
                                 MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
-        private static final CtTypeMember EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
-                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
-                        FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_MEMBERS, "bravo");
+        private static final CtTypeMember
+                EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
+                        SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                                FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_NULL_DEFAULT_VALUE_MEMBERS,
+                                "bravo");
 
         private static final URL INITIALIZER_BLOCK_FIXTURE_URL = TestCaseResourceUtils.requireClasspathResourceUrl(
                 "/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java");

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceDefaultValueFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceDefaultValueFixture.java
@@ -1,0 +1,7 @@
+package fixtures.dependency_graph;
+
+public class FieldInitializerExplicitDeclaringTypeForwardReferenceDefaultValueFixture {
+
+    private static final int alpha = FieldInitializerExplicitDeclaringTypeForwardReferenceDefaultValueFixture.bravo + 1;
+    private static final int bravo = 0;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceFixture.java
@@ -1,0 +1,7 @@
+package fixtures.dependency_graph;
+
+public class FieldInitializerExplicitDeclaringTypeForwardReferenceFixture {
+
+    private static final int alpha = FieldInitializerExplicitDeclaringTypeForwardReferenceFixture.bravo + 1;
+    private static final int bravo = 10;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceImplicitDefaultValueFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceImplicitDefaultValueFixture.java
@@ -1,0 +1,8 @@
+package fixtures.dependency_graph;
+
+public class FieldInitializerExplicitDeclaringTypeForwardReferenceImplicitDefaultValueFixture {
+
+    private static final int alpha =
+            FieldInitializerExplicitDeclaringTypeForwardReferenceImplicitDefaultValueFixture.bravo + 1;
+    private static int bravo;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-declaring-type-forward-reference/FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture.java
@@ -1,0 +1,8 @@
+package fixtures.dependency_graph;
+
+public class FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture {
+
+    private static final int alpha =
+            FieldInitializerExplicitDeclaringTypeForwardReferenceNullDefaultValueFixture.bravo == null ? 1 : 0;
+    private static final String bravo = null;
+}


### PR DESCRIPTION
### Motivation
- Remove duplicated logic between `this.<field>` and `DeclaringType.<field>` forward-reference handling by sharing the common algorithm. 
- Ensure both instance-qualified and class-qualified explicit forward references use the same earlier-referrer scanning and default-value detection logic to avoid near-duplicate implementations. 

### Description
- Introduced `ExplicitInitializerForwardReferenceDependencyUtils` which centralizes scanning earlier fields and default-value initializer detection used by explicit forward-reference providers. 
- Simplified `ExplicitThisInitializerFieldDependencyProvider` to call `ExplicitInitializerForwardReferenceDependencyUtils` and delegate only `this`-specific checks via `OrderDependentFieldReferenceUtils::hasExplicitThisReferenceTo`. 
- Added `ExplicitDeclaringTypeInitializerFieldDependencyProvider` that reuses the shared utility, applies a `static`-field filter, and uses `OrderDependentFieldReferenceUtils::hasExplicitDeclaringTypeReferenceTo`. 
- Extended `OrderDependentFieldReferenceUtils` with `hasExplicitDeclaringTypeReferenceTo` and `isExplicitDeclaringTypeQualifiedAccess` (with `CtTypeAccess` import) and registered the new provider in `MemberDependencyGraphBuilder`. 
- Added a unit test and fixture for the class-qualified forward-reference case: `buildDependencyGraph_explicitDeclaringTypeForwardReference_preservesSourceDeclarationOrder` and `FieldInitializerExplicitDeclaringTypeForwardReferenceFixture.java`. 

### Testing
- Ran `mvn -pl core -Dtest=MemberDependencyGraphBuilderTest test` in this environment and the build failed due to inability to resolve `org.mockito:mockito-bom:5.21.0` from Maven Central (network unreachable). 
- No repository-wide CI run was performed here, but the new test and fixture are present for CI or a network-enabled local execution to validate behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f93fb5b48325b1c190e387cd0ff5)