### PR TITLE
Refactor disabled E2E expected regeneration to one-pass stream

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 class SourceProcessorE2EFixtureTest {
 
     private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
+    private static final String FIXTURES_RESOURCE_IN_PROJECT = "test-cases/core/e2e/restructure/";
+    private static final Path PROJECT_TEST_RESOURCES_ROOT = Path.of("core/src/test/resources");
     private static final URL FIXTURE_RESOURCES_ROOT_DIR =
             TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
     private static final Path FIXTURES_ROOT = resolveFixturesRoot();
@@ -109,6 +111,7 @@ class SourceProcessorE2EFixtureTest {
             Object[] argumentValues = fixture.get();
             Path fixtureInputFile = (Path) argumentValues[0];
             Path expectedSourceFile = (Path) argumentValues[1];
+            Path projectExpectedSourceFile = resolveProjectExpectedSourceFile(expectedSourceFile);
             Path fixtureScenario = fixtureInputFile.getParent().getParent();
             String scenarioName = fixtureScenario.getFileName().toString();
 
@@ -118,14 +121,16 @@ class SourceProcessorE2EFixtureTest {
             runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), FlowType.RESTRUCTURE);
 
             try {
-                Files.createDirectories(expectedSourceFile.getParent());
-                Files.copy(workingInputFile, expectedSourceFile, StandardCopyOption.REPLACE_EXISTING);
+                Files.createDirectories(projectExpectedSourceFile.getParent());
+                Files.copy(workingInputFile, projectExpectedSourceFile, StandardCopyOption.REPLACE_EXISTING);
             } catch (IOException exception) {
-                throw new IllegalStateException("Failed to regenerate expected fixture: " + expectedSourceFile, exception);
+                throw new IllegalStateException(
+                        "Failed to regenerate expected fixture in project resources: " + projectExpectedSourceFile,
+                        exception);
             }
 
-            assertThat(expectedSourceFile)
-                    .as("Expected source file should exist after regeneration: %s", expectedSourceFile)
+            assertThat(projectExpectedSourceFile)
+                    .as("Expected source file should exist after regeneration: %s", projectExpectedSourceFile)
                     .exists();
         });
     }
@@ -194,5 +199,10 @@ class SourceProcessorE2EFixtureTest {
 
     private static Path resolveExpected(Path scenario) {
         return scenario.resolve(EXPECTED_DIRECTORY);
+    }
+
+    private static Path resolveProjectExpectedSourceFile(Path expectedSourceFileFromClasspath) {
+        Path expectedRelativePath = FIXTURES_ROOT.relativize(expectedSourceFileFromClasspath);
+        return PROJECT_TEST_RESOURCES_ROOT.resolve(FIXTURES_RESOURCE_IN_PROJECT).resolve(expectedRelativePath);
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 class SourceProcessorE2EFixtureTest {
 
     private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
-    private static final String FIXTURES_RESOURCE_IN_PROJECT = "test-cases/core/e2e/restructure/";
     private static final Path PROJECT_TEST_RESOURCES_ROOT = Path.of("src/test/resources");
     private static final URL FIXTURE_RESOURCES_ROOT_DIR =
             TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
@@ -205,8 +204,12 @@ class SourceProcessorE2EFixtureTest {
     }
 
     private static Path resolveProjectExpectedSourceFile(Path scenarioDir, Path sourceFile) {
+        String fixturesResourceRelative = FIXTURES_RESOURCE.startsWith("/")
+                ? FIXTURES_RESOURCE.substring(1)
+                : FIXTURES_RESOURCE;
+
         return PROJECT_TEST_RESOURCES_ROOT
-                .resolve(FIXTURES_RESOURCE_IN_PROJECT)
+                .resolve(fixturesResourceRelative)
                 .resolve(scenarioDir)
                 .resolve(EXPECTED_DIRECTORY)
                 .resolve(sourceFile);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -19,14 +19,16 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-// TODO Create a method for expected fixtures regeneration
 class SourceProcessorE2EFixtureTest {
 
     private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
@@ -96,6 +98,36 @@ class SourceProcessorE2EFixtureTest {
                         "Expected main method execution to succeed for %s. Output:%n%s",
                         runAfterResult.getClassName(), runAfterResult.getOutput())
                 .isZero();
+    }
+
+    @Test
+    @Disabled("Utility only. Run manually to regenerate all e2e expected fixtures")
+    void regenerateExpectedFixtures_whenRun_overwritesExpectedSources() throws Exception {
+        Path regenerateWorkspace = temporaryDirectory.resolve("SourceProcessorE2E-regenerate-expected");
+
+        fixtureInputFiles().forEach(fixture -> {
+            Object[] argumentValues = fixture.get();
+            Path fixtureInputFile = (Path) argumentValues[0];
+            Path expectedSourceFile = (Path) argumentValues[1];
+            Path fixtureScenario = fixtureInputFile.getParent().getParent();
+            String scenarioName = fixtureScenario.getFileName().toString();
+
+            Path workingScenarioRoot = regenerateWorkspace.resolve(scenarioName);
+            Path workingInputFile = copyInputJavaFile(fixtureInputFile, workingScenarioRoot);
+
+            runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), FlowType.RESTRUCTURE);
+
+            try {
+                Files.createDirectories(expectedSourceFile.getParent());
+                Files.copy(workingInputFile, expectedSourceFile, StandardCopyOption.REPLACE_EXISTING);
+            } catch (IOException exception) {
+                throw new IllegalStateException("Failed to regenerate expected fixture: " + expectedSourceFile, exception);
+            }
+
+            assertThat(expectedSourceFile)
+                    .as("Expected source file should exist after regeneration: %s", expectedSourceFile)
+                    .exists();
+        });
     }
 
     private static Stream<Arguments> fixtureInputFiles() throws IOException {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -46,7 +46,7 @@ class SourceProcessorE2EFixtureTest {
     @TempDir
     Path temporaryDirectory;
 
-    @ParameterizedTest(name = "[{index}] {0}")
+    @ParameterizedTest(name = "[{index}] {0}/{1}")
     @MethodSource("fixtureInputFiles")
     void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path sourceFile)
             throws Exception {
@@ -204,10 +204,7 @@ class SourceProcessorE2EFixtureTest {
     }
 
     private static Path resolveProjectExpectedSourceFile(Path scenarioDir, Path sourceFile) {
-        String fixturesResourceRelative = FIXTURES_RESOURCE.startsWith("/")
-                ? FIXTURES_RESOURCE.substring(1)
-                : FIXTURES_RESOURCE;
-
+        String fixturesResourceRelative = FIXTURES_RESOURCE.substring(1);
         return PROJECT_TEST_RESOURCES_ROOT
                 .resolve(fixturesResourceRelative)
                 .resolve(scenarioDir)

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -33,7 +33,7 @@ class SourceProcessorE2EFixtureTest {
 
     private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
     private static final String FIXTURES_RESOURCE_IN_PROJECT = "test-cases/core/e2e/restructure/";
-    private static final Path PROJECT_TEST_RESOURCES_ROOT = Path.of("core/src/test/resources");
+    private static final Path PROJECT_TEST_RESOURCES_ROOT = Path.of("src/test/resources");
     private static final URL FIXTURE_RESOURCES_ROOT_DIR =
             TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
     private static final Path FIXTURES_ROOT = resolveFixturesRoot();
@@ -49,10 +49,12 @@ class SourceProcessorE2EFixtureTest {
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("fixtureInputFiles")
-    void processFixtureInputFile_matchesExpectedAndCompileAfter(Path fixtureInputFile, Path expectedSourceFile)
+    void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path sourceFile)
             throws Exception {
-        Path fixtureScenario = fixtureInputFile.getParent().getParent();
-        String scenarioName = fixtureScenario.getFileName().toString();
+        Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
+        Path fixtureInputFile = resolveInput(fixtureScenario).resolve(sourceFile);
+        Path expectedSourceFile = resolveExpected(fixtureScenario).resolve(sourceFile);
+        String scenarioName = scenarioDir.toString();
 
         Path workingScenarioRoot =
                 temporaryDirectory.resolve(WORKING_DIRECTORY_NAME).resolve(scenarioName);
@@ -109,11 +111,12 @@ class SourceProcessorE2EFixtureTest {
 
         fixtureInputFiles().forEach(fixture -> {
             Object[] argumentValues = fixture.get();
-            Path fixtureInputFile = (Path) argumentValues[0];
-            Path expectedSourceFile = (Path) argumentValues[1];
-            Path projectExpectedSourceFile = resolveProjectExpectedSourceFile(expectedSourceFile);
-            Path fixtureScenario = fixtureInputFile.getParent().getParent();
-            String scenarioName = fixtureScenario.getFileName().toString();
+            Path scenarioDir = (Path) argumentValues[0];
+            Path sourceFile = (Path) argumentValues[1];
+            Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
+            Path fixtureInputFile = resolveInput(fixtureScenario).resolve(sourceFile);
+            Path projectExpectedSourceFile = resolveProjectExpectedSourceFile(scenarioDir, sourceFile);
+            String scenarioName = scenarioDir.toString();
 
             Path workingScenarioRoot = regenerateWorkspace.resolve(scenarioName);
             Path workingInputFile = copyInputJavaFile(fixtureInputFile, workingScenarioRoot);
@@ -139,9 +142,9 @@ class SourceProcessorE2EFixtureTest {
         return SourceFilesHandler.findJavaFiles(FIXTURES_ROOT, List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())
                 .sorted()
                 .map(fixtureInputFile -> {
-                    Path fixtureScenario = fixtureInputFile.getParent().getParent();
-                    Path expectedSourceFile = resolveExpected(fixtureScenario).resolve(fixtureInputFile.getFileName());
-                    return Arguments.of(fixtureInputFile, expectedSourceFile);
+                    Path scenarioDir = fixtureInputFile.getParent().getParent().getFileName();
+                    Path sourceFile = fixtureInputFile.getFileName();
+                    return Arguments.of(scenarioDir, sourceFile);
                 });
     }
 
@@ -201,8 +204,15 @@ class SourceProcessorE2EFixtureTest {
         return scenario.resolve(EXPECTED_DIRECTORY);
     }
 
-    private static Path resolveProjectExpectedSourceFile(Path expectedSourceFileFromClasspath) {
-        Path expectedRelativePath = FIXTURES_ROOT.relativize(expectedSourceFileFromClasspath);
-        return PROJECT_TEST_RESOURCES_ROOT.resolve(FIXTURES_RESOURCE_IN_PROJECT).resolve(expectedRelativePath);
+    private static Path resolveProjectExpectedSourceFile(Path scenarioDir, Path sourceFile) {
+        return PROJECT_TEST_RESOURCES_ROOT
+                .resolve(FIXTURES_RESOURCE_IN_PROJECT)
+                .resolve(scenarioDir)
+                .resolve(EXPECTED_DIRECTORY)
+                .resolve(sourceFile);
+    }
+
+    private static Path resolveInput(Path scenario) {
+        return scenario.resolve(INPUT_DIRECTORY);
     }
 }


### PR DESCRIPTION
### Motivation
- Address a review comment pointing out unnecessary materialization of the fixtures stream and a duplicate traversal by processing fixtures in a single pass. 
- Keep the utility test behavior unchanged while simplifying control flow and improving failure diagnostics.

### Description
- Rewrote `regenerateExpectedFixtures_whenRun_overwritesExpectedSources()` to use `fixtureInputFiles().forEach(...)` so processing, file overwrite, and existence assertion happen in a single stream pass in `core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java`.
- Removed intermediate `List<Arguments>` collection and the separate second loop that asserted regenerated files.
- Added local `try/catch (IOException)` inside the lambda and rethrow as `IllegalStateException` to surface which expected fixture failed to regenerate.
- Added necessary imports for `StandardCopyOption`, `@Test`, and `@Disabled` used by the test.

### Testing
- Ran `mvn -pl core -Dtest=SourceProcessorE2EFixtureTest test`, but the run could not complete because Maven failed to resolve `org.mockito:mockito-bom:5.21.0` from Central due to a `Network is unreachable` error, so the test execution could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dc091d55883259709fcac1617ddc7)