### PR TITLE
Add E2E fixture: default-config coverage for record/interface/enum/annotation mix

### DIFF
--- a/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/config.yml
@@ -1,0 +1,431 @@
+formatting:
+  fix-imports: true
+  formatter-style: PALANTIR # NONE, AOSP, GOOGLE, PALANTIR
+
+backups-enabled: true
+
+header-line:
+  character: '-'
+  left-padding: 3
+
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class, record ]
+    - interface
+    - enum
+    - annotation
+  ordering-rules: [ visibility-asc, alpha ]
+
+type-members-ordering:
+  - name: Test Classes
+    includes:
+      - [ class, '@~.*Test$' ]
+      - [ class, '@ExtendWith' ]
+      - [ class, '@RunWith' ]
+      - [ class, ~.*Test$ ]
+    ordering-rules: alpha
+    groups:
+      - name: JUnit Fields
+        separator: new-line
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: field
+        groups:
+          - name: JUnit Constants
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: [ static, final ]
+          - name: JUnit Static fields
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: static
+
+      - name: JUnit Methods
+        separator: new-line
+        ordering-rules: alpha
+        includes: method
+        groups:
+          - name: JUnit Setup Methods
+            separator: header
+            ordering-rules: preserve
+            includes:
+              - '@BeforeEach'
+              - '@BeforeAll'
+
+          - name: JUnit Test Methods
+            separator: header
+            ordering-rules: alpha
+            includes: '@Test'
+
+          - name: JUnit Teardown Methods
+            separator: header
+            ordering-rules: preserve
+            includes:
+              - '@AfterEach'
+              - '@AfterAll'
+
+          - name: Utility Methods
+            separator: header
+            includes: static
+            ordering-rules: alpha
+
+      - name: JUnit Test Configuration
+        separator: new-line
+        ordering-rules: alpha
+        includes:
+          - [ static, class, '@TestConfiguration' ]
+
+
+  - name: DTO and Entities
+    includes:
+      - ~.*(Dto|DTO)$
+      - ~.*Entity$
+      - '@Value'
+      - '@Data'
+      - '@Entity'
+      - '@MappedSuperclass'
+      - '@Embeddable'
+      - '@ConfigurationProperties'
+      - '@Document'
+    ordering-rules: [ visibility-asc, alpha ]
+    groups:
+      - name: Serializable UID
+        separator: new-line
+        ordering-rules: preserve
+        includes: [ field, static, final, =serialVersionUID ]
+
+      - name: Fields
+        separator: new-line
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: field
+        groups:
+          - name: Constants
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: [ static, final ]
+            groups:
+              - name: Public Constants
+                separator: new-line
+                ordering-rules: alpha
+                includes: public
+              - name: Protected Constants
+                separator: new-line
+                ordering-rules: alpha
+                includes: protected
+              - name: Package-Private Constants
+                separator: new-line
+                ordering-rules: alpha
+                includes: package-private
+              - name: Private Constants
+                separator: new-line
+                ordering-rules: alpha
+                includes: private
+
+          - name: Static Fields
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: static
+
+          - name: Final Instance Fields
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: final
+
+      - name: Static Initializer Blocks
+        separator: none
+        ordering-rules: preserve
+        includes: [ static, initializer ]
+
+      - name: Static Methods
+        separator: none
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: [ static, method ]
+
+      - name: Instance Initializer Blocks
+        separator: none
+        ordering-rules: preserve
+        includes: [ initializer ]
+        excludes: static
+
+      - name: Constructors
+        separator: none
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: constructor
+
+      - name: Accessor Methods
+        separator: none
+        keepAccessorsTogether: true
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: [ method, ~^(get|set|is|has).+$ ]
+
+      - name: Instance Methods
+        separator: none
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: [ method ]
+        excludes:
+          - [ method, =toString ]
+          - [ method, =equals ]
+          - [ method, =hashCode ]
+          - [ method, =clone ]
+
+      - name: Basic Object Methods
+        ordering-rules: preserve
+        includes:
+          - [ method, =toString ]
+          - [ method, =equals ]
+          - [ method, =hashCode ]
+          - [ method, =clone ]
+
+  - name: Default Rule
+    includes: ~.*
+    ordering-rules: preserve
+    groups:
+      # Record components live in the record header; keep them stable.
+      - name: Record components
+        separator: none
+        ordering-rules: preserve
+        includes: [ record-component ]
+
+      # Enum constants must stay at the top of enum bodies; keep them stable.
+      - name: Enum constants
+        separator: none
+        ordering-rules: preserve
+        includes: [ enum-constant ]
+
+      - name: Fields
+        separator: new-line
+        ordering-rules: [ visibility-asc, alpha ]
+        includes: field
+        groups:
+          - name: Static fields
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: static
+            groups:
+              - name: Static final fields
+                separator: new-line
+                ordering-rules: [ visibility-asc, alpha ]
+                includes: final
+                groups:
+                  - name: serialVersionUID
+                    separator: new-line
+                    ordering-rules: preserve
+                    includes: [ =serialVersionUID ]
+
+                  - name: Logger fields
+                    separator: new-line
+                    ordering-rules: preserve
+                    includes: [ '~(?i)(log|.*logger)$' ]
+
+          - name: Instance final fields
+            separator: new-line
+            ordering-rules: [ visibility-asc, alpha ]
+            includes: final
+
+      - name: Initializers
+        separator: none
+        ordering-rules: preserve
+        includes: [ initializer ]
+        groups:
+          - name: Static initializers
+            separator: none
+            ordering-rules: preserve
+            includes: [ static, initializer ]
+
+          - name: Instance initializers
+            separator: none
+            ordering-rules: preserve
+            includes: [ initializer ]
+            excludes: static
+
+      - name: Methods
+        separator: none
+        ordering-rules: alpha
+        keepAccessorsTogether: true
+        includes: [ method, constructor ]
+        groups:
+          - name: Public
+            separator: none
+            ordering-rules: alpha
+            includes: public
+            groups:
+              - name: Static methods
+                separator: none
+                ordering-rules: alpha
+                includes: [ method, static ]
+
+              - name: Constructors
+                separator: none
+                ordering-rules: alpha
+                includes: constructor
+
+              - name: Instance methods
+                separator: none
+                ordering-rules: alpha
+                includes: method
+
+          - name: Protected
+            separator: none
+            ordering-rules: alpha
+            includes: protected
+            groups:
+              - name: Static methods
+                separator: none
+                ordering-rules: alpha
+                includes: [ method, static ]
+
+              - name: Constructors
+                separator: none
+                ordering-rules: alpha
+                includes: constructor
+
+              - name: Instance methods
+                separator: none
+                ordering-rules: alpha
+                includes: method
+
+          - name: Package-private
+            separator: none
+            ordering-rules: alpha
+            includes: package-private
+            groups:
+              - name: Static methods
+                separator: none
+                ordering-rules: alpha
+                includes: [ method, static ]
+
+              - name: Constructors
+                separator: none
+                ordering-rules: alpha
+                includes: constructor
+
+              - name: Instance methods
+                separator: none
+                ordering-rules: alpha
+                includes: method
+
+          - name: Private
+            separator: none
+            ordering-rules: alpha
+            includes: private
+            groups:
+              - name: Static methods
+                separator: none
+                ordering-rules: alpha
+                includes: [ method, static ]
+
+              - name: Constructors
+                separator: none
+                ordering-rules: alpha
+                includes: constructor
+
+              - name: Instance methods
+                separator: none
+                ordering-rules: alpha
+                includes: method
+
+      - name: Nested types
+        separator: new-line
+        ordering-rules: alpha
+        includes: [ annotation, enum, record, interface, class ]
+        groups:
+          - name: Public
+            separator: new-line
+            ordering-rules: alpha
+            includes: public
+            groups:
+              - name: Annotations
+                separator: new-line
+                ordering-rules: alpha
+                includes: annotation
+              - name: Enums
+                separator: new-line
+                ordering-rules: alpha
+                includes: enum
+              - name: Records
+                separator: new-line
+                ordering-rules: alpha
+                includes: record
+              - name: Interfaces
+                separator: new-line
+                ordering-rules: alpha
+                includes: interface
+              - name: Classes
+                separator: new-line
+                ordering-rules: alpha
+                includes: class
+          - name: Protected
+            separator: new-line
+            ordering-rules: alpha
+            includes: protected
+            groups:
+              - name: Annotations
+                separator: new-line
+                ordering-rules: alpha
+                includes: annotation
+              - name: Enums
+                separator: new-line
+                ordering-rules: alpha
+                includes: enum
+              - name: Records
+                separator: new-line
+                ordering-rules: alpha
+                includes: record
+              - name: Interfaces
+                separator: new-line
+                ordering-rules: alpha
+                includes: interface
+              - name: Classes
+                separator: new-line
+                ordering-rules: alpha
+                includes: class
+          - name: Package-private
+            separator: new-line
+            ordering-rules: alpha
+            includes: package-private
+            groups:
+              - name: Annotations
+                separator: new-line
+                ordering-rules: alpha
+                includes: annotation
+              - name: Enums
+                separator: new-line
+                ordering-rules: alpha
+                includes: enum
+              - name: Records
+                separator: new-line
+                ordering-rules: alpha
+                includes: record
+              - name: Interfaces
+                separator: new-line
+                ordering-rules: alpha
+                includes: interface
+              - name: Classes
+                separator: new-line
+                ordering-rules: alpha
+                includes: class
+          - name: Private
+            separator: new-line
+            ordering-rules: alpha
+            includes: private
+            groups:
+              - name: Annotations
+                separator: new-line
+                ordering-rules: alpha
+                includes: annotation
+              - name: Enums
+                separator: new-line
+                ordering-rules: alpha
+                includes: enum
+              - name: Records
+                separator: new-line
+                ordering-rules: alpha
+                includes: record
+              - name: Interfaces
+                separator: new-line
+                ordering-rules: alpha
+                includes: interface
+              - name: Classes
+                separator: new-line
+                ordering-rules: alpha
+                includes: class

--- a/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/expected/DefaultConfigComplexTypesScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/expected/DefaultConfigComplexTypesScenario.java
@@ -1,0 +1,127 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+interface BetaInterface {
+    private static String zPrivateStatic() {
+        return "zPrivateStatic";
+    }
+
+    static String bStatic() {
+        return "bStatic";
+    }
+
+    default String dDefault() {
+        return "dDefault";
+    }
+
+    private String aPrivate() {
+        return "aPrivate";
+    }
+
+    String cAbstract();
+}
+
+@interface SampleAnno {
+    int zeta() default 7;
+
+    String alpha() default "alpha";
+}
+
+record AlphaRecord(int z, int a) {
+    static String zUtility() {
+        return "zUtility";
+    }
+
+    private static String aPrivateUtility() {
+        return "aPrivateUtility";
+    }
+
+    AlphaRecord {
+        if (z < 0 || a < 0) {
+            throw new IllegalArgumentException("Record components must be non-negative");
+        }
+    }
+
+    public String zDescribe() {
+        return z + ":" + a;
+    }
+
+    private String aInternal() {
+        return "internal-" + zDescribe();
+    }
+}
+
+enum ZetaEnum {
+    GAMMA,
+    ALPHA,
+    BETA;
+
+    private static final String MARKER = "enum";
+
+    private final int code;
+
+    private ZetaEnum() {
+        this.code = ordinal();
+    }
+
+    public static String zUtility() {
+        return MARKER;
+    }
+
+    public int bCode() {
+        return code;
+    }
+
+    private String aLabel() {
+        return name().toLowerCase();
+    }
+}
+
+public class DefaultConfigComplexTypesScenario {
+
+    private enum PrivateEnum {
+        SECOND,
+        FIRST
+    }
+
+    private interface PrivateInterface {
+        String value();
+    }
+
+    private @interface PrivateAnnotation {
+        String name();
+    }
+
+    private record PrivateRecord(String value) {}
+
+    public static void main(String[] args) {
+        AlphaRecord record = new AlphaRecord(2, 1);
+        if (!"2:1".equals(record.zDescribe())) {
+            throw new IllegalStateException("Unexpected record behavior");
+        }
+
+        BetaInterface beta = new BetaInterface() {
+            @Override
+            public String cAbstract() {
+                return "abstract";
+            }
+        };
+
+        if (!"dDefault".equals(beta.dDefault())) {
+            throw new IllegalStateException("Unexpected interface default method behavior");
+        }
+
+        if (ZetaEnum.values()[0] != ZetaEnum.GAMMA
+                || ZetaEnum.values()[1] != ZetaEnum.ALPHA
+                || ZetaEnum.values()[2] != ZetaEnum.BETA) {
+            throw new IllegalStateException("Enum constants order changed");
+        }
+
+        if (!"enum".equals(ZetaEnum.zUtility())) {
+            throw new IllegalStateException("Enum utility method failed");
+        }
+
+        if (PrivateEnum.FIRST.ordinal() != 1 || PrivateEnum.SECOND.ordinal() != 0) {
+            throw new IllegalStateException("Nested enum constants order changed");
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/input/DefaultConfigComplexTypesScenario.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/input/DefaultConfigComplexTypesScenario.java
@@ -1,0 +1,126 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+interface BetaInterface {
+    private static String zPrivateStatic() {
+        return "zPrivateStatic";
+    }
+
+    static String bStatic() {
+        return "bStatic";
+    }
+
+    default String dDefault() {
+        return "dDefault";
+    }
+
+    private String aPrivate() {
+        return "aPrivate";
+    }
+
+    String cAbstract();
+}
+
+@interface SampleAnno {
+    int zeta() default 7;
+
+    String alpha() default "alpha";
+}
+
+record AlphaRecord(int z, int a) {
+    static String zUtility() {
+        return "zUtility";
+    }
+
+    private static String aPrivateUtility() {
+        return "aPrivateUtility";
+    }
+
+    AlphaRecord {
+        if (z < 0 || a < 0) {
+            throw new IllegalArgumentException("Record components must be non-negative");
+        }
+    }
+
+    public String zDescribe() {
+        return z + ":" + a;
+    }
+
+    private String aInternal() {
+        return "internal-" + zDescribe();
+    }
+}
+
+enum ZetaEnum {
+    GAMMA,
+    ALPHA,
+    BETA;
+
+    private final int code;
+
+    private static final String MARKER = "enum";
+
+    private ZetaEnum() {
+        this.code = ordinal();
+    }
+
+    public static String zUtility() {
+        return MARKER;
+    }
+
+    public int bCode() {
+        return code;
+    }
+
+    private String aLabel() {
+        return name().toLowerCase();
+    }
+}
+
+public class DefaultConfigComplexTypesScenario {
+    private enum PrivateEnum {
+        SECOND,
+        FIRST
+    }
+
+    private interface PrivateInterface {
+        String value();
+    }
+
+    private @interface PrivateAnnotation {
+        String name();
+    }
+
+    private record PrivateRecord(String value) {}
+
+    public static void main(String[] args) {
+        AlphaRecord record = new AlphaRecord(2, 1);
+        if (!"2:1".equals(record.zDescribe())) {
+            throw new IllegalStateException("Unexpected record behavior");
+        }
+
+        BetaInterface beta = new BetaInterface() {
+            @Override
+            public String cAbstract() {
+                return "abstract";
+            }
+        };
+
+        if (!"dDefault".equals(beta.dDefault())) {
+            throw new IllegalStateException("Unexpected interface default method behavior");
+        }
+
+        if (ZetaEnum.values()[0] != ZetaEnum.GAMMA
+                || ZetaEnum.values()[1] != ZetaEnum.ALPHA
+                || ZetaEnum.values()[2] != ZetaEnum.BETA) {
+            throw new IllegalStateException("Enum constants order changed");
+        }
+
+        if (!"enum".equals(ZetaEnum.zUtility())) {
+            throw new IllegalStateException("Enum utility method failed");
+        }
+
+        if (PrivateEnum.FIRST.ordinal() != 1 || PrivateEnum.SECOND.ordinal() != 0) {
+            throw new IllegalStateException("Nested enum constants order changed");
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the default configuration is exercised for non-class top-level types (record, interface, enum, annotation) and their members, including default/private interface methods, record components, enum constants and nested types.

### Description
- Added a new E2E scenario `core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types` with `config.yml`, `input/DefaultConfigComplexTypesScenario.java` and `expected/DefaultConfigComplexTypesScenario.java`.
- `config.yml` is the full default configuration to validate ordering for top-level and nested types using the project defaults.
- The input fixture contains a complex mix of top-level `interface`, `@interface`, `record`, `enum`, and `class` plus nested enum/interface/@interface/record to exercise sorting combinatorics.
- No production code changes; only test fixtures and configuration files were added and committed.

### Testing
- Ran `mvn -pl core -Dtest=SourceProcessorE2EFixtureTest test`; the first attempt failed due to a transient Maven Central network error (502) when downloading a dependency.
- A subsequent run failed on `pmd:check` due to existing PMD violations unrelated to these test fixtures.
- Ran `mvn -pl core -Dpmd.skip=true -Dtest=SourceProcessorE2EFixtureTest test` and the e2e harness passed: `Tests run: 26, Failures: 0, Errors: 0, Skipped: 1`.
- The processor debug/formatted output was used to generate the `expected` fixture to ensure deterministic comparison in the e2e test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b01f0de0088325a419197b34799166)