### PR TITLE
Replace Unicode ellipsis with ASCII prefix in path abbreviation to avoid garbled output

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/PathDisplayFormatUtil.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/PathDisplayFormatUtil.java
@@ -9,7 +9,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 class PathDisplayFormatUtil {
 
-    private static final String ELLIPSIS = "…";
+    private static final String ELLIPSIS = "...";
     private static final int MINIMAL_JAVA_FILE_NAME_LENGTH = "A.java".length();
 
     @NonNull

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/PathDisplayFormatUtilTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/PathDisplayFormatUtilTest.java
@@ -1,0 +1,44 @@
+package io.github.lemon_ant.jharmonizer.core.processing_stat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+class PathDisplayFormatUtilTest {
+
+    @Test
+    void abbreviatePathForDisplay_longPath_usesAsciiPrefixAndRespectsMaxLength() {
+        // Given
+        Path longPath = Path.of(
+                "workspace",
+                "very-long-module-name",
+                "feature",
+                "deeply",
+                "nested",
+                "DefaultConfigComplexTypesScenario.java");
+        int maxLength = 60;
+
+        // When
+        String abbreviatedPath = PathDisplayFormatUtil.abbreviatePathForDisplay(longPath, maxLength);
+
+        // Then
+        String separator = longPath.getFileSystem().getSeparator();
+        assertThat(abbreviatedPath)
+                .startsWith("..." + separator)
+                .doesNotContain("…")
+                .hasSizeLessThanOrEqualTo(maxLength);
+    }
+
+    @Test
+    void abbreviatePathForDisplay_shortPath_returnsOriginalPath() {
+        // Given
+        Path shortPath = Path.of("DefaultConfigComplexTypesScenario.java");
+
+        // When
+        String abbreviatedPath = PathDisplayFormatUtil.abbreviatePathForDisplay(shortPath, 100);
+
+        // Then
+        assertThat(abbreviatedPath).isEqualTo(shortPath.toString());
+    }
+}


### PR DESCRIPTION
### Motivation
- Terminals/logging pipelines that do not render the Unicode ellipsis (`…`) produce `?` characters in harmonization statistics when paths are abbreviated, so the output must be made encoding-robust.

### Description
- Replace the Unicode ellipsis constant with an ASCII prefix by changing `ELLIPSIS` from `"…"` to `"..."` in `core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/PathDisplayFormatUtil.java`.
- Add focused unit tests in `core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/PathDisplayFormatUtilTest.java` that assert long paths use the ASCII prefix, the abbreviated output does not contain `…`, and short paths remain unchanged.

### Testing
- Added `PathDisplayFormatUtilTest` (2 tests) and ran the targeted unit tests with `mvn -pl core -Dpmd.skip=true -Dspotbugs.skip=true -Dtest=PathDisplayFormatUtilTest test`, which completed successfully.
- Running the module without `-Dpmd.skip` initially failed the build due to existing PMD violations elsewhere in the project, but the new tests themselves passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b034f48d9883259dc7080b7811c0f3)