### PR TITLE
Exclude static compile-time constant fields from declaration dependency edges and add detection util

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractReferencedFieldsDeclarationDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractReferencedFieldsDeclarationDependencyProvider.java
@@ -24,6 +24,9 @@ abstract class AbstractReferencedFieldsDeclarationDependencyProvider implements 
                         DeclaringTypeFieldReferenceUtils.findProviderFieldsRequiredByDependentMember(
                                         dependentMember, ctElement)
                                 .stream()
+                                .filter(providerMember ->
+                                        !InitializationOrderDependencyUtils.isStaticCompileTimeConstantVariable(
+                                                providerMember))
                                 .map(providerMember -> new MemberDependencyArc(
                                         providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
                                 .collect(Collectors.toUnmodifiableSet()))

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/ExplicitDeclaringTypeInitializerFieldDependencyProvider.java
@@ -3,13 +3,10 @@ package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireDeclaringType;
 
 import lombok.NonNull;
-import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldAccess;
-import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
-import spoon.reflect.declaration.ModifierKind;
 
 /**
  * Provides declaration dependencies created by explicit {@code <DeclaringType>.<field>} references in static field
@@ -20,7 +17,8 @@ final class ExplicitDeclaringTypeInitializerFieldDependencyProvider
 
     @Override
     protected boolean isSupportedReferencedField(@NonNull CtField<?> referencedField) {
-        return isStaticField(referencedField) && !isCompileTimeConstantVariable(referencedField);
+        return isStaticField(referencedField)
+                && !InitializationOrderDependencyUtils.isStaticCompileTimeConstantVariable(referencedField);
     }
 
     @Override
@@ -37,21 +35,6 @@ final class ExplicitDeclaringTypeInitializerFieldDependencyProvider
                 referencedField,
                 (fieldAccess, ignoredDeclaringType) ->
                         isExplicitDeclaringTypeQualifiedAccess(fieldAccess, referrerDeclaringType));
-    }
-
-    private static boolean isCompileTimeConstantVariable(CtField<?> field) {
-        if (!field.getModifiers().contains(ModifierKind.FINAL)) {
-            return false;
-        }
-
-        CtExpression<?> defaultExpression = field.getDefaultExpression();
-        if (defaultExpression == null) {
-            return false;
-        }
-
-        String typeQualifiedName = field.getType().getQualifiedName();
-        boolean isPrimitiveOrString = field.getType().isPrimitive() || "java.lang.String".equals(typeQualifiedName);
-        return isPrimitiveOrString && defaultExpression.partiallyEvaluate() instanceof CtLiteral<?>;
     }
 
     @SuppressWarnings("PMD.CompareObjectsWithEquals")

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/InitializationOrderDependencyUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/InitializationOrderDependencyUtils.java
@@ -11,6 +11,8 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Value;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtAnonymousExecutable;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -46,6 +48,25 @@ final class InitializationOrderDependencyUtils {
 
     static boolean isBlankFinalField(@NonNull CtField<?> field) {
         return field.getModifiers().contains(ModifierKind.FINAL) && field.getDefaultExpression() == null;
+    }
+
+    static boolean isStaticCompileTimeConstantVariable(@NonNull CtField<?> field) {
+        if (!field.getModifiers().contains(ModifierKind.STATIC)) {
+            return false;
+        }
+
+        if (!field.getModifiers().contains(ModifierKind.FINAL)) {
+            return false;
+        }
+
+        CtExpression<?> defaultExpression = field.getDefaultExpression();
+        if (defaultExpression == null) {
+            return false;
+        }
+
+        String typeQualifiedName = field.getType().getQualifiedName();
+        boolean isPrimitiveOrString = field.getType().isPrimitive() || "java.lang.String".equals(typeQualifiedName);
+        return isPrimitiveOrString && defaultExpression.partiallyEvaluate() instanceof CtLiteral<?>;
     }
 
     /**

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -69,6 +69,36 @@ class MemberDependencyGraphBuilderTest {
         assertThat(directProviders).containsExactly(Constants.BRAVO_FIELD_MEMBER);
     }
 
+
+    @Test
+    void buildDependencyGraph_fieldInitializerReferencesCompileTimeConstant_constantExcludedFromDependencies() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.COMPILE_TIME_CONSTANT_EXCLUSION_ALPHA_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).containsExactly(Constants.COMPILE_TIME_CONSTANT_EXCLUSION_BRAVO_FIELD_MEMBER);
+    }
+    @Test
+    void buildDependencyGraph_instanceFinalLiteralField_keepsDeclarationDependencyEdge() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph =
+                MemberDependencyGraphBuilder.buildDependencyGraph(Constants.FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.INSTANCE_FINAL_LITERAL_ALPHA_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders).containsExactly(Constants.INSTANCE_FINAL_LITERAL_BRAVO_FIELD_MEMBER);
+    }
+
     @Test
     void buildDependencyGraph_explicitThisForwardReference_preservesSourceDeclarationOrder() {
         // Given
@@ -299,6 +329,22 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
+    void buildDependencyGraph_initializerBlockReferencesCompileTimeConstant_constantExcludedFromDependencies() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph =
+                MemberDependencyGraphBuilder.buildDependencyGraph(Constants.INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_STATIC_INITIALIZER_BLOCK_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders)
+                .containsExactly(Constants.INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_B_PROVIDER_FIELD_MEMBER);
+    }
+
+    @Test
     void buildDependencyGraph_initializerBlockReferencesEarlierField_declarationDependencyEdgeCreated() {
         // Given
         MemberDependencyGraph memberDependencyGraph =
@@ -416,6 +462,40 @@ class MemberDependencyGraphBuilderTest {
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(FIELD_INITIALIZER_MEMBERS, "BRAVO");
         private static final CtTypeMember ALPHA_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(FIELD_INITIALIZER_MEMBERS, "ALPHA");
+
+        private static final URL FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerCompileTimeConstantExclusionFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS = buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember COMPILE_TIME_CONSTANT_EXCLUSION_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS, "BRAVO");
+        private static final CtTypeMember COMPILE_TIME_CONSTANT_EXCLUSION_ALPHA_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS, "ALPHA");
+
+        private static final URL FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerInstanceFinalLiteralFixture.java");
+        private static final CtType<?> FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup> FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_MEMBERS =
+                buildTypeMember2NaturalGroup(
+                        FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember INSTANCE_FINAL_LITERAL_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_MEMBERS, "BRAVO");
+        private static final CtTypeMember INSTANCE_FINAL_LITERAL_ALPHA_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_INSTANCE_FINAL_LITERAL_MEMBERS, "ALPHA");
 
         private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(
@@ -712,6 +792,24 @@ class MemberDependencyGraphBuilderTest {
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(INITIALIZER_BLOCK_MEMBERS, "ALPHA");
         private static final CtTypeMember STATIC_INITIALIZER_BLOCK_MEMBER =
                 requireUniqueInitializerBlockMember(INITIALIZER_BLOCK_FIXTURE_MAIN_TYPE, true);
+
+        private static final URL INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockCompileTimeConstantExclusionFixture.java");
+        private static final CtType<?> INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_MAIN_TYPE =
+                SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                        INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS = buildTypeMember2NaturalGroup(
+                        INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_MAIN_TYPE,
+                        MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_B_PROVIDER_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_MEMBERS, "B_PROVIDER");
+        private static final CtTypeMember
+                INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_STATIC_INITIALIZER_BLOCK_MEMBER =
+                        requireUniqueInitializerBlockMember(
+                                INITIALIZER_BLOCK_COMPILE_TIME_CONSTANT_EXCLUSION_FIXTURE_MAIN_TYPE, true);
 
         private static final URL ENUM_CONSTANT_INITIALIZER_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/config.yml
@@ -1,0 +1,25 @@
+formatting:
+  fix-imports: false
+  formatter-style: PALANTIR
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  sort-keys: [ preserve ]
+type-members-ordering:
+  - name: Initializers then fields
+    includes: ~.*
+    sort-keys: preserve
+    groups:
+      - name: Initializers
+        separator: none
+        sort-keys: preserve
+        includes: initializer
+      - name: Fields
+        separator: none
+        sort-keys: alpha
+        includes: field

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/expected/GeneralCompileTimeConstantInitializerSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/expected/GeneralCompileTimeConstantInitializerSample.java
@@ -1,0 +1,15 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class GeneralCompileTimeConstantInitializerSample {
+    static final int bProvider = Integer.parseInt("1");
+    static final int aDependent = bProvider + GeneralCompileTimeConstantInitializerSample.zConstant;
+    static final int cIndependent = 2;
+    static final int zConstant = 7;
+
+    public static void main(String[] args) {
+        if (aDependent != 8 || bProvider != 1 || cIndependent != 2 || zConstant != 7) {
+            throw new IllegalStateException("Unexpected field values: aDependent=" + aDependent + ", bProvider="
+                    + bProvider + ", cIndependent=" + cIndependent + ", zConstant=" + zConstant);
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/expected/InitializerBlockStaticConstantExclusionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/expected/InitializerBlockStaticConstantExclusionSample.java
@@ -1,0 +1,18 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class InitializerBlockStaticConstantExclusionSample {
+    static int bProvider = Integer.parseInt("1");
+    static {
+        sink = InitializerBlockStaticConstantExclusionSample.bProvider
+                + InitializerBlockStaticConstantExclusionSample.zConstant;
+    }
+    static int sink;
+    static final int zConstant = 7;
+
+    public static void main(String[] args) {
+        if (bProvider != 1 || zConstant != 7 || sink != 8) {
+            throw new IllegalStateException(
+                    "Unexpected values: bProvider=" + bProvider + ", zConstant=" + zConstant + ", sink=" + sink);
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/GeneralCompileTimeConstantInitializerSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/GeneralCompileTimeConstantInitializerSample.java
@@ -1,0 +1,16 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class GeneralCompileTimeConstantInitializerSample {
+    static final int zConstant = 7;
+    static final int cIndependent = 2;
+    static final int bProvider = Integer.parseInt("1");
+    static final int aDependent = bProvider + GeneralCompileTimeConstantInitializerSample.zConstant;
+
+    public static void main(String[] args) {
+        if (aDependent != 8 || bProvider != 1 || cIndependent != 2 || zConstant != 7) {
+            throw new IllegalStateException(
+                    "Unexpected field values: aDependent=" + aDependent + ", bProvider=" + bProvider
+                            + ", cIndependent=" + cIndependent + ", zConstant=" + zConstant);
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/InitializerBlockStaticConstantExclusionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/InitializerBlockStaticConstantExclusionSample.java
@@ -1,0 +1,20 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class InitializerBlockStaticConstantExclusionSample {
+    static final int zConstant = 7;
+    static int bProvider = Integer.parseInt("1");
+
+    static {
+        sink = InitializerBlockStaticConstantExclusionSample.bProvider
+                + InitializerBlockStaticConstantExclusionSample.zConstant;
+    }
+
+    static int sink;
+
+    public static void main(String[] args) {
+        if (bProvider != 1 || zConstant != 7 || sink != 8) {
+            throw new IllegalStateException(
+                    "Unexpected values: bProvider=" + bProvider + ", zConstant=" + zConstant + ", sink=" + sink);
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerBuilderFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerBuilderFixture.java
@@ -2,7 +2,7 @@ package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
 public class FieldInitializerBuilderFixture {
 
-    private static final int BRAVO = 1;
+    private static final int BRAVO = Integer.parseInt("1");
 
     private static final int ALPHA = BRAVO + 1;
 }

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerCompileTimeConstantExclusionFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerCompileTimeConstantExclusionFixture.java
@@ -1,0 +1,9 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
+
+public class FieldInitializerCompileTimeConstantExclusionFixture {
+
+    private static final int BRAVO = Integer.parseInt("1");
+    private static final int CONSTANT = 7;
+
+    private static final int ALPHA = BRAVO + CONSTANT;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerInstanceFinalLiteralFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/FieldInitializerInstanceFinalLiteralFixture.java
@@ -1,0 +1,8 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
+
+public class FieldInitializerInstanceFinalLiteralFixture {
+
+    private final int BRAVO = 1;
+
+    private final int ALPHA = BRAVO + 1;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockBuilderFixture.java
@@ -2,7 +2,7 @@ package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
 public class InitializerBlockBuilderFixture {
 
-    private static final int ALPHA = 1;
+    private static int ALPHA = 1;
 
     static {
         int localCopy = ALPHA;

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockCompileTimeConstantExclusionFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/InitializerBlockCompileTimeConstantExclusionFixture.java
@@ -1,0 +1,12 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
+
+public class InitializerBlockCompileTimeConstantExclusionFixture {
+
+    private static final int Z_CONSTANT = 7;
+    private static int B_PROVIDER = Integer.parseInt("1");
+    private static int SINK;
+
+    static {
+        SINK = B_PROVIDER + InitializerBlockCompileTimeConstantExclusionFixture.Z_CONSTANT;
+    }
+}


### PR DESCRIPTION
### Motivation

- Avoid creating declaration-order dependency edges on static compile-time constant fields because they are inlined by the compiler and should not affect initialization ordering decisions.

### Description

- Add `InitializationOrderDependencyUtils.isStaticCompileTimeConstantVariable` to detect `static final` fields with a primitive or `String` literal initializer that partially evaluates to a `CtLiteral`.
- Exclude static compile-time constant fields from declaration dependency providers by filtering provider members in `AbstractReferencedFieldsDeclarationDependencyProvider.findDirectProviderEdges`.
- Replace the previous local compile-time-constant check in `ExplicitDeclaringTypeInitializerFieldDependencyProvider` with a call to the new utility and remove the duplicated helper implementation.
- Add tests and fixtures exercising exclusion of static compile-time constants from dependency edges and a case ensuring instance final literal fields still keep declaration dependencies, plus e2e fixtures for restructuring behavior.

### Testing

- Ran unit tests in `MemberDependencyGraphBuilderTest`, including `buildDependencyGraph_fieldInitializerReferencesCompileTimeConstant_constantExcludedFromDependencies`, `buildDependencyGraph_instanceFinalLiteralField_keepsDeclarationDependencyEdge`, and `buildDependencyGraph_initializerBlockReferencesCompileTimeConstant_constantExcludedFromDependencies`, and they all passed.
- Existing dependency-graph unit tests were executed and continued to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab0e29371c83259ffcc0a35f0d5da8)