### PR TITLE
Make VISIBILITY_DESC the default and correct visibility comparator behavior

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/ComparatorUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/ComparatorUtils.java
@@ -134,10 +134,10 @@ class ComparatorUtils {
             case ALPHA ->
                 Comparator.comparingInt(SortableTypeMember.OrderingKey::getAlphaSortingRank)
                         .thenComparing(SortableTypeMember.OrderingKey::getAlphaKey);
-            case VISIBILITY_ASC -> Comparator.comparingInt(SortableTypeMember.OrderingKey::getVisibilityRank);
-            case VISIBILITY_DESC ->
-                buildOrderingComparatorForOrderingRule(OrderingRule.VISIBILITY_ASC)
+            case VISIBILITY_ASC ->
+                Comparator.comparingInt(SortableTypeMember.OrderingKey::getVisibilityRank)
                         .reversed();
+            case VISIBILITY_DESC -> Comparator.comparingInt(SortableTypeMember.OrderingKey::getVisibilityRank);
         };
     }
 

--- a/core/src/main/resources/default-config.yml
+++ b/core/src/main/resources/default-config.yml
@@ -15,7 +15,7 @@ top-level-types-ordering:
     - interface
     - enum
     - annotation
-  ordering-rules: [ visibility-asc, alpha ]
+  ordering-rules: [ visibility-desc, alpha ]
 
 type-members-ordering:
   - name: Test Classes
@@ -28,16 +28,16 @@ type-members-ordering:
     groups:
       - name: JUnit Fields
         separator: new-line
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: field
         groups:
           - name: JUnit Constants
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: [ static, final ]
           - name: JUnit Static fields
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: static
 
       - name: JUnit Methods
@@ -87,7 +87,7 @@ type-members-ordering:
       - '@Embeddable'
       - '@ConfigurationProperties'
       - '@Document'
-    ordering-rules: [ visibility-asc, alpha ]
+    ordering-rules: [ visibility-desc, alpha ]
     groups:
       - name: Serializable UID
         separator: new-line
@@ -96,12 +96,12 @@ type-members-ordering:
 
       - name: Fields
         separator: new-line
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: field
         groups:
           - name: Constants
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: [ static, final ]
             groups:
               - name: Public Constants
@@ -123,12 +123,12 @@ type-members-ordering:
 
           - name: Static Fields
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: static
 
           - name: Final Instance Fields
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: final
 
       - name: Static Initializer Blocks
@@ -138,7 +138,7 @@ type-members-ordering:
 
       - name: Static Methods
         separator: none
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: [ static, method ]
 
       - name: Instance Initializer Blocks
@@ -149,18 +149,18 @@ type-members-ordering:
 
       - name: Constructors
         separator: none
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: constructor
 
       - name: Accessor Methods
         separator: none
         keepAccessorsTogether: true
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: [ method, ~^(get|set|is|has).+$ ]
 
       - name: Instance Methods
         separator: none
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: [ method ]
         excludes:
           - [ method, =toString ]
@@ -194,17 +194,17 @@ type-members-ordering:
 
       - name: Fields
         separator: new-line
-        ordering-rules: [ visibility-asc, alpha ]
+        ordering-rules: [ visibility-desc, alpha ]
         includes: field
         groups:
           - name: Static fields
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: static
             groups:
               - name: Static final fields
                 separator: new-line
-                ordering-rules: [ visibility-asc, alpha ]
+                ordering-rules: [ visibility-desc, alpha ]
                 includes: final
                 groups:
                   - name: serialVersionUID
@@ -219,7 +219,7 @@ type-members-ordering:
 
           - name: Instance final fields
             separator: new-line
-            ordering-rules: [ visibility-asc, alpha ]
+            ordering-rules: [ visibility-desc, alpha ]
             includes: final
 
       - name: Initializers

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/JHarmonizerConfigLoaderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/JHarmonizerConfigLoaderTest.java
@@ -91,7 +91,7 @@ class JHarmonizerConfigLoaderTest {
         topLevelTypesOrdering.getTopLevelTypeSelectors().forEach(entry -> assertThat(entry.getTypeKinds())
                 .isNotEmpty());
         assertThat(topLevelTypesOrdering.getOrderingRules())
-                .containsExactly(JHarmonizerOrderingRule.VISIBILITY_ASC, JHarmonizerOrderingRule.ALPHA);
+                .containsExactly(JHarmonizerOrderingRule.VISIBILITY_DESC, JHarmonizerOrderingRule.ALPHA);
         assertThat(jharmonizerConfig.getFormatting().isFixImports()).isTrue();
         assertThat(jharmonizerConfig.getFormatting().getFormatterStyle()).isEqualTo(FormatterStyle.PALANTIR);
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererOrderingRulesTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererOrderingRulesTest.java
@@ -148,11 +148,11 @@ class GroupMembersOrdererOrderingRulesTest {
         // Then
         assertThat(orderedBlocks.getFirst().getTypeMembers())
                 .containsExactly(
-                        publicFieldFirstMember,
-                        publicFieldSecondMember,
-                        protectedFieldMember,
+                        privateFieldMember,
                         packagePrivateFieldMember,
-                        privateFieldMember);
+                        protectedFieldMember,
+                        publicFieldFirstMember,
+                        publicFieldSecondMember);
     }
 
     @Test
@@ -187,11 +187,11 @@ class GroupMembersOrdererOrderingRulesTest {
         // Then
         assertThat(orderedBlocks.getFirst().getTypeMembers())
                 .containsExactly(
-                        privateFieldMember,
-                        packagePrivateFieldMember,
-                        protectedFieldMember,
                         publicFieldFirstMember,
-                        publicFieldSecondMember);
+                        publicFieldSecondMember,
+                        protectedFieldMember,
+                        packagePrivateFieldMember,
+                        privateFieldMember);
     }
 
     @Test

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-jharmonizer-config.json
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-jharmonizer-config.json
@@ -27,7 +27,7 @@
         "separator" : "NEW_LINE",
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "name" : "JUnit Static fields",
         "includes" : [ [ "static" ] ],
@@ -35,9 +35,9 @@
         "separator" : "NEW_LINE",
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       } ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "JUnit Methods",
       "includes" : [ [ "method" ] ],
@@ -147,7 +147,7 @@
           "memberSubGroups" : [ ],
           "orderingRules" : [ "ALPHA" ]
         } ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "name" : "Static Fields",
         "includes" : [ [ "static" ] ],
@@ -155,7 +155,7 @@
         "separator" : "NEW_LINE",
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "name" : "Final Instance Fields",
         "includes" : [ [ "final" ] ],
@@ -163,9 +163,9 @@
         "separator" : "NEW_LINE",
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       } ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "Static Initializer Blocks",
       "includes" : [ [ "static", "initializer" ] ],
@@ -181,7 +181,7 @@
       "separator" : "NONE",
       "keepAccessorsTogether" : null,
       "memberSubGroups" : [ ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "Instance Initializer Blocks",
       "includes" : [ [ "initializer" ] ],
@@ -197,7 +197,7 @@
       "separator" : "NONE",
       "keepAccessorsTogether" : null,
       "memberSubGroups" : [ ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "Accessor Methods",
       "includes" : [ [ "method", "~^(get|set|is|has).+$" ] ],
@@ -205,7 +205,7 @@
       "separator" : "NONE",
       "keepAccessorsTogether" : true,
       "memberSubGroups" : [ ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "Instance Methods",
       "includes" : [ [ "method" ] ],
@@ -213,7 +213,7 @@
       "separator" : "NONE",
       "keepAccessorsTogether" : null,
       "memberSubGroups" : [ ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "Basic Object Methods",
       "includes" : [ [ "method", "=toString" ], [ "method", "=clone" ], [ "method", "=equals" ], [ "method", "=hashCode" ] ],
@@ -223,7 +223,7 @@
       "memberSubGroups" : [ ],
       "orderingRules" : [ "PRESERVE" ]
     } ],
-    "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+    "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
   }, {
     "name" : "Default Rule",
     "includes" : [ [ "~.*" ] ],
@@ -281,9 +281,9 @@
             "memberSubGroups" : [ ],
             "orderingRules" : [ "PRESERVE" ]
           } ],
-          "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+          "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
         } ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "name" : "Instance final fields",
         "includes" : [ [ "final" ] ],
@@ -291,9 +291,9 @@
         "separator" : "NEW_LINE",
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       } ],
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "name" : "Initializers",
       "includes" : [ [ "initializer" ] ],
@@ -659,7 +659,7 @@
   } ],
   "topLevelTypesOrdering" : {
     "mainTypeFirst" : true,
-    "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ],
+    "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ],
     "topLevelTypeSelectors" : [ {
       "typeKinds" : [ "CLASS", "RECORD" ]
     }, {

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-unified-config.json
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-unified-config.json
@@ -29,7 +29,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "groupName" : "JUnit Static fields",
         "keepAccessorsTogether" : null,
@@ -45,7 +45,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -58,7 +58,7 @@
         } ]
       },
       "separator" : "NEW_LINE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "JUnit Methods",
       "keepAccessorsTogether" : null,
@@ -332,7 +332,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "groupName" : "Static Fields",
         "keepAccessorsTogether" : null,
@@ -348,7 +348,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "groupName" : "Final Instance Fields",
         "keepAccessorsTogether" : null,
@@ -364,7 +364,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -377,7 +377,7 @@
         } ]
       },
       "separator" : "NEW_LINE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "Static Initializer Blocks",
       "keepAccessorsTogether" : null,
@@ -409,7 +409,7 @@
         } ]
       },
       "separator" : "NONE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "Instance Initializer Blocks",
       "keepAccessorsTogether" : null,
@@ -447,7 +447,7 @@
         } ]
       },
       "separator" : "NONE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "Accessor Methods",
       "keepAccessorsTogether" : true,
@@ -466,7 +466,7 @@
         } ]
       },
       "separator" : "NONE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "Instance Methods",
       "keepAccessorsTogether" : null,
@@ -518,7 +518,7 @@
         } ]
       },
       "separator" : "NONE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "Basic Object Methods",
       "keepAccessorsTogether" : null,
@@ -652,7 +652,7 @@
       } ]
     },
     "separator" : "NONE",
-    "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+    "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
   }, {
     "groupName" : "Default Rule",
     "keepAccessorsTogether" : null,
@@ -747,7 +747,7 @@
             } ]
           },
           "separator" : "NEW_LINE",
-          "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+          "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -760,7 +760,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       }, {
         "groupName" : "Instance final fields",
         "keepAccessorsTogether" : null,
@@ -776,7 +776,7 @@
           } ]
         },
         "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -789,7 +789,7 @@
         } ]
       },
       "separator" : "NEW_LINE",
-      "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ]
+      "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
       "groupName" : "Initializers",
       "keepAccessorsTogether" : null,
@@ -1535,7 +1535,7 @@
   } ],
   "topLevelTypesOrdering" : {
     "mainTypeFirst" : true,
-    "orderingRules" : [ "VISIBILITY_ASC", "ALPHA" ],
+    "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ],
     "topLevelTypeSelectors" : [ {
       "typeKinds" : [ "CLASS", "RECORD" ]
     }, {


### PR DESCRIPTION
### Motivation

- Change default ordering to prefer higher-visibility members first by switching default ordering rules from `visibility-asc` to `visibility-desc` in configuration. 
- Fix inconsistent comparator logic that produced the opposite visibility ordering than the rule name indicated.

### Description

- Update `ComparatorUtils.buildOrderingComparatorForOrderingRule` to map `VISIBILITY_ASC` to a reversed visibility-rank comparator and `VISIBILITY_DESC` to the direct visibility-rank comparator so rule names match actual ordering. 
- Change `core/src/main/resources/default-config.yml` to use `visibility-desc` as the default visibility ordering in the top-level and member group configurations. 
- Update tests and expected fixtures to reflect the new default and corrected comparator, including `JHarmonizerConfigLoaderTest`, `GroupMembersOrdererOrderingRulesTest`, and the JSON expectation files under `test-resources`. 

### Testing

- Ran unit tests including `JHarmonizerConfigLoaderTest` and `GroupMembersOrdererOrderingRulesTest` after updating expected outputs. 
- Updated JSON fixture files `expected-default-jharmonizer-config.json` and `expected-default-unified-config.json` to match the new default ordering. 
- All modified unit tests passed locally when running `mvn test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01e16d46083258f7073fe915a0a06)