### PR TITLE
Add test for separator-directive handling in GroupBoundaryMarker and supporting fixtures

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupBoundaryMarkerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupBoundaryMarkerTest.java
@@ -3,13 +3,21 @@ package io.github.lemon_ant.jharmonizer.core.sorter.spoon;
 import static io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledMemberGroupTestCreator.createTrivialMemberGroup;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedSeparator;
+import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.testutils.SpoonTestCaseUtils;
+import io.github.lemon_ant.jharmonizer.core.testutils.TestCaseResourceUtils;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import lombok.NonNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 
@@ -17,6 +25,17 @@ class GroupBoundaryMarkerTest {
 
     private static final URL FIXTURE_URL = GroupBoundaryMarkerTest.class.getResource(
             "/test-cases/core/sorter/spoon/type-member-grouper/valid/TypeMemberGrouperFixture.java");
+    private static final URL SEPARATOR_DIRECTIVE_CONFIG_RESOURCE_URL =
+            TestCaseResourceUtils.requireClasspathResourceUrl(
+                    "/test-cases/core/sorter/spoon/group-boundary-marker/separator-directive-config.yml");
+    private static final URL SEPARATOR_DIRECTIVE_INPUT_RESOURCE_URL = TestCaseResourceUtils.requireClasspathResourceUrl(
+            "/test-cases/core/sorter/spoon/group-boundary-marker/input/SeparatorDirectiveSample.java");
+    private static final URL SEPARATOR_DIRECTIVE_EXPECTED_RESOURCE_URL =
+            TestCaseResourceUtils.requireClasspathResourceUrl(
+                    "/test-cases/core/sorter/spoon/group-boundary-marker/expected/SeparatorDirectiveSample.java");
+
+    @TempDir
+    Path temporaryDirectory;
 
     @Test
     void markGroupBoundaries_groupsContainMembers_writeMetadataOnlyToFirstMemberOfEachNonEmptyGroup() {
@@ -67,6 +86,26 @@ class GroupBoundaryMarkerTest {
                 .isNull();
     }
 
+    @Test
+    void processSources_separatorDirectiveConfig_emitExpectedHeaderBlankLineAndNoneOutput() throws Exception {
+        // Given
+        String originalSourceCode =
+                TestCaseResourceUtils.readClasspathResourceAsString(SEPARATOR_DIRECTIVE_INPUT_RESOURCE_URL);
+        String expectedSourceCode =
+                TestCaseResourceUtils.readClasspathResourceAsString(SEPARATOR_DIRECTIVE_EXPECTED_RESOURCE_URL);
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "SeparatorDirectiveSample.java", originalSourceCode);
+        SourceProcessor sourceProcessor =
+                new SourceProcessor(JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromClasspathResource(
+                        SEPARATOR_DIRECTIVE_CONFIG_RESOURCE_URL));
+
+        // When
+        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+
+        // Then
+        assertThat(processedSourceCode).isEqualTo(expectedSourceCode);
+    }
+
     @NonNull
     private static CtType<?> parseMainType() {
         return SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(FIXTURE_URL);
@@ -76,5 +115,11 @@ class GroupBoundaryMarkerTest {
     private static MemberGroupBlock createGroupBlock(
             String groupName, UnifiedSeparator separator, List<CtTypeMember> members) {
         return new MemberGroupBlock(createTrivialMemberGroup(groupName, false, 0, separator), members);
+    }
+
+    @NonNull
+    private static Path writeJavaFile(Path baseDirectoryPath, String fileName, String fileContent) throws Exception {
+        Path javaFilePath = baseDirectoryPath.resolve(fileName);
+        return Files.writeString(javaFilePath, fileContent, StandardCharsets.UTF_8);
     }
 }

--- a/core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/expected/SeparatorDirectiveSample.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/expected/SeparatorDirectiveSample.java
@@ -1,0 +1,10 @@
+class SeparatorDirectiveSample {
+    // Header fields
+    int a = 1;
+    int z = 2;
+    int b = 4;
+    int p = 3;
+
+    int c = 5;
+    int d = 6;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/input/SeparatorDirectiveSample.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/input/SeparatorDirectiveSample.java
@@ -1,0 +1,8 @@
+class SeparatorDirectiveSample {
+    int d = 6;
+    int a = 1;
+    int z = 2;
+    int p = 3;
+    int b = 4;
+    int c = 5;
+}

--- a/core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/separator-directive-config.yml
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/separator-directive-config.yml
@@ -1,0 +1,29 @@
+formatting:
+  fix-imports: false
+  formatter-style: PALANTIR
+backups-enabled: false
+header-line:
+  character: "-"
+  left-padding: 0
+top-level-types-ordering:
+  main-type-first: true
+  type-groups:
+    - [ class ]
+  ordering-rules: [ preserve ]
+type-members-ordering:
+  - name: Separator contract
+    includes: ~.*
+    ordering-rules: preserve
+    groups:
+      - name: Header fields
+        separator: header
+        ordering-rules: alpha
+        includes: [ field, ~^(a|z)$ ]
+      - name: No separator fields
+        separator: none
+        ordering-rules: alpha
+        includes: [ field, ~^(b|p)$ ]
+      - name: New line fields
+        separator: new-line
+        ordering-rules: alpha
+        includes: [ field, ~^(c|d)$ ]


### PR DESCRIPTION
### Motivation
- Verify that separator directives from a unified configuration produce the expected blank-line/header/none separators when marking group boundaries during source processing.

### Description
- Add `processSources_separatorDirectiveConfig_emitExpectedHeaderBlankLineAndNoneOutput` to `GroupBoundaryMarkerTest` which writes an input Java file to a temp directory, loads a flexible unified config via `JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromClasspathResource`, runs `SourceProcessor.processSources` with `FlowType.RESTRUCTURE`, and asserts output equals the expected fixture.
- Add test resources under `core/src/test/resources/test-cases/core/sorter/spoon/group-boundary-marker/` including `input/SeparatorDirectiveSample.java`, `expected/SeparatorDirectiveSample.java`, and `separator-directive-config.yml` that define the directive-driven grouping and ordering.
- Introduce small test helpers and imports in the test such as a `@TempDir` `Path` for temporary files and a `writeJavaFile` helper that writes the Java file with `Files.writeString` using `StandardCharsets.UTF_8`.

### Testing
- Executed the unit test class `GroupBoundaryMarkerTest` which includes the new `processSources_separatorDirectiveConfig_emitExpectedHeaderBlankLineAndNoneOutput` test and the class-level tests, and the suite completed successfully under the project test run (`mvn test`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5343ed22c832594121702fc33b28c)