### PR TITLE
Improve runtime error logging and clarify default config description in BaseCommand

### DIFF
--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -168,9 +168,20 @@ abstract class BaseCommand implements Callable<Integer> {
             log.error("Processing failed with detailed stack trace.", exception);
             return;
         }
+        String errorDetails = describeRuntimeFailure(exception);
         log.error(
                 "Processing failed: {}. Re-run with -v/--verbose for detailed diagnostics.",
-                exception.getMessage());
+                errorDetails);
+    }
+
+    @NonNull
+    private static String describeRuntimeFailure(RuntimeException exception) {
+        String exceptionType = exception.getClass().getSimpleName();
+        String exceptionMessage = exception.getMessage();
+        if (exceptionMessage == null || exceptionMessage.isBlank()) {
+            return exceptionType;
+        }
+        return exceptionType + ": " + exceptionMessage;
     }
 
     @Value

--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -116,7 +116,7 @@ abstract class BaseCommand implements Callable<Integer> {
         try {
             return processWithFlow(commandOptions);
         } catch (RuntimeException e) {
-            log.error("Processing failed: {}", e.getMessage());
+            logRuntimeFailure(commandOptions.isVerbose(), e);
             return 1;
         }
     }
@@ -160,7 +160,17 @@ abstract class BaseCommand implements Callable<Integer> {
     private static String describeConfigSource(@Nullable Path configFilePath) {
         return configFilePath != null
                 ? configFilePath.toString()
-                : "embedded core default config (/default-config.yml)";
+                : "embedded default resource config (/default-config.yml)";
+    }
+
+    private static void logRuntimeFailure(boolean verbose, RuntimeException exception) {
+        if (verbose) {
+            log.error("Processing failed with detailed stack trace.", exception);
+            return;
+        }
+        log.error(
+                "Processing failed: {}. Re-run with -v/--verbose for detailed diagnostics.",
+                exception.getMessage());
     }
 
     @Value


### PR DESCRIPTION
### Motivation
- Provide more helpful diagnostics on runtime failures and clarify the messaging for the embedded default config source.

### Description
- Replace the previous generic runtime error log in `BaseCommand.call()` with a new `logRuntimeFailure` helper that prints a full stack trace when `verbose` is enabled and otherwise prints the error message with a suggestion to re-run with `-v/--verbose`.
- Rename the null config description string in `describeConfigSource` from "embedded core default config" to `"embedded default resource config (/default-config.yml)"` for clearer wording.

### Testing
- Ran the project's automated unit tests with `mvn test` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c548c16e308325b21de063b19b0b31)