### PR TITLE
Add e2e test for alphabetical field ordering with multi-level dependencies

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonTypeMemberUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonTypeMemberUtils.java
@@ -19,6 +19,7 @@ import spoon.reflect.reference.CtTypeReference;
 
 @UtilityClass
 public class SpoonTypeMemberUtils {
+
     @NonNull
     public static CtTypeReference<?> normalizeTypeReferenceByErasureAndBoxing(
             @NonNull CtTypeReference<?> typeReference) {

--- a/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/config.yml
@@ -1,0 +1,21 @@
+formatting:
+  fix-imports: false
+  formatter-style: PALANTIR
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 2
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  ordering-rules: [ preserve ]
+type-members-ordering:
+  - name: Field alpha ordering with dependency graph
+    includes: ~.*
+    ordering-rules: preserve
+    groups:
+      - name: Fields
+        separator: new-line
+        ordering-rules: alpha
+        includes: field

--- a/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/expected/FieldAlphaOrderingMultiLevelDependenciesSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/expected/FieldAlphaOrderingMultiLevelDependenciesSample.java
@@ -1,0 +1,28 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class FieldAlphaOrderingMultiLevelDependenciesSample {
+
+    private static int C1 = 10;
+    private static int C2 = 20;
+    private static int C3 = 30;
+    private static int B1 = C3 + C2 + C1 + 1;
+    private static int B2 = C3 + C2 + C1 + 2;
+    private static int B3 = C3 + C2 + C1;
+    private static int A1 = C3 + C2 + C1 + B3 + B2 + B1 + 1;
+    private static int A2 = C3 + C2 + C1 + B3 + B2 + B1 + 2;
+    private static int A3 = C3 + C2 + C1 + B3 + B2 + B1;
+
+    public static void main(String[] args) {
+        if (C3 != 30 || C2 != 20 || C1 != 10) {
+            throw new IllegalStateException("Unexpected C-level values: C3=" + C3 + ", C2=" + C2 + ", C1=" + C1);
+        }
+
+        if (B3 != 60 || B2 != 62 || B1 != 61) {
+            throw new IllegalStateException("Unexpected B-level values: B3=" + B3 + ", B2=" + B2 + ", B1=" + B1);
+        }
+
+        if (A3 != 243 || A2 != 245 || A1 != 244) {
+            throw new IllegalStateException("Unexpected A-level values: A3=" + A3 + ", A2=" + A2 + ", A1=" + A1);
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/input/FieldAlphaOrderingMultiLevelDependenciesSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/input/FieldAlphaOrderingMultiLevelDependenciesSample.java
@@ -1,0 +1,29 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class FieldAlphaOrderingMultiLevelDependenciesSample {
+    private static int C3 = 30;
+    private static int C2 = 20;
+    private static int C1 = 10;
+
+    private static int B3 = C3 + C2 + C1;
+    private static int B2 = C3 + C2 + C1 + 2;
+    private static int B1 = C3 + C2 + C1 + 1;
+
+    private static int A3 = C3 + C2 + C1 + B3 + B2 + B1;
+    private static int A2 = C3 + C2 + C1 + B3 + B2 + B1 + 2;
+    private static int A1 = C3 + C2 + C1 + B3 + B2 + B1 + 1;
+
+    public static void main(String[] args) {
+        if (C3 != 30 || C2 != 20 || C1 != 10) {
+            throw new IllegalStateException("Unexpected C-level values: C3=" + C3 + ", C2=" + C2 + ", C1=" + C1);
+        }
+
+        if (B3 != 60 || B2 != 62 || B1 != 61) {
+            throw new IllegalStateException("Unexpected B-level values: B3=" + B3 + ", B2=" + B2 + ", B1=" + B1);
+        }
+
+        if (A3 != 243 || A2 != 245 || A1 != 244) {
+            throw new IllegalStateException("Unexpected A-level values: A3=" + A3 + ", A2=" + A2 + ", A1=" + A1);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Add a targeted end-to-end test to validate that field alphabetical ordering is applied while respecting multi-level dependency expressions between fields.

### Description
- Add a new test case directory `core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies` containing `config.yml`, `input/FieldAlphaOrderingMultiLevelDependenciesSample.java`, and `expected/FieldAlphaOrderingMultiLevelDependenciesSample.java`.
- The test checks that fields are reordered to alphabetical order (`C1,C2,C3,B1,B2,B3,A1,A2,A3`) while preserving computed values that depend on other fields across multiple levels.

### Testing
- Executed the project's e2e restructure test for this case using the existing test runner and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aeff329a748325ad7c198782d024fc)