### PR TITLE
Add e2e fixture for method-reference field access initializer

### DIFF
--- a/core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/expected/LazyMethodReferenceFieldAccessSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/expected/LazyMethodReferenceFieldAccessSample.java
@@ -1,0 +1,15 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+import java.util.function.IntSupplier;
+
+public class LazyMethodReferenceFieldAccessSample {
+
+    // Alphabetically first field. Method-reference target expression contains a field access
+    // (LazyMethodReferenceFieldAccessSample.zProvider::intValue).
+    // This field access must be treated as lazy and should not force provider-before-dependent ordering.
+    static IntSupplier aDependent = LazyMethodReferenceFieldAccessSample.zProvider::intValue;
+    static int bIndependent = 3;
+
+    // Intentionally placed before aDependent in input to provoke a potential false declaration dependency.
+    static Integer zProvider = Integer.valueOf(7);
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/input/LazyMethodReferenceFieldAccessSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/input/LazyMethodReferenceFieldAccessSample.java
@@ -1,0 +1,14 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+import java.util.function.IntSupplier;
+
+public class LazyMethodReferenceFieldAccessSample {
+    // Intentionally placed before aDependent in input to provoke a potential false declaration dependency.
+    static Integer zProvider = Integer.valueOf(7);
+    static int bIndependent = 3;
+
+    // Alphabetically first field. Method-reference target expression contains a field access
+    // (LazyMethodReferenceFieldAccessSample.zProvider::intValue).
+    // This field access must be treated as lazy and should not force provider-before-dependent ordering.
+    static IntSupplier aDependent = LazyMethodReferenceFieldAccessSample.zProvider::intValue;
+}


### PR DESCRIPTION
### Motivation
- Cover a corner-case where a method-reference initializer targets a field (e.g. `SomeType.zProvider::intValue`) and must be treated as lazy so it does not force provider-before-dependent ordering.

### Description
- Added a minimal input fixture `core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/input/LazyMethodReferenceFieldAccessSample.java` that reproduces the corner-case. 
- Added the matching expected fixture `core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/expected/LazyMethodReferenceFieldAccessSample.java` which fixes the intended ordering (dependent stays first and provider remains lazy).
- Placed the new files in the existing `11-lazy-initializer-contexts` scenario to keep the change surgical and scenario-local.

### Testing
- Ran the full e2e fixture test class with the default lifecycle using `mvn -B -ntp -pl core -Dtest=SourceProcessorE2EFixtureTest test` which initially failed due to PMD checks unrelated to the new fixtures. 
- Re-ran the e2e suite skipping PMD/CPD with `mvn -B -ntp -pl core -Dtest=SourceProcessorE2EFixtureTest -Dpmd.skip=true -Dcpd.skip=true test` and observed success: `Tests run: 57, Failures: 0, Errors: 0, Skipped: 1`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3e607f8bc8325b7dc693f243edf97)