### PR TITLE
Add e2e test for field-initializer compile-time constant edge cases

### DIFF
--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/expected/CompileTimeConstantEdgeCasesSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/expected/CompileTimeConstantEdgeCasesSample.java
@@ -1,0 +1,19 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class CompileTimeConstantEdgeCasesSample {
+    static final int bDependsOnCastConstant = CompileTimeConstantEdgeCasesSample.zCastConstant + 10;
+    static final String cDependsOnConcatConstant = CompileTimeConstantEdgeCasesSample.yConcatConstant + "!";
+    static final String yConcatConstant = "ab" + "cd";
+    static final int zCastConstant = (int) (1L + 2L);
+
+    public static void main(String[] args) {
+        if (bDependsOnCastConstant != 13
+                || !"abcd!".equals(cDependsOnConcatConstant)
+                || zCastConstant != 3
+                || !"abcd".equals(yConcatConstant)) {
+            throw new IllegalStateException("Unexpected values: bDependsOnCastConstant=" + bDependsOnCastConstant
+                    + ", cDependsOnConcatConstant=" + cDependsOnConcatConstant + ", zCastConstant="
+                    + zCastConstant + ", yConcatConstant=" + yConcatConstant);
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/CompileTimeConstantEdgeCasesSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/CompileTimeConstantEdgeCasesSample.java
@@ -1,0 +1,19 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class CompileTimeConstantEdgeCasesSample {
+    static final int zCastConstant = (int) (1L + 2L);
+    static final String yConcatConstant = "ab" + "cd";
+    static final String cDependsOnConcatConstant = CompileTimeConstantEdgeCasesSample.yConcatConstant + "!";
+    static final int bDependsOnCastConstant = CompileTimeConstantEdgeCasesSample.zCastConstant + 10;
+
+    public static void main(String[] args) {
+        if (bDependsOnCastConstant != 13
+                || !"abcd!".equals(cDependsOnConcatConstant)
+                || zCastConstant != 3
+                || !"abcd".equals(yConcatConstant)) {
+            throw new IllegalStateException("Unexpected values: bDependsOnCastConstant=" + bDependsOnCastConstant
+                    + ", cDependsOnConcatConstant=" + cDependsOnConcatConstant + ", zCastConstant="
+                    + zCastConstant + ", yConcatConstant=" + yConcatConstant);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Add coverage for field-initializer reorder/analysis when constants depend on casted arithmetic and string concatenation to ensure compile-time constant behavior is handled correctly.

### Description

- Add new test resources `core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/input/CompileTimeConstantEdgeCasesSample.java` and corresponding `expected` file demonstrating constant dependencies including a casted numeric expression and string concatenation.
- The sample class `CompileTimeConstantEdgeCasesSample` defines several `static final` constants with dependency ordering and contains a `main` check that verifies evaluated values at runtime.

### Testing

- Ran the core tests including the e2e restructure test suite that consumes the new test case; the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4037e9a648325b4f7f6e7223c484f)