### PR TITLE
Run newer core E2E fixture scenarios first

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SourceProcessorE2EFixtureTest.java
@@ -179,8 +179,11 @@ class SourceProcessorE2EFixtureTest {
 
     @NonNull
     private static Stream<Arguments> fixtureInputFiles() throws IOException {
+        Comparator<Path> fixtureExecutionOrder = Comparator.comparing(
+                        SourceProcessorE2EFixtureTest::resolveScenarioDirectoryName, Comparator.reverseOrder())
+                .thenComparing(Path::getFileName, Comparator.naturalOrder());
         return SourceFilesHandler.findJavaFiles(FIXTURES_ROOT, List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())
-                .sorted()
+                .sorted(fixtureExecutionOrder)
                 .map(fixtureInputFile -> {
                     Path scenarioDir = fixtureInputFile.getParent().getParent().getFileName();
                     Path sourceFile = fixtureInputFile.getFileName();
@@ -287,5 +290,10 @@ class SourceProcessorE2EFixtureTest {
     @NonNull
     private static Path resolveInput(Path scenario) {
         return scenario.resolve(INPUT_DIRECTORY);
+    }
+
+    @NonNull
+    private static String resolveScenarioDirectoryName(Path fixtureInputFile) {
+        return fixtureInputFile.getParent().getParent().getFileName().toString();
     }
 }


### PR DESCRIPTION
### Motivation
- Parameterized core E2E fixtures were being executed in natural sorted order which runs older numbered scenarios first, causing newly added scenarios to be executed last and slowing local iteration.

### Description
- Changed `fixtureInputFiles()` to sort discovered fixture input files by scenario directory name in descending order and added a stable secondary sort by source file name.
- Added a small helper `resolveScenarioDirectoryName(Path)` and applied the new comparator in `SourceProcessorE2EFixtureTest` under `core/src/test/java/.../SourceProcessorE2EFixtureTest.java`.

### Testing
- Executed `mvn -B -ntp -pl core -Dtest=SourceProcessorE2EFixtureTest test` which completed successfully with `Tests run: 55, Failures: 0, Errors: 0, Skipped: 1` and `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2f4b7901883258206a2bb0199266c)