### PR TITLE
Add Codex Maven settings and document build override

### DIFF
--- a/.mvn/settings-codex.xml
+++ b/.mvn/settings-codex.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <!--
+      Codex runtime Maven settings.
+      Enables proxy required by this container and keeps GitHub Packages credentials via env.
+    -->
+    <servers>
+        <server>
+            <id>github</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+
+    <proxies>
+        <proxy>
+            <id>default-http-proxy</id>
+            <active>true</active>
+            <protocol>http</protocol>
+            <host>proxy</host>
+            <port>8080</port>
+            <nonProxyHosts>localhost|127.0.0.1|::1|browser</nonProxyHosts>
+        </proxy>
+        <proxy>
+            <id>default-https-proxy</id>
+            <active>true</active>
+            <protocol>https</protocol>
+            <host>proxy</host>
+            <port>8080</port>
+            <nonProxyHosts>localhost|127.0.0.1|::1|browser</nonProxyHosts>
+        </proxy>
+    </proxies>
+</settings>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -16,23 +16,4 @@
             <password>${env.GITHUB_TOKEN}</password>
         </server>
     </servers>
-
-    <proxies>
-        <proxy>
-            <id>default-http-proxy</id>
-            <active>${env.CODEX_PROXY_ACTIVE}</active>
-            <protocol>http</protocol>
-            <host>proxy</host>
-            <port>8080</port>
-            <nonProxyHosts>localhost|127.0.0.1|::1|browser</nonProxyHosts>
-        </proxy>
-        <proxy>
-            <id>default-https-proxy</id>
-            <active>${env.CODEX_PROXY_ACTIVE}</active>
-            <protocol>https</protocol>
-            <host>proxy</host>
-            <port>8080</port>
-            <nonProxyHosts>localhost|127.0.0.1|::1|browser</nonProxyHosts>
-        </proxy>
-    </proxies>
 </settings>

--- a/README.md
+++ b/README.md
@@ -23,3 +23,28 @@ It parses Java source, resolves grouping/sorting rules, applies dependency-safe 
   - handle recursion/cycles safely and conservatively.
 
 Details and implementation notes are tracked in [docs/TODO.md](docs/TODO.md).
+
+## Build
+
+Default (local / IDE / CI that relies on project config):
+
+```bash
+mvn -B -ntp verify
+```
+
+This uses `.mvn/maven.config`, which points to `.mvn/settings.xml`.
+
+Codex/runtime mode (proxy-enabled settings override via environment variable):
+
+```bash
+export MAVEN_ARGS="--settings .mvn/settings-codex.xml"
+mvn -B -ntp verify
+```
+
+Recommended Codex env var value:
+
+```bash
+MAVEN_ARGS=--settings\ .mvn/settings-codex.xml
+```
+
+So local environments keep using `.mvn/settings.xml`, while Codex overrides settings through `MAVEN_ARGS` only.


### PR DESCRIPTION
### Motivation
- Provide a separate Maven settings file for the Codex/runtime environment that enables a container proxy and reads GitHub Packages credentials from environment variables. 
- Keep the default project-local settings free of an always-on proxy so local/IDE/CI builds are unaffected and secrets are not stored in VCS. 
- Document how to run the build using the Codex settings override. 

### Description
- Add `.mvn/settings-codex.xml` containing a `github` server entry referencing `${env.GITHUB_ACTOR}` and `${env.GITHUB_TOKEN}` and enabled HTTP/HTTPS proxy entries for the Codex runtime. 
- Remove proxy entries from `.mvn/settings.xml` so the default settings no longer enable the proxy while preserving the `github` server credentials via environment variables. 
- Update `README.md` with a `Build` section that documents the default `mvn -B -ntp verify` invocation and how to run the build in Codex/runtime mode using `--settings .mvn/settings-codex.xml` and the `MAVEN_ARGS` recommendation. 

### Testing
- No automated tests were modified or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad719d22e4832585a11765ea364449)