### PR TITLE
Add CLI flag to disable backups (--no-backup) and support runtime backups override

### DIFF
--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -4,9 +4,9 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
-import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
+import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfigMerger;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.flow.NotFormattedException;
 import io.github.lemon_ant.jharmonizer.core.flow.NotOrderedException;
@@ -159,9 +159,22 @@ abstract class BaseCommand implements Callable<Integer> {
         FlexibleUnifiedConfig externalConfig = configFilePath != null
                 ? JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(configFilePath)
                 : null;
-        FlexibleUnifiedConfig effectiveConfig =
-                ConfigurationManager.withBackupsEnabledOverride(externalConfig, disableBackups ? false : null);
+        FlexibleUnifiedConfig backupsOverrideConfig =
+                disableBackups ? new FlexibleUnifiedConfig(null, null, false, null, null) : null;
+        FlexibleUnifiedConfig effectiveConfig = mergeFlexibleConfigs(externalConfig, backupsOverrideConfig);
         return new SourceProcessor(effectiveConfig);
+    }
+
+    @Nullable
+    private static FlexibleUnifiedConfig mergeFlexibleConfigs(
+            @Nullable FlexibleUnifiedConfig baselineConfig, @Nullable FlexibleUnifiedConfig overlayConfig) {
+        if (baselineConfig == null) {
+            return overlayConfig;
+        }
+        if (overlayConfig == null) {
+            return baselineConfig;
+        }
+        return UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
     }
 
     @Nullable

--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
@@ -71,6 +72,11 @@ abstract class BaseCommand implements Callable<Integer> {
     @Nullable
     private Path configFilePath;
 
+    @Option(
+            names = {"-B", "--no-backup"},
+            description = "Disable backup (.bak) file creation even when config enables backups.")
+    private boolean noBackup;
+
     /**
      * Returns the processing flow implemented by the command.
      *
@@ -109,7 +115,12 @@ abstract class BaseCommand implements Callable<Integer> {
             return 1;
         }
         CommandOptions commandOptions = new CommandOptions(
-                absoluteBaseDir, Set.copyOf(includeGlobs), Set.copyOf(excludeGlobs), verbose, effectiveConfigFilePath);
+                absoluteBaseDir,
+                Set.copyOf(includeGlobs),
+                Set.copyOf(excludeGlobs),
+                verbose,
+                effectiveConfigFilePath,
+                noBackup);
         if (commandOptions.isVerbose()) {
             ((Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
         }
@@ -130,7 +141,7 @@ abstract class BaseCommand implements Callable<Integer> {
                 commandOptions.getBaseDir(),
                 describeConfigSource(commandOptions.getConfigFilePath()));
         try {
-            createSourceProcessor(commandOptions.getConfigFilePath())
+            createSourceProcessor(commandOptions.getConfigFilePath(), commandOptions.isNoBackup())
                     .processSources(
                             commandOptions.getBaseDir(),
                             commandOptions.getIncludeGlobs(),
@@ -144,11 +155,13 @@ abstract class BaseCommand implements Callable<Integer> {
     }
 
     @NonNull
-    private static SourceProcessor createSourceProcessor(@Nullable Path configFilePath) {
+    private static SourceProcessor createSourceProcessor(@Nullable Path configFilePath, boolean disableBackups) {
         FlexibleUnifiedConfig externalConfig = configFilePath != null
                 ? JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(configFilePath)
                 : null;
-        return new SourceProcessor(externalConfig);
+        FlexibleUnifiedConfig effectiveConfig =
+                ConfigurationManager.withBackupsEnabledOverride(externalConfig, disableBackups ? false : null);
+        return new SourceProcessor(effectiveConfig);
     }
 
     @Nullable
@@ -197,5 +210,7 @@ abstract class BaseCommand implements Callable<Integer> {
 
         @Nullable
         Path configFilePath;
+
+        boolean noBackup;
     }
 }

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
@@ -8,9 +8,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats.AggregatedProcessingStatistic;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
@@ -109,6 +113,32 @@ class BaseCommandTest {
 
         // Then
         assertThat(exitCode).isZero();
+    }
+
+    @Test
+    void call_noBackupOptionInvoked_disablesBackupsInSourceProcessor() {
+        // Given
+        CommandLine cmd = new CommandLine(new TestCommand());
+        AtomicReference<List<?>> constructorArguments = new AtomicReference<>();
+
+        // When
+        int exitCode;
+        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+                mockConstruction(SourceProcessor.class, (mock, context) -> {
+                    constructorArguments.set(context.arguments());
+                    when(mock.processSources(any(Path.class), any(), any(), any()))
+                            .thenReturn(new AggregatedProcessingStatistic(0, 0, 0, null, null));
+                })) {
+            exitCode = cmd.execute("--base-dir", "src", "--no-backup");
+        }
+
+        // Then
+        assertThat(exitCode).isZero();
+        assertThat(constructorArguments.get()).hasSize(1);
+        Object constructorConfig = constructorArguments.get().getFirst();
+        assertThat(constructorConfig).isInstanceOf(FlexibleUnifiedConfig.class);
+        FlexibleUnifiedConfig flexibleConfig = (FlexibleUnifiedConfig) constructorConfig;
+        assertThat(flexibleConfig.getBackupsEnabled()).contains(false);
     }
 
     @Test

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
@@ -76,6 +76,7 @@ class RestructureCommandTest {
         assertThat(usage.toString())
                 .contains("-b, --base-dir")
                 .contains("-c, --config")
+                .contains("-B, --no-backup")
                 .contains("-i, --include")
                 .contains("-e, --exclude")
                 .contains("Repeat this option or pass multiple patterns as a")

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -97,6 +97,7 @@ class JHarmonizerCliPackagedJarIT {
                 .as(result.toString())
                 .contains("Usage: jharmonizer " + command)
                 .contains("-b, --base-dir")
+                .contains("-B, --no-backup")
                 .contains("-i, --include")
                 .contains("-e, --exclude")
                 .contains("Repeat this option or pass multiple patterns as a")

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SourceProcessor.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SourceProcessor.java
@@ -1,5 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
@@ -48,8 +49,10 @@ public final class SourceProcessor {
 
     /**
      * Primary constructor for SourceProcessor embedded into some wrapper.
+     *
+     * @param externalConfig optional external configuration overlay
      */
-    public SourceProcessor(FlexibleUnifiedConfig externalConfig) {
+    public SourceProcessor(@Nullable FlexibleUnifiedConfig externalConfig) {
         this(ConfigurationManager.overrideDefaultConfig(externalConfig));
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/ConfigurationManager.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/ConfigurationManager.java
@@ -41,12 +41,50 @@ public class ConfigurationManager {
      */
     @NonNull
     public static CompiledConfig overrideDefaultConfig(@Nullable FlexibleUnifiedConfig externalConfig) {
-        if (null == externalConfig) {
+        return overrideDefaultConfig(externalConfig, null);
+    }
+
+    /**
+     * Overrides the default config with external configuration and optional backups override.
+     *
+     * @param externalConfig the external configuration overrides
+     * @param backupsEnabledOverride optional backups-enabled runtime override
+     * @return the merged and compiled runtime configuration
+     */
+    @NonNull
+    public static CompiledConfig overrideDefaultConfig(
+            @Nullable FlexibleUnifiedConfig externalConfig, @Nullable Boolean backupsEnabledOverride) {
+        FlexibleUnifiedConfig effectiveExternalConfig =
+                withBackupsEnabledOverride(externalConfig, backupsEnabledOverride);
+        if (effectiveExternalConfig == null) {
             return loadDefaultConfig();
         }
-
         UnifiedConfig defaultUnifiedConfig = JHarmonizerConfigurationManager.parseUnifiedDefaultConfig();
-        UnifiedConfig mergedUnifiedConfig = UnifiedConfigMerger.merge(defaultUnifiedConfig, externalConfig);
+        UnifiedConfig mergedUnifiedConfig = UnifiedConfigMerger.merge(defaultUnifiedConfig, effectiveExternalConfig);
         return Unified2CompiledModelCompiler.compile(mergedUnifiedConfig);
+    }
+
+    /**
+     * Returns an external config copy with optional backups override applied.
+     *
+     * @param externalConfig the external configuration overrides
+     * @param backupsEnabledOverride optional backups-enabled runtime override
+     * @return adjusted external config; {@code null} when no external config/override is provided
+     */
+    @Nullable
+    public static FlexibleUnifiedConfig withBackupsEnabledOverride(
+            @Nullable FlexibleUnifiedConfig externalConfig, @Nullable Boolean backupsEnabledOverride) {
+        if (backupsEnabledOverride == null) {
+            return externalConfig;
+        }
+        if (externalConfig == null) {
+            return new FlexibleUnifiedConfig(null, null, backupsEnabledOverride, null, null);
+        }
+        return new FlexibleUnifiedConfig(
+                externalConfig.getTopLevelTypesOrdering().orElse(null),
+                externalConfig.getFormatting().orElse(null),
+                backupsEnabledOverride,
+                externalConfig.getHeaderLine().orElse(null),
+                externalConfig.getRootMemberGroups().orElse(null));
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/ConfigurationManager.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/ConfigurationManager.java
@@ -41,50 +41,11 @@ public class ConfigurationManager {
      */
     @NonNull
     public static CompiledConfig overrideDefaultConfig(@Nullable FlexibleUnifiedConfig externalConfig) {
-        return overrideDefaultConfig(externalConfig, null);
-    }
-
-    /**
-     * Overrides the default config with external configuration and optional backups override.
-     *
-     * @param externalConfig the external configuration overrides
-     * @param backupsEnabledOverride optional backups-enabled runtime override
-     * @return the merged and compiled runtime configuration
-     */
-    @NonNull
-    public static CompiledConfig overrideDefaultConfig(
-            @Nullable FlexibleUnifiedConfig externalConfig, @Nullable Boolean backupsEnabledOverride) {
-        FlexibleUnifiedConfig effectiveExternalConfig =
-                withBackupsEnabledOverride(externalConfig, backupsEnabledOverride);
-        if (effectiveExternalConfig == null) {
+        if (null == externalConfig) {
             return loadDefaultConfig();
         }
         UnifiedConfig defaultUnifiedConfig = JHarmonizerConfigurationManager.parseUnifiedDefaultConfig();
-        UnifiedConfig mergedUnifiedConfig = UnifiedConfigMerger.merge(defaultUnifiedConfig, effectiveExternalConfig);
+        UnifiedConfig mergedUnifiedConfig = UnifiedConfigMerger.merge(defaultUnifiedConfig, externalConfig);
         return Unified2CompiledModelCompiler.compile(mergedUnifiedConfig);
-    }
-
-    /**
-     * Returns an external config copy with optional backups override applied.
-     *
-     * @param externalConfig the external configuration overrides
-     * @param backupsEnabledOverride optional backups-enabled runtime override
-     * @return adjusted external config; {@code null} when no external config/override is provided
-     */
-    @Nullable
-    public static FlexibleUnifiedConfig withBackupsEnabledOverride(
-            @Nullable FlexibleUnifiedConfig externalConfig, @Nullable Boolean backupsEnabledOverride) {
-        if (backupsEnabledOverride == null) {
-            return externalConfig;
-        }
-        if (externalConfig == null) {
-            return new FlexibleUnifiedConfig(null, null, backupsEnabledOverride, null, null);
-        }
-        return new FlexibleUnifiedConfig(
-                externalConfig.getTopLevelTypesOrdering().orElse(null),
-                externalConfig.getFormatting().orElse(null),
-                backupsEnabledOverride,
-                externalConfig.getHeaderLine().orElse(null),
-                externalConfig.getRootMemberGroups().orElse(null));
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
@@ -45,6 +45,33 @@ public class UnifiedConfigMerger {
                 .build();
     }
 
+    /**
+     * Performs a field-wise overlay of one flexible config onto another flexible config.
+     *
+     * @param baseline the baseline flexible config
+     * @param overlay the overlay flexible config
+     * @return merged flexible config
+     */
+    @NonNull
+    public static FlexibleUnifiedConfig merge(
+            @NonNull FlexibleUnifiedConfig baseline, @NonNull FlexibleUnifiedConfig overlay) {
+        UnifiedTopLevelTypesOrdering top = overlay.getTopLevelTypesOrdering()
+                .orElse(baseline.getTopLevelTypesOrdering().orElse(null));
+        UnifiedFormatting formatting =
+                overlay.getFormatting().orElse(baseline.getFormatting().orElse(null));
+        UnifiedHeaderLine header =
+                overlay.getHeaderLine().orElse(baseline.getHeaderLine().orElse(null));
+        Boolean backupsEnabled =
+                overlay.getBackupsEnabled().orElse(baseline.getBackupsEnabled().orElse(null));
+        List<UnifiedMemberGroup> root = overlay.getRootMemberGroups()
+                .map(overlayRootGroups -> baseline.getRootMemberGroups()
+                        .map(baselineRootGroups -> mergeRootMemberGroups(baselineRootGroups, overlayRootGroups))
+                        .orElse(overlayRootGroups))
+                .orElse(baseline.getRootMemberGroups().orElse(null));
+
+        return new FlexibleUnifiedConfig(top, formatting, backupsEnabled, header, root);
+    }
+
     @NonNull
     private static List<UnifiedMemberGroup> mergeRootMemberGroups(
             List<UnifiedMemberGroup> baselineRootGroups, List<UnifiedMemberGroup> overlayRootGroups) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
@@ -6,9 +6,9 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
+import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfigMerger;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.FileProcessingStatistic;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats.AggregatedProcessingStatistic;
@@ -264,8 +264,9 @@ class SourceProcessorTest {
         String unformattedSourceCode = "package demo; public class BackupOverrideDisabled {private int x;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupOverrideDisabled.java", unformattedSourceCode);
         String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        FlexibleUnifiedConfig effectiveConfig = ConfigurationManager.withBackupsEnabledOverride(
-                new FlexibleUnifiedConfig(null, null, true, null, null), false);
+        FlexibleUnifiedConfig effectiveConfig = UnifiedConfigMerger.merge(
+                new FlexibleUnifiedConfig(null, null, true, null, null),
+                new FlexibleUnifiedConfig(null, null, false, null, null));
         SourceProcessor sourceProcessor = new SourceProcessor(effectiveConfig);
 
         // When

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
@@ -245,6 +246,27 @@ class SourceProcessorTest {
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSourceCode);
         String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
         SourceProcessor sourceProcessor = new SourceProcessor(new FlexibleUnifiedConfig(null, null, false, null, null));
+
+        // When
+        sourceProcessor.processSources(
+                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+
+        // Then
+        Path backupFilePath =
+                javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
+        assertThat(backupFilePath).doesNotExist();
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSourceCode);
+    }
+
+    @Test
+    void processSources_restructureWithNoBackupOverride_doesNotCreateBackup() throws Exception {
+        // Given
+        String unformattedSourceCode = "package demo; public class BackupOverrideDisabled {private int x;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupOverrideDisabled.java", unformattedSourceCode);
+        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        FlexibleUnifiedConfig effectiveConfig = ConfigurationManager.withBackupsEnabledOverride(
+                new FlexibleUnifiedConfig(null, null, true, null, null), false);
+        SourceProcessor sourceProcessor = new SourceProcessor(effectiveConfig);
 
         // When
         sourceProcessor.processSources(

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
@@ -130,6 +130,44 @@ class UnifiedConfigMergerTest {
                 .hasMessageContaining("Baseline root member group names must be unique");
     }
 
+    @Test
+    void merge_flexibleOverlayProvided_overridesBackupsAndKeepsBaselineFields() {
+        // Given
+        FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
+                TOP_LEVEL_TYPES_ORDERING, FORMATTING, true, HEADER_LINE, List.of(createGroup("Default Rule")));
+        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, false, null, null);
+
+        // When
+        FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
+
+        // Then
+        assertThat(mergedConfig.getBackupsEnabled()).contains(false);
+        assertThat(mergedConfig.getFormatting()).contains(FORMATTING);
+        assertThat(mergedConfig.getTopLevelTypesOrdering()).contains(TOP_LEVEL_TYPES_ORDERING);
+        assertThat(mergedConfig.getHeaderLine()).contains(HEADER_LINE);
+        assertThat(mergedConfig.getRootMemberGroups()).contains(List.of(createGroup("Default Rule")));
+    }
+
+    @Test
+    void merge_flexibleRootGroupsProvided_mergesRootGroupsLikeStrictMerge() {
+        // Given
+        UnifiedMemberGroup baselineDefaultGroup = createGroup("Default Rule");
+        UnifiedMemberGroup baselineUnitsGroup = createGroup("Units");
+        FlexibleUnifiedConfig baselineConfig =
+                new FlexibleUnifiedConfig(null, null, null, null, List.of(baselineDefaultGroup, baselineUnitsGroup));
+        UnifiedMemberGroup replacementDefaultGroup = createGroup("Default Rule");
+        UnifiedMemberGroup newAuditGroup = createGroup("Audit");
+        FlexibleUnifiedConfig overlayConfig =
+                new FlexibleUnifiedConfig(null, null, null, null, List.of(replacementDefaultGroup, newAuditGroup));
+
+        // When
+        FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
+
+        // Then
+        assertThat(mergedConfig.getRootMemberGroups())
+                .contains(List.of(newAuditGroup, replacementDefaultGroup, baselineUnitsGroup));
+    }
+
     @NonNull
     private static UnifiedConfig createConfig(List<UnifiedMemberGroup> rootMemberGroups) {
         return UnifiedConfig.builder()


### PR DESCRIPTION
### Motivation

- Provide a way for users to disable creation of .bak backup files at runtime even when the configuration enables backups.

### Description

- Add a new CLI option `-B, --no-backup` to `BaseCommand` and propagate it through `CommandOptions` to the processor creation path.
- Extend `ConfigurationManager` with `withBackupsEnabledOverride(...)` and an overloaded `overrideDefaultConfig(...)` to apply an optional backups-enabled runtime override when merging external configs.
- Update `createSourceProcessor(...)` to build an effective external config with the backups override and pass it to `SourceProcessor`, and mark the `SourceProcessor(FlexibleUnifiedConfig)` parameter as nullable.
- Update CLI help output and tests to assert the new option is present and to verify that the no-backup flag prevents `.bak` creation and that the constructed processor receives a `FlexibleUnifiedConfig` with backups disabled.

### Testing

- Ran unit and integration tests covering CLI and core behavior (updated `BaseCommandTest`, `RestructureCommandTest`, `SourceProcessorTest` and e2e `JHarmonizerCliPackagedJarIT`).
- All automated tests completed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55f246d608325bc95393a5084c289)