### PR TITLE
Add e2e fixtures and tests for non-type-only compilation units

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -118,6 +118,7 @@
 - Do not keep non-trivial multi-line textual fixtures such as YAML, JSON, XML, Java source, or long expected-output snippets inline in test code.
 - Store those fixtures under `src/test/resources/test-cases/**` and load them through shared helpers such as `TestCaseResourceUtils`.
 - Only tiny one-off inline snippets are acceptable when extracting a file would hurt readability.
+- For formatter-focused fixtures under `src/test/resources/test-cases/**`, keep `input/` resources valid but intentionally not already formatted like `expected/`, so the scenario demonstrates a real formatter rewrite.
 - Use `valid/` for fixtures that must compile and be compilable by the build gate.
 - Use `invalid/` for fixtures that may intentionally not compile in negative tests.
 - All `valid/**/*.java` fixtures must compile as part of the build.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,5 +65,3 @@ This file defines repository-wide conventions for coding agents working in this 
 ## Test conventions
 
 - See `docs/test-conventions.md`.
-- In particular, keep non-trivial multi-line textual test fixtures in `src/test/resources/test-cases/**` instead of embedding them inline in test classes.
-- For formatter-focused fixtures under `src/test/resources/test-cases/**`, keep the `input/` files intentionally valid but not already formatted like `expected/`, so the scenario proves the formatter makes a real change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,4 @@ This file defines repository-wide conventions for coding agents working in this 
 
 - See `docs/test-conventions.md`.
 - In particular, keep non-trivial multi-line textual test fixtures in `src/test/resources/test-cases/**` instead of embedding them inline in test classes.
+- For formatter-focused fixtures under `src/test/resources/test-cases/**`, keep the `input/` files intentionally valid but not already formatted like `expected/`, so the scenario proves the formatter makes a real change.

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/spoon/SpoonTypeUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/spoon/SpoonTypeUtils.java
@@ -56,13 +56,13 @@ public class SpoonTypeUtils {
     }
 
     /**
-     * Checks whether the compilation unit is a type-declaration unit without declared types.
+     * Checks whether the compilation unit has no declared types to sort.
      * @param compilationUnit the compilation unit to inspect
-     * @return {@code true} when the unit is TYPE_DECLARATION and has no declared types
+     * @return {@code true} when the unit is not TYPE_DECLARATION or has no declared types
      */
-    public static boolean hasNoDeclaredTypesInTypeDeclarationUnit(@NonNull CtCompilationUnit compilationUnit) {
-        return compilationUnit.getUnitType() == CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
-                && compilationUnit.getDeclaredTypes().isEmpty();
+    public static boolean hasNoDeclaredTypes(@NonNull CtCompilationUnit compilationUnit) {
+        return compilationUnit.getUnitType() != CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
+                || compilationUnit.getDeclaredTypes().isEmpty();
     }
 
     /**

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/spoon/SpoonTypeUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/spoon/SpoonTypeUtils.java
@@ -56,6 +56,16 @@ public class SpoonTypeUtils {
     }
 
     /**
+     * Checks whether the compilation unit is a type-declaration unit without declared types.
+     * @param compilationUnit the compilation unit to inspect
+     * @return {@code true} when the unit is TYPE_DECLARATION and has no declared types
+     */
+    public static boolean hasNoDeclaredTypesInTypeDeclarationUnit(@NonNull CtCompilationUnit compilationUnit) {
+        return compilationUnit.getUnitType() == CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
+                && compilationUnit.getDeclaredTypes().isEmpty();
+    }
+
+    /**
      * Current order for a whole compilation unit: declared types as-is.
      */
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSourcePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSourcePrinter.java
@@ -110,8 +110,10 @@ class SpoonCustomSourcePrinter extends DefaultJavaPrettyPrinter {
      */
     @Override
     public void visitCtCompilationUnit(@NonNull CtCompilationUnit compilationUnit) {
-        if (compilationUnit.getUnitType() != CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION) {
-            // For non-type-declaration units, delegate to the default implementation and stop.
+        if (compilationUnit.getUnitType() != CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
+                || compilationUnit.getDeclaredTypes().isEmpty()) {
+            // For non-type-declaration units and type-declaration files without any declared types,
+            // delegate to the default implementation and stop.
             super.visitCtCompilationUnit(compilationUnit);
             return;
         }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSourcePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSourcePrinter.java
@@ -111,7 +111,7 @@ class SpoonCustomSourcePrinter extends DefaultJavaPrettyPrinter {
     @Override
     public void visitCtCompilationUnit(@NonNull CtCompilationUnit compilationUnit) {
         if (compilationUnit.getUnitType() != CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
-                || compilationUnit.getDeclaredTypes().isEmpty()) {
+                || SpoonTypeUtils.hasNoDeclaredTypesInTypeDeclarationUnit(compilationUnit)) {
             // For non-type-declaration units and type-declaration files without any declared types,
             // delegate to the default implementation and stop.
             super.visitCtCompilationUnit(compilationUnit);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSourcePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSourcePrinter.java
@@ -110,8 +110,7 @@ class SpoonCustomSourcePrinter extends DefaultJavaPrettyPrinter {
      */
     @Override
     public void visitCtCompilationUnit(@NonNull CtCompilationUnit compilationUnit) {
-        if (compilationUnit.getUnitType() != CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
-                || SpoonTypeUtils.hasNoDeclaredTypesInTypeDeclarationUnit(compilationUnit)) {
+        if (SpoonTypeUtils.hasNoDeclaredTypes(compilationUnit)) {
             // For non-type-declaration units and type-declaration files without any declared types,
             // delegate to the default implementation and stop.
             super.visitCtCompilationUnit(compilationUnit);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
@@ -44,7 +44,7 @@ public class SpoonParser {
         CtType<?> mainType = SpoonTypeUtils.findMainType(compilationUnit);
         JHarmonizerOptOuts optOuts = JHarmonizerOptOutResolver.resolve(srcFile, compilationUnit);
         Supplier<SerializedSourceWithSkippedTypeRanges> serializedSrcCode = () -> {
-            if (SpoonTypeUtils.hasNoDeclaredTypesInTypeDeclarationUnit(compilationUnit)) {
+            if (SpoonTypeUtils.hasNoDeclaredTypes(compilationUnit)) {
                 return new SerializedSourceWithSkippedTypeRanges(srcFile.getSrcCode(), Map.of());
             }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
@@ -9,9 +9,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang3.Validate;
 import spoon.Launcher;
-import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtType;
 import spoon.support.compiler.VirtualFile;
@@ -80,28 +78,6 @@ public class SpoonParser {
 
     @NonNull
     private static CtCompilationUnit extractCompilationUnit(@NonNull SrcFile srcFile, Launcher launcher) {
-        Map<String, CompilationUnit> compilationUnitsByPath =
-                launcher.getFactory().CompilationUnit().getMap();
-        Validate.validState(
-                compilationUnitsByPath.size() <= 1,
-                "Expected at most one parsed compilation unit, got %d",
-                compilationUnitsByPath.size());
-
-        CompilationUnit compilationUnit = compilationUnitsByPath.isEmpty()
-                ? createMissingSrcCompilationUnit(srcFile, launcher)
-                : compilationUnitsByPath.values().iterator().next();
-        Validate.validState(
-                compilationUnit instanceof CtCompilationUnit,
-                "Expected Spoon compilation unit to implement CtCompilationUnit, got %s",
-                compilationUnit.getClass().getName());
-        return (CtCompilationUnit) compilationUnit;
-    }
-
-    @NonNull
-    private static CompilationUnit createMissingSrcCompilationUnit(@NonNull SrcFile srcFile, Launcher launcher) {
-        // Spoon does not always cache a compilation unit for comment-only / effectively empty source files.
-        // We still create one keyed by the virtual src path so downstream code can keep treating the file as a
-        // compilation unit and preserve the original src text instead of failing on missing declared types.
         return launcher.getFactory()
                 .CompilationUnit()
                 .getOrCreate(srcFile.getPath().toString());

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
@@ -5,12 +5,13 @@ import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOutResolver;
 import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOuts;
 import io.github.lemon_ant.jharmonizer.core.spoon.SpoonTypeUtils;
 import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
-import java.util.Collection;
+import java.util.Map;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.Validate;
 import spoon.Launcher;
+import spoon.reflect.cu.CompilationUnit;
 import spoon.reflect.declaration.CtCompilationUnit;
 import spoon.reflect.declaration.CtType;
 import spoon.support.compiler.VirtualFile;
@@ -38,10 +39,14 @@ public class SpoonParser {
 
     @NonNull
     private static SpoonAstModel buildSpoonAstModel(SrcFile srcFile, Launcher launcher) {
-        CtCompilationUnit compilationUnit = extractCompilationUnit(launcher);
+        CtCompilationUnit compilationUnit = extractCompilationUnit(srcFile, launcher);
         CtType<?> mainType = SpoonTypeUtils.findMainType(compilationUnit);
         JHarmonizerOptOuts optOuts = JHarmonizerOptOutResolver.resolve(srcFile, compilationUnit);
         Supplier<SerializedSourceWithSkippedTypeRanges> serializedSrcCode = () -> {
+            if (shouldPreserveOriginalSource(compilationUnit)) {
+                return new SerializedSourceWithSkippedTypeRanges(srcFile.getSrcCode(), Map.of());
+            }
+
             SpoonCustomSourcePrinter printer = new SpoonCustomSourcePrinter(
                     launcher.getEnvironment(), srcFile.getSrcCode(), optOuts.getSortingSkippedTypes());
             return printer.serializeCompilationUnit(compilationUnit);
@@ -73,11 +78,30 @@ public class SpoonParser {
     }
 
     @NonNull
-    private static CtCompilationUnit extractCompilationUnit(Launcher launcher) {
-        Collection<CtType<?>> allTypes = launcher.buildModel().getAllTypes();
-        // TODO Flesh out the corner cases with package-info.java and module-info.java
-        Validate.notEmpty(allTypes, "AllTypes cannot be empty");
-        CtType<?> firstType = allTypes.iterator().next();
-        return firstType.getPosition().getCompilationUnit();
+    private static CtCompilationUnit extractCompilationUnit(@NonNull SrcFile srcFile, Launcher launcher) {
+        launcher.buildModel();
+
+        Map<String, CompilationUnit> compilationUnitsByPath =
+                launcher.getFactory().CompilationUnit().getMap();
+        Validate.validState(
+                compilationUnitsByPath.size() <= 1,
+                "Expected at most one parsed compilation unit, got %d",
+                compilationUnitsByPath.size());
+
+        CompilationUnit compilationUnit = compilationUnitsByPath.isEmpty()
+                ? launcher.getFactory()
+                        .CompilationUnit()
+                        .getOrCreate(srcFile.getPath().toString())
+                : compilationUnitsByPath.values().iterator().next();
+        Validate.validState(
+                compilationUnit instanceof CtCompilationUnit,
+                "Expected Spoon compilation unit to implement CtCompilationUnit, got %s",
+                compilationUnit.getClass().getName());
+        return (CtCompilationUnit) compilationUnit;
+    }
+
+    private static boolean shouldPreserveOriginalSource(CtCompilationUnit compilationUnit) {
+        return compilationUnit.getUnitType() == CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
+                && compilationUnit.getDeclaredTypes().isEmpty();
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
@@ -39,11 +39,12 @@ public class SpoonParser {
 
     @NonNull
     private static SpoonAstModel buildSpoonAstModel(SrcFile srcFile, Launcher launcher) {
+        launcher.buildModel();
         CtCompilationUnit compilationUnit = extractCompilationUnit(srcFile, launcher);
         CtType<?> mainType = SpoonTypeUtils.findMainType(compilationUnit);
         JHarmonizerOptOuts optOuts = JHarmonizerOptOutResolver.resolve(srcFile, compilationUnit);
         Supplier<SerializedSourceWithSkippedTypeRanges> serializedSrcCode = () -> {
-            if (shouldPreserveOriginalSource(compilationUnit)) {
+            if (SpoonTypeUtils.hasNoDeclaredTypesInTypeDeclarationUnit(compilationUnit)) {
                 return new SerializedSourceWithSkippedTypeRanges(srcFile.getSrcCode(), Map.of());
             }
 
@@ -79,8 +80,6 @@ public class SpoonParser {
 
     @NonNull
     private static CtCompilationUnit extractCompilationUnit(@NonNull SrcFile srcFile, Launcher launcher) {
-        launcher.buildModel();
-
         Map<String, CompilationUnit> compilationUnitsByPath =
                 launcher.getFactory().CompilationUnit().getMap();
         Validate.validState(
@@ -89,9 +88,7 @@ public class SpoonParser {
                 compilationUnitsByPath.size());
 
         CompilationUnit compilationUnit = compilationUnitsByPath.isEmpty()
-                ? launcher.getFactory()
-                        .CompilationUnit()
-                        .getOrCreate(srcFile.getPath().toString())
+                ? createMissingSrcCompilationUnit(srcFile, launcher)
                 : compilationUnitsByPath.values().iterator().next();
         Validate.validState(
                 compilationUnit instanceof CtCompilationUnit,
@@ -100,8 +97,13 @@ public class SpoonParser {
         return (CtCompilationUnit) compilationUnit;
     }
 
-    private static boolean shouldPreserveOriginalSource(CtCompilationUnit compilationUnit) {
-        return compilationUnit.getUnitType() == CtCompilationUnit.UNIT_TYPE.TYPE_DECLARATION
-                && compilationUnit.getDeclaredTypes().isEmpty();
+    @NonNull
+    private static CompilationUnit createMissingSrcCompilationUnit(@NonNull SrcFile srcFile, Launcher launcher) {
+        // Spoon does not always cache a compilation unit for comment-only / effectively empty source files.
+        // We still create one keyed by the virtual src path so downstream code can keep treating the file as a
+        // compilation unit and preserve the original src text instead of failing on missing declared types.
+        return launcher.getFactory()
+                .CompilationUnit()
+                .getOrCreate(srcFile.getPath().toString());
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -166,6 +166,7 @@ final class SpoonTypePrinter {
         return currentElementNeedsSeparatorAfter;
     }
 
+    @SuppressWarnings("PMD.NullAssignment")
     @NonNull
     Map<CtType<?>, SrcCharacterRange> getSortingSkippedTypeRanges() {
         Map<CtType<?>, SrcCharacterRange> activeSortingSkippedTypeRanges = requireSortingSkippedTypeRanges();

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -4,7 +4,6 @@ import static io.github.lemon_ant.jharmonizer.core.e2e.JavaCompileTestUtils.comp
 import static io.github.lemon_ant.jharmonizer.core.e2e.JavaRunMainTestUtils.runJavaMainMethod;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
@@ -52,13 +51,12 @@ class SourceProcessorE2EFixtureTest {
     private static final String COMPILE_BEFORE_DIRECTORY_NAME = "SourceProcessorE2E-compile-before";
     private static final String COMPILE_AFTER_DIRECTORY_NAME = "SourceProcessorE2E-compile-after";
     private static final Pattern SCENARIO_PREFIX_PATTERN = Pattern.compile("^(\\d+)-.+$");
-    private static final String NON_TYPE_COMPILATION_UNITS_SCENARIO = "20-non-type-compilation-units";
 
     @TempDir
     Path temporaryDirectory;
 
     @ParameterizedTest(name = "[{index}] {0}/{1}")
-    @MethodSource("processableFixtureInputFiles")
+    @MethodSource("fixtureInputFiles")
     void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path sourceFile) throws Exception {
         // Given
         Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
@@ -86,12 +84,7 @@ class SourceProcessorE2EFixtureTest {
                         workingInputFile, compileBeforeResult.getOutput())
                 .isZero();
 
-        JavaRunMainTestUtils.RunResult runBeforeResult = runJavaMainMethod(workingInputFile, compileBeforeOutput);
-        assertThat(runBeforeResult.getExitCode())
-                .as(
-                        "Expected main method execution to succeed for %s. Output:%n%s",
-                        runBeforeResult.getClassName(), runBeforeResult.getOutput())
-                .isZero();
+        assertMainMethodExecutionSucceedsWhenPresent(workingInputFile, compileBeforeOutput);
 
         assertFileIsNotProcessedYet(fixtureScenario, workingInputFile, unchangedFixture);
 
@@ -111,57 +104,7 @@ class SourceProcessorE2EFixtureTest {
 
         assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(expectedSourceCode);
 
-        JavaRunMainTestUtils.RunResult runAfterResult = runJavaMainMethod(workingInputFile, compileAfterOutput);
-        assertThat(runAfterResult.getExitCode())
-                .as(
-                        "Expected main method execution to succeed for %s. Output:%n%s",
-                        runAfterResult.getClassName(), runAfterResult.getOutput())
-                .isZero();
-    }
-
-    @ParameterizedTest(name = "[{index}] {0}/{1}/{2}")
-    @MethodSource("nonTypeDefinitionFixtureInputFiles")
-    void processNonTypeFixtureInputFile_nonTypeFixture_preserveExpectedSource(
-            Path scenarioDir, Path sourceFile, FlowType flowType) throws Exception {
-        // Given
-        Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
-        Path fixtureInputFile = resolveInput(fixtureScenario).resolve(sourceFile);
-        Path expectedSourceFile = resolveExpected(fixtureScenario).resolve(sourceFile);
-        String expectedSourceCode = Files.readString(expectedSourceFile, StandardCharsets.UTF_8);
-        String scenarioName = scenarioDir + "-" + flowType.name().toLowerCase();
-        Path workingScenarioRoot =
-                temporaryDirectory.resolve(WORKING_DIRECTORY_NAME).resolve(scenarioName);
-        Path workingInputFile = copyInputJavaFile(fixtureInputFile, workingScenarioRoot);
-        Path compileBeforeOutput =
-                temporaryDirectory.resolve(COMPILE_BEFORE_DIRECTORY_NAME).resolve(scenarioName);
-        Path compileAfterOutput =
-                temporaryDirectory.resolve(COMPILE_AFTER_DIRECTORY_NAME).resolve(scenarioName);
-
-        JavaCompileTestUtils.CompileResult compileBeforeResult =
-                compileJavaSourceWithRelease21(workingInputFile, compileBeforeOutput);
-        assertThat(compileBeforeResult.getExitCode())
-                .as(
-                        "Expected javac --release 21 to compile file %s before processing non-type fixture. Diagnostics:%n%s",
-                        workingInputFile, compileBeforeResult.getOutput())
-                .isZero();
-
-        // When
-        runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), FlowType.RESTRUCTURE);
-
-        // Then
-        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(expectedSourceCode);
-
-        JavaCompileTestUtils.CompileResult compileAfterResult =
-                compileJavaSourceWithRelease21(workingInputFile, compileAfterOutput);
-        assertThat(compileAfterResult.getExitCode())
-                .as(
-                        "Expected javac --release 21 to compile file %s after restructuring non-type fixture. Diagnostics:%n%s",
-                        workingInputFile, compileAfterResult.getOutput())
-                .isZero();
-
-        assertThatCode(() -> runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), flowType))
-                .doesNotThrowAnyException();
-        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(expectedSourceCode);
+        assertMainMethodExecutionSucceedsWhenPresent(workingInputFile, compileAfterOutput);
     }
 
     @Test
@@ -233,23 +176,6 @@ class SourceProcessorE2EFixtureTest {
     }
 
     @NonNull
-    private static Stream<Arguments> processableFixtureInputFiles() throws IOException {
-        return fixtureInputFiles()
-                .filter(arguments -> !NON_TYPE_COMPILATION_UNITS_SCENARIO.equals(
-                        ((Path) arguments.get()[0]).toString()));
-    }
-
-    @NonNull
-    private static Stream<Arguments> nonTypeDefinitionFixtureInputFiles() throws IOException {
-        return fixtureInputFiles()
-                .filter(arguments -> NON_TYPE_COMPILATION_UNITS_SCENARIO.equals(
-                        ((Path) arguments.get()[0]).toString()))
-                .flatMap(arguments -> Stream.of(FlowType.RESTRUCTURE, FlowType.CHECK_ALL, FlowType.CHECK_FAIL_FAST)
-                        .map(flowType ->
-                                Arguments.of(arguments.get()[0], arguments.get()[1], flowType)));
-    }
-
-    @NonNull
     private static Stream<Arguments> fixtureInputFiles() throws IOException {
         return SourceFilesHandler.findJavaFiles(FIXTURES_ROOT, List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())
                 .sorted()
@@ -267,6 +193,28 @@ class SourceProcessorE2EFixtureTest {
         } catch (URISyntaxException exception) {
             throw new IllegalArgumentException(
                     "Cannot convert fixtures URL to URI: " + FIXTURE_RESOURCES_ROOT_DIR, exception);
+        }
+    }
+
+    private static void assertMainMethodExecutionSucceedsWhenPresent(Path srcFile, Path compiledOutputDirectory)
+            throws IOException, InterruptedException {
+        if (!containsMainMethodDeclaration(srcFile)) {
+            return;
+        }
+
+        JavaRunMainTestUtils.RunResult runResult = runJavaMainMethod(srcFile, compiledOutputDirectory);
+        assertThat(runResult.getExitCode())
+                .as(
+                        "Expected main method execution to succeed for %s. Output:%n%s",
+                        runResult.getClassName(), runResult.getOutput())
+                .isZero();
+    }
+
+    private static boolean containsMainMethodDeclaration(Path srcFile) {
+        try (Stream<String> lines = Files.lines(srcFile, StandardCharsets.UTF_8)) {
+            return lines.map(String::trim).anyMatch(line -> line.contains("public static void main("));
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to inspect source file for main method: " + srcFile, exception);
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -4,6 +4,7 @@ import static io.github.lemon_ant.jharmonizer.core.e2e.JavaCompileTestUtils.comp
 import static io.github.lemon_ant.jharmonizer.core.e2e.JavaRunMainTestUtils.runJavaMainMethod;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
@@ -102,9 +103,10 @@ class SourceProcessorE2EFixtureTest {
                         workingInputFile, compileAfterResult.getOutput())
                 .isZero();
 
-        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(expectedSourceCode);
-
         assertMainMethodExecutionSucceedsWhenPresent(workingInputFile, compileAfterOutput);
+
+        String workingInputFileSrc = Files.readString(workingInputFile, StandardCharsets.UTF_8);
+        assertThat(workingInputFileSrc).isEqualTo(expectedSourceCode);
     }
 
     @Test

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -121,32 +121,47 @@ class SourceProcessorE2EFixtureTest {
 
     @ParameterizedTest(name = "[{index}] {0}/{1}/{2}")
     @MethodSource("nonTypeDefinitionFixtureInputFiles")
-    void processNonTypeFixtureInputFile_nonTypeDeclarationsPresent_failWithAllTypesCannotBeEmpty(
+    void processNonTypeFixtureInputFile_nonTypeFixture_preserveExpectedSource(
             Path scenarioDir, Path sourceFile, FlowType flowType) throws Exception {
         // Given
         Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
         Path fixtureInputFile = resolveInput(fixtureScenario).resolve(sourceFile);
-        String inputSourceCode = Files.readString(fixtureInputFile, StandardCharsets.UTF_8);
+        Path expectedSourceFile = resolveExpected(fixtureScenario).resolve(sourceFile);
+        String expectedSourceCode = Files.readString(expectedSourceFile, StandardCharsets.UTF_8);
         String scenarioName = scenarioDir + "-" + flowType.name().toLowerCase();
         Path workingScenarioRoot =
                 temporaryDirectory.resolve(WORKING_DIRECTORY_NAME).resolve(scenarioName);
         Path workingInputFile = copyInputJavaFile(fixtureInputFile, workingScenarioRoot);
         Path compileBeforeOutput =
                 temporaryDirectory.resolve(COMPILE_BEFORE_DIRECTORY_NAME).resolve(scenarioName);
+        Path compileAfterOutput =
+                temporaryDirectory.resolve(COMPILE_AFTER_DIRECTORY_NAME).resolve(scenarioName);
 
         JavaCompileTestUtils.CompileResult compileBeforeResult =
                 compileJavaSourceWithRelease21(workingInputFile, compileBeforeOutput);
         assertThat(compileBeforeResult.getExitCode())
                 .as(
-                        "Expected javac --release 21 to compile file %s before exercising parser failure. Diagnostics:%n%s",
+                        "Expected javac --release 21 to compile file %s before processing non-type fixture. Diagnostics:%n%s",
                         workingInputFile, compileBeforeResult.getOutput())
                 .isZero();
 
-        // When / Then
-        assertThatThrownBy(() -> runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), flowType))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("AllTypes cannot be empty");
-        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(inputSourceCode);
+        // When
+        runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), FlowType.RESTRUCTURE);
+
+        // Then
+        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(expectedSourceCode);
+
+        JavaCompileTestUtils.CompileResult compileAfterResult =
+                compileJavaSourceWithRelease21(workingInputFile, compileAfterOutput);
+        assertThat(compileAfterResult.getExitCode())
+                .as(
+                        "Expected javac --release 21 to compile file %s after restructuring non-type fixture. Diagnostics:%n%s",
+                        workingInputFile, compileAfterResult.getOutput())
+                .isZero();
+
+        assertThatCode(() -> runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), flowType))
+                .doesNotThrowAnyException();
+        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(expectedSourceCode);
     }
 
     @Test

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -52,12 +52,13 @@ class SourceProcessorE2EFixtureTest {
     private static final String COMPILE_BEFORE_DIRECTORY_NAME = "SourceProcessorE2E-compile-before";
     private static final String COMPILE_AFTER_DIRECTORY_NAME = "SourceProcessorE2E-compile-after";
     private static final Pattern SCENARIO_PREFIX_PATTERN = Pattern.compile("^(\\d+)-.+$");
+    private static final String NON_TYPE_COMPILATION_UNITS_SCENARIO = "20-non-type-compilation-units";
 
     @TempDir
     Path temporaryDirectory;
 
     @ParameterizedTest(name = "[{index}] {0}/{1}")
-    @MethodSource("fixtureInputFiles")
+    @MethodSource("processableFixtureInputFiles")
     void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path sourceFile) throws Exception {
         // Given
         Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
@@ -116,6 +117,36 @@ class SourceProcessorE2EFixtureTest {
                         "Expected main method execution to succeed for %s. Output:%n%s",
                         runAfterResult.getClassName(), runAfterResult.getOutput())
                 .isZero();
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}/{1}/{2}")
+    @MethodSource("nonTypeDefinitionFixtureInputFiles")
+    void processNonTypeFixtureInputFile_nonTypeDeclarationsPresent_failWithAllTypesCannotBeEmpty(
+            Path scenarioDir, Path sourceFile, FlowType flowType) throws Exception {
+        // Given
+        Path fixtureScenario = FIXTURES_ROOT.resolve(scenarioDir);
+        Path fixtureInputFile = resolveInput(fixtureScenario).resolve(sourceFile);
+        String inputSourceCode = Files.readString(fixtureInputFile, StandardCharsets.UTF_8);
+        String scenarioName = scenarioDir + "-" + flowType.name().toLowerCase();
+        Path workingScenarioRoot =
+                temporaryDirectory.resolve(WORKING_DIRECTORY_NAME).resolve(scenarioName);
+        Path workingInputFile = copyInputJavaFile(fixtureInputFile, workingScenarioRoot);
+        Path compileBeforeOutput =
+                temporaryDirectory.resolve(COMPILE_BEFORE_DIRECTORY_NAME).resolve(scenarioName);
+
+        JavaCompileTestUtils.CompileResult compileBeforeResult =
+                compileJavaSourceWithRelease21(workingInputFile, compileBeforeOutput);
+        assertThat(compileBeforeResult.getExitCode())
+                .as(
+                        "Expected javac --release 21 to compile file %s before exercising parser failure. Diagnostics:%n%s",
+                        workingInputFile, compileBeforeResult.getOutput())
+                .isZero();
+
+        // When / Then
+        assertThatThrownBy(() -> runProcessorForSingleFile(workingInputFile, resolveConfig(fixtureScenario), flowType))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("AllTypes cannot be empty");
+        assertThat(Files.readString(workingInputFile, StandardCharsets.UTF_8)).isEqualTo(inputSourceCode);
     }
 
     @Test
@@ -184,6 +215,23 @@ class SourceProcessorE2EFixtureTest {
                             .boxed()
                             .toArray(Integer[]::new));
         }
+    }
+
+    @NonNull
+    private static Stream<Arguments> processableFixtureInputFiles() throws IOException {
+        return fixtureInputFiles()
+                .filter(arguments -> !NON_TYPE_COMPILATION_UNITS_SCENARIO.equals(
+                        ((Path) arguments.get()[0]).toString()));
+    }
+
+    @NonNull
+    private static Stream<Arguments> nonTypeDefinitionFixtureInputFiles() throws IOException {
+        return fixtureInputFiles()
+                .filter(arguments -> NON_TYPE_COMPILATION_UNITS_SCENARIO.equals(
+                        ((Path) arguments.get()[0]).toString()))
+                .flatMap(arguments -> Stream.of(FlowType.RESTRUCTURE, FlowType.CHECK_ALL, FlowType.CHECK_FAIL_FAST)
+                        .map(flowType ->
+                                Arguments.of(arguments.get()[0], arguments.get()[1], flowType)));
     }
 
     @NonNull

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/config.yml
@@ -1,0 +1,22 @@
+formatting:
+  fix-imports: true
+  formatter-style: PALANTIR
+
+backups-enabled: false
+
+header-line:
+  character: '-'
+  left-padding: 0
+
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class, record, interface, enum, annotation ]
+  ordering-rules: [ preserve ]
+
+type-members-ordering:
+  - name: Root
+    includes: ~.*
+    ordering-rules: preserve
+    separator: none
+    groups: [ ]

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/CommentOnly.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/CommentOnly.java
@@ -1,2 +1,2 @@
-// Intentionally empty compilation unit with comments only.
-/* No package, imports, module, or type declarations. */
+    // Intentionally empty compilation unit with comments only.
+/*    No package, imports, module, or type declarations.    */

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/CommentOnly.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/CommentOnly.java
@@ -1,0 +1,2 @@
+// Intentionally empty compilation unit with comments only.
+/* No package, imports, module, or type declarations. */

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/DirectivesOnly.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/DirectivesOnly.java
@@ -1,0 +1,3 @@
+package io.github.lemon_ant.jharmonizer.core.e2e.nontype;
+
+// Intentionally no type declaration here.

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/module-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/module-info.java
@@ -1,0 +1,5 @@
+module io.github.lemon_ant.jharmonizer.core.e2e.nontype {
+    requires java.base;
+
+    uses java.lang.AutoCloseable;
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/module-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/module-info.java
@@ -1,3 +1,4 @@
+@Deprecated
 module io.github.lemon_ant.jharmonizer.core.e2e.nontype {
     requires java.base;
 

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/package-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/package-info.java
@@ -3,5 +3,5 @@
  *
  * <p>Keeps legal package annotations so the formatter and parser still have syntax to preserve.
  */
-@java.lang.Deprecated
+@Deprecated
 package io.github.lemon_ant.jharmonizer.core.e2e.nontype;

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/package-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/expected/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Package-level documentation fixture for non-type compilation-unit coverage.
+ *
+ * <p>Keeps legal package annotations so the formatter and parser still have syntax to preserve.
+ */
+@java.lang.Deprecated
+package io.github.lemon_ant.jharmonizer.core.e2e.nontype;

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/CommentOnly.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/CommentOnly.java
@@ -1,2 +1,2 @@
-// Intentionally empty compilation unit with comments only.
-/* No package, imports, module, or type declarations. */
+    // Intentionally empty compilation unit with comments only.    
+/*    No package, imports, module, or type declarations.    */

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/CommentOnly.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/CommentOnly.java
@@ -1,0 +1,2 @@
+// Intentionally empty compilation unit with comments only.
+/* No package, imports, module, or type declarations. */

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/DirectivesOnly.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/DirectivesOnly.java
@@ -1,0 +1,6 @@
+package io.github.lemon_ant.jharmonizer.core.e2e.nontype;
+
+import java.util.List;
+import static java.util.Collections.emptyList;
+
+// Intentionally no type declaration here.

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/module-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/module-info.java
@@ -1,0 +1,5 @@
+@Deprecated
+module io.github.lemon_ant.jharmonizer.core.e2e.nontype {
+    requires java.base;
+    uses java.lang.AutoCloseable;
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/package-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Package-level documentation fixture for non-type compilation-unit coverage.
+ *
+ * <p>Keeps legal package annotations so the formatter and parser still have syntax to preserve.
+ */
+@Deprecated
+package io.github.lemon_ant.jharmonizer.core.e2e.nontype;

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/package-info.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/input/package-info.java
@@ -3,5 +3,4 @@
  *
  * <p>Keeps legal package annotations so the formatter and parser still have syntax to preserve.
  */
-@Deprecated
-package io.github.lemon_ant.jharmonizer.core.e2e.nontype;
+  @Deprecated   package io.github.lemon_ant.jharmonizer.core.e2e.nontype;

--- a/docs/test-conventions.md
+++ b/docs/test-conventions.md
@@ -126,6 +126,8 @@ void resolveGroups_nestedMatch_winOverParentGroup() {
 - Use explicit scenario folder names (avoid generic `example/`).
 - Prefer resource fixtures under `src/test/resources/test-cases/**` over large inline YAML/Java strings embedded directly in test classes.
 - Do not keep non-trivial multi-line textual fixtures (for example YAML, JSON, XML, Java source, or long expected-output snippets) inline in test code.
+- For formatter-focused fixtures under `src/test/resources/test-cases/**`, keep `input/` resources valid for the parser/compiler but intentionally not already formatted like `expected/`.
+  - The scenario should require a real formatter rewrite instead of passing because `input/` already matches `expected/`.
   - Store them under `src/test/resources/test-cases/**` and load them via shared helpers such as `TestCaseResourceUtils`.
   - Only tiny one-off snippets that stay obviously readable inline are acceptable.
 


### PR DESCRIPTION
### Motivation
- Improve end-to-end coverage for compilation units that contain no type declarations (e.g., comments, directives, package/module-info only).
- Ensure the processor either skips normal restructuring flow for these fixtures or fails with a clear error when appropriate.
- Prevent the new non-type fixtures from being treated as normal processable inputs during the existing e2e run.

### Description
- Added a new fixture scenario `20-non-type-compilation-units` with `config.yml` and input files `CommentOnly.java`, `DirectivesOnly.java`, `module-info.java`, and `package-info.java` under `core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units`.
- Introduced `NON_TYPE_COMPILATION_UNITS_SCENARIO` constant and switched the main parameterized test to use `processableFixtureInputFiles()` so non-type fixtures are excluded from the normal processing test.
- Added a new parameterized test `processNonTypeFixtureInputFile_nonTypeDeclarationsPresent_failWithAllTypesCannotBeEmpty` that runs the processor for the non-type scenario across `FlowType.RESTRUCTURE`, `FlowType.CHECK_ALL`, and `FlowType.CHECK_FAIL_FAST` and asserts a `RuntimeException` containing `AllTypes cannot be empty` is thrown and the input file is unchanged.
- Implemented helper streams `processableFixtureInputFiles()` and `nonTypeDefinitionFixtureInputFiles()` to filter and parametrize fixtures appropriately.

### Testing
- Ran the core test suite targeting the changed class with `mvn -pl core test` and the `SourceProcessorE2EFixtureTest` tests executed successfully.
- All added and existing automated tests related to e2e fixtures passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c151adb5488325b16c8757c7903f14)