### PR TITLE
chore: bump SpotBugs and PMD versions to latest stable releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,15 @@
         <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
         <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
         <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+        <maven-pmd-plugin.version>3.28.0</maven-pmd-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>
         <palantir-java-format.version>2.88.0</palantir-java-format.version>
+        <pmd.version>7.21.0</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
-        <spotbugs-maven-plugin.version>4.9.8.0</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotless-maven-plugin.version>2.44.5</spotless-maven-plugin.version>
     </properties>
@@ -349,7 +351,7 @@
 
                     <plugin>
                         <artifactId>maven-pmd-plugin</artifactId>
-                        <version>3.27.0</version>
+                        <version>${maven-pmd-plugin.version}</version>
                         <configuration>
                             <linkXRef>false</linkXRef>
                             <printFailingErrors>true</printFailingErrors>
@@ -357,6 +359,13 @@
                                 <ruleset>${maven.multiModuleProjectDirectory}/quality-gates/pmd-custom-ruleset.xml</ruleset>
                             </rulesets>
                         </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>net.sourceforge.pmd</groupId>
+                                <artifactId>pmd-java</artifactId>
+                                <version>${pmd.version}</version>
+                            </dependency>
+                        </dependencies>
 
                         <executions>
                             <execution>


### PR DESCRIPTION
### Motivation

- Ensure static analysis plugins and their underlying analyzers are on the newest stable releases to get latest fixes and rules.
- Pin the PMD engine used by the Maven PMD plugin to avoid mismatches between the plugin wrapper and analyzer versions.

### Description

- Bumped `spotbugs-maven-plugin` property from `4.9.8.0` to `4.9.8.2` in `pom.xml`.
- Introduced managed properties `maven-pmd-plugin.version=3.28.0` and `pmd.version=7.21.0` in `pom.xml`.
- Switched `maven-pmd-plugin` to use `${maven-pmd-plugin.version}` and added a plugin dependency `net.sourceforge.pmd:pmd-java:${pmd.version}` so the plugin uses the pinned PMD engine.

### Testing

- Fetched plugin/engine metadata from Maven Central with `curl` to validate available versions for `spotbugs-maven-plugin`, `spotbugs`, `maven-pmd-plugin`, and `net.sourceforge.pmd:pmd-java`; these queries returned the expected latest stable versions.
- Ran `mvn -DskipTests -Dskip-quality-gates -Dci-pipeline=true validate` to validate the build configuration, which failed due to external network/Maven Central reachability (could not download `org.mockito:mockito-bom`), not due to the pom changes.
- No unit/integration tests were changed or added as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a0bbfa7648325a7a77ca9c163fbf0)