### PR TITLE
Add integration coverage for RESTRUCTURE backup behavior

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
@@ -164,6 +164,43 @@ class SourceProcessorTest {
                 .isLessThan(processedSourceCode.indexOf("class Sample"));
     }
 
+    @Test
+    void processSources_restructureWithBackupsEnabled_createsBackupNextToSource() throws Exception {
+        // Given
+        String unformattedSourceCode = "package demo; public class BackupEnabled {private int x;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupEnabled.java", unformattedSourceCode);
+        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        SourceProcessor sourceProcessor = new SourceProcessor(new FlexibleUnifiedConfig(null, null, true, null, null));
+
+        // When
+        sourceProcessor.processSources(
+                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+
+        // Then
+        Path backupFilePath =
+                javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
+        assertThat(backupFilePath).exists();
+        assertThat(Files.readString(backupFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSourceCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSourceCode);
+    }
+
+    @Test
+    void processSources_restructureWithBackupsDisabled_doesNotCreateBackup() throws Exception {
+        // Given
+        String unformattedSourceCode = "package demo; public class BackupDisabled {private int x;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSourceCode);
+        SourceProcessor sourceProcessor = new SourceProcessor(new FlexibleUnifiedConfig(null, null, false, null, null));
+
+        // When
+        sourceProcessor.processSources(
+                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+
+        // Then
+        Path backupFilePath =
+                javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
+        assertThat(backupFilePath).doesNotExist();
+    }
+
     @NonNull
     private static Path writeJavaFile(Path baseDirectoryPath, String fileName, String fileContent) throws Exception {
         Path javaFilePath = baseDirectoryPath.resolve(fileName);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
@@ -189,6 +189,7 @@ class SourceProcessorTest {
         // Given
         String unformattedSourceCode = "package demo; public class BackupDisabled {private int x;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSourceCode);
+        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
         SourceProcessor sourceProcessor = new SourceProcessor(new FlexibleUnifiedConfig(null, null, false, null, null));
 
         // When
@@ -199,6 +200,7 @@ class SourceProcessorTest {
         Path backupFilePath =
                 javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
         assertThat(backupFilePath).doesNotExist();
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSourceCode);
     }
 
     @NonNull

--- a/docs/test-coverage-plan.md
+++ b/docs/test-coverage-plan.md
@@ -73,7 +73,7 @@ Use it as a contract/roadmap: we will implement tests **one item at a time** and
   - **Goal:** processes all files, aggregates counts/times/statuses deterministically.
   - **Must assert:** error cases are reported but do not prevent other files.
 
-- [ ] **RESTRUCTURE file-write + backup contract**
+- [x] **RESTRUCTURE file-write + backup contract**
   - **Type:** integration/E2E
   - **Targets:** `RestructureFlow`, `SourceFilesHandler`
   - **Goal:** file rewrite and backup naming/placement follow configuration.


### PR DESCRIPTION
### Motivation
- Verify the flow-level contract that backups are created only when `backupsEnabled` is true for the RESTRUCTURE flow and that backups are placed/named next to the source file.
- Existing tests only exercise the low-level `SourceFilesHandler.renameToBackup(...)` behavior, not the integration path through `RestructureFlow`/`SourceProcessor`.

### Description
- Added two integration-style tests to `core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java`: `processSources_restructureWithBackupsEnabled_createsBackupNextToSource` and `processSources_restructureWithBackupsDisabled_doesNotCreateBackup` which assert `.bak` creation and content when enabled and absence when disabled.
- Reused the production `FlexibleUnifiedConfig` path by constructing `new FlexibleUnifiedConfig(null, null, <true|false>, null, null)` to control the `backupsEnabled` flag passed into `SourceProcessor` for the scenario.
- Marked the corresponding checklist entry in `docs/test-coverage-plan.md` as completed for the RESTRUCTURE backup contract.

### Testing
- Ran targeted tests with PMD skipped using `mvn -pl core -Dpmd.skip=true -Dtest=SourceProcessorTest,SourceFilesHandlerTest test` and the run completed successfully with all tests passing.
- A plain targeted run without skipping PMD (`mvn -pl core -Dtest=SourceProcessorTest,SourceFilesHandlerTest test`) fails due to pre-existing PMD violations unrelated to these changes, so PMD was skipped for validation above.
- Low-level backup behavior remains covered by existing `SourceFilesHandlerTest` (no changes required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c53783734083258feaf341199870c4)