### PR TITLE
Refactor CLI tests to use shared CommandLine setup and add variable-naming guideline

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,6 +50,7 @@
 - Do not add a second unmodifiable wrapper or defensive copy when the collection already stays immutable upstream or never leaves the local method scope.
 - Non-obvious build/configuration workarounds must include a nearby comment that explains why the workaround exists, which upstream component requires it, and when it can be removed.
 - When a piece of code intentionally keeps a non-obvious, previously reverted, or easy-to-"simplify" behavior because of an external constraint, leave a nearby comment that explains why it exists, what constraint it preserves, and why it should not be changed casually.
+- Prefer clear, fully descriptive variable names; avoid non-obvious abbreviations unless the abbreviation is an established term such as `URL`, `URI`, or `ID`, or an established repository abbreviation such as the `src*` naming family.
 - Build and validate with JDK 21. The standard repository command is `mvn -B -ntp verify`.
 
 ## Test conventions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -80,6 +80,8 @@
 ### Naming
 
 - JUnit test method names must follow exactly 3 segments: `subject_condition_expectedResult`.
+- This naming rule applies only to executable test methods (for example `@Test`, `@ParameterizedTest`, and other JUnit invocation annotations).
+- It does not apply to lifecycle and helper methods such as `@BeforeEach`, `@BeforeAll`, `@AfterEach`, `@AfterAll`, or private utilities; name those with normal Java conventions such as `setUp` or `tearDown`.
 - `subject` names what is being tested and usually mirrors the production method, command, or feature name.
 - `condition` states only the relevant precondition or input shape.
 - `expectedResult` states the observable outcome.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ This file defines repository-wide conventions for coding agents working in this 
 - Prefer static imports for frequently used assertion/helper methods when repeated type-qualified calls add noise.
 - Do not use `protected` fields; keep fields `private` and expose only the narrow protected accessor methods that subclasses actually need.
 - Prefer the shorter `src*` naming family (`srcFile`, `srcPath`, `srcCode`, `srcDiff`) for source-related variables and parameters.
+- Prefer clear, fully descriptive variable names; avoid non-obvious abbreviations unless the abbreviation is an established term (for example `URL`, `URI`, `ID`) or an established repository abbreviation such as the `src*` naming family.
 - Every non-private production method and constructor must have concise JavaDoc that states the purpose, documents parameters, and documents the return value when applicable.
   - Exception: do not add JavaDoc to standard `Object` overrides such as `equals`, `hashCode`, and `toString`.
 - Annotate every non-private method's reference-type parameters and non-primitive return type with explicit nullability using `lombok.NonNull`, `edu.umd.cs.findbugs.annotations.Nullable`, or the accepted legacy `javax.annotation` nullability annotations already present in the codebase.

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
@@ -12,23 +12,28 @@ import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import java.nio.file.Path;
 import java.util.Set;
 import lombok.NonNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import picocli.CommandLine;
 
 class BaseCommandTest {
 
+    private CommandLine commandLine;
+
+    @BeforeEach
+    void setUp_commandConfigured_initializeCommandLine() {
+        commandLine = new CommandLine(new TestCommand());
+    }
+
     @Test
     void call_baseDirOptionInvoked_passesNormalizedAbsoluteBaseDir() {
-        // Given
-        CommandLine cmd = new CommandLine(new TestCommand());
-
         // When
         int exitCode;
         SourceProcessor constructedProcessor;
         try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
             constructedProcessor = sourceProcessorMocks.constructed().getFirst();
         }
 
@@ -41,15 +46,12 @@ class BaseCommandTest {
 
     @Test
     void call_includeOptionInvoked_parsesIncludePatternCorrectly() {
-        // Given
-        CommandLine cmd = new CommandLine(new TestCommand());
-
         // When
         int exitCode;
         SourceProcessor constructedProcessor;
         try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute("--base-dir", "src", "--include", "**/*.java");
+            exitCode = commandLine.execute("--base-dir", "src", "--include", "**/*.java");
             constructedProcessor = sourceProcessorMocks.constructed().getFirst();
         }
 
@@ -61,15 +63,12 @@ class BaseCommandTest {
 
     @Test
     void call_mixedCollectionOptionsInvoked_combinesAllValuesCorrectly() {
-        // Given
-        CommandLine cmd = new CommandLine(new TestCommand());
-
         // When
         int exitCode;
         SourceProcessor constructedProcessor;
         try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute(
+            exitCode = commandLine.execute(
                     "-b",
                     "src",
                     "-i",
@@ -98,13 +97,10 @@ class BaseCommandTest {
 
     @Test
     void call_processingSucceeds_returnsExitCode0() {
-        // Given
-        CommandLine cmd = new CommandLine(new TestCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then
@@ -113,16 +109,13 @@ class BaseCommandTest {
 
     @Test
     void call_processorThrowsRuntimeException_returnsExitCode1() {
-        // Given
-        CommandLine cmd = new CommandLine(new TestCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
@@ -22,7 +22,7 @@ class BaseCommandTest {
     private CommandLine commandLine;
 
     @BeforeEach
-    void setUp_commandConfigured_initializeCommandLine() {
+    void setUp() {
         commandLine = new CommandLine(new TestCommand());
     }
 

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckAllCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckAllCommandTest.java
@@ -10,23 +10,28 @@ import static org.mockito.Mockito.when;
 import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import picocli.CommandLine;
 
 class CheckAllCommandTest {
 
+    private CommandLine commandLine;
+
+    @BeforeEach
+    void setUp_commandConfigured_initializeCommandLine() {
+        commandLine = new CommandLine(new CheckAllCommand());
+    }
+
     @Test
     void checkCommand_invoked_usesCheckAllFlow() {
-        // Given
-        CommandLine cmd = new CommandLine(new CheckAllCommand());
-
         // When
         int exitCode;
         SourceProcessor constructedProcessor;
         try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
             constructedProcessor = sourceProcessorMocks.constructed().getFirst();
         }
 
@@ -38,16 +43,13 @@ class CheckAllCommandTest {
 
     @Test
     void checkCommand_processorThrowsRuntimeException_returnsExitCode1() {
-        // Given
-        CommandLine cmd = new CommandLine(new CheckAllCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckAllCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckAllCommandTest.java
@@ -20,7 +20,7 @@ class CheckAllCommandTest {
     private CommandLine commandLine;
 
     @BeforeEach
-    void setUp_commandConfigured_initializeCommandLine() {
+    void setUp() {
         commandLine = new CommandLine(new CheckAllCommand());
     }
 

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckFastCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckFastCommandTest.java
@@ -13,23 +13,28 @@ import io.github.lemon_ant.jharmonizer.core.flow.NotFormattedException;
 import io.github.lemon_ant.jharmonizer.core.flow.NotOrderedException;
 import java.nio.file.Path;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import picocli.CommandLine;
 
 class CheckFastCommandTest {
 
+    private CommandLine commandLine;
+
+    @BeforeEach
+    void setUp_commandConfigured_initializeCommandLine() {
+        commandLine = new CommandLine(new CheckFastCommand());
+    }
+
     @Test
     void checkFastCommand_invoked_usesCheckFailFastFlow() {
-        // Given
-        CommandLine cmd = new CommandLine(new CheckFastCommand());
-
         // When
         int exitCode;
         SourceProcessor constructedProcessor;
         try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
             constructedProcessor = sourceProcessorMocks.constructed().getFirst();
         }
 
@@ -42,16 +47,13 @@ class CheckFastCommandTest {
 
     @Test
     void checkFastCommand_formattingChangesDetected_returnsExitCode3() {
-        // Given
-        CommandLine cmd = new CommandLine(new CheckFastCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new NotFormattedException(Path.of("SomeFile.java"), "--- diff ---"));
         })) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then
@@ -60,16 +62,13 @@ class CheckFastCommandTest {
 
     @Test
     void checkFastCommand_orderingChangesDetected_returnsExitCode3() {
-        // Given
-        CommandLine cmd = new CommandLine(new CheckFastCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new NotOrderedException(Path.of("SomeFile.java"), List.of()));
         })) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then
@@ -78,16 +77,13 @@ class CheckFastCommandTest {
 
     @Test
     void checkFastCommand_processorThrowsRuntimeException_returnsExitCode1() {
-        // Given
-        CommandLine cmd = new CommandLine(new CheckFastCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckFastCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckFastCommandTest.java
@@ -23,7 +23,7 @@ class CheckFastCommandTest {
     private CommandLine commandLine;
 
     @BeforeEach
-    void setUp_commandConfigured_initializeCommandLine() {
+    void setUp() {
         commandLine = new CommandLine(new CheckFastCommand());
     }
 

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
@@ -15,12 +15,15 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.NonNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedConstruction;
 import picocli.CommandLine;
 
 class RestructureCommandTest {
+
+    private CommandLine commandLine;
 
     private static final String SOURCE_WITH_MULTIPLE_TOP_LEVEL_TYPES = """
             package demo;
@@ -39,17 +42,19 @@ class RestructureCommandTest {
     @TempDir
     Path temporaryDirectory;
 
+    @BeforeEach
+    void setUp_commandConfigured_initializeCommandLine() {
+        commandLine = new CommandLine(new RestructureCommand());
+    }
+
     @Test
     void restructureCommand_invoked_usesRestructureFlow() {
-        // Given
-        CommandLine cmd = new CommandLine(new RestructureCommand());
-
         // When
         int exitCode;
         SourceProcessor constructedProcessor;
         try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
-            exitCode = cmd.execute("--base-dir", "src/main/java");
+            exitCode = commandLine.execute("--base-dir", "src/main/java");
             constructedProcessor = sourceProcessorMocks.constructed().getFirst();
         }
 
@@ -66,11 +71,10 @@ class RestructureCommandTest {
     @Test
     void restructureCommand_helpUsage_describeOptionAliasesAndCollectionFormats() {
         // Given
-        CommandLine cmd = new CommandLine(new RestructureCommand());
         StringWriter usage = new StringWriter();
 
         // When
-        cmd.usage(new PrintWriter(usage), CommandLine.Help.Ansi.OFF);
+        commandLine.usage(new PrintWriter(usage), CommandLine.Help.Ansi.OFF);
 
         // Then
         assertThat(usage.toString())
@@ -90,10 +94,9 @@ class RestructureCommandTest {
                 SOURCE_WITH_MULTIPLE_TOP_LEVEL_TYPES,
                 StandardCharsets.UTF_8);
         Path configFilePath = writeConfigFile(temporaryDirectory.resolve("custom-config.yml"));
-        CommandLine cmd = new CommandLine(new RestructureCommand());
 
         // When
-        int exitCode = cmd.execute("--base-dir", temporaryDirectory.toString(), "--config", configFilePath.toString());
+        int exitCode = commandLine.execute("--base-dir", temporaryDirectory.toString(), "--config", configFilePath.toString());
 
         // Then
         assertThat(exitCode).isZero();
@@ -104,16 +107,13 @@ class RestructureCommandTest {
 
     @Test
     void restructureCommand_processorThrowsRuntimeException_returnsExitCode1() {
-        // Given
-        CommandLine cmd = new CommandLine(new RestructureCommand());
-
         // When
         int exitCode;
         try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {
-            exitCode = cmd.execute("--base-dir", "src");
+            exitCode = commandLine.execute("--base-dir", "src");
         }
 
         // Then

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
@@ -43,7 +43,7 @@ class RestructureCommandTest {
     Path temporaryDirectory;
 
     @BeforeEach
-    void setUp_commandConfigured_initializeCommandLine() {
+    void setUp() {
         commandLine = new CommandLine(new RestructureCommand());
     }
 

--- a/docs/test-conventions.md
+++ b/docs/test-conventions.md
@@ -48,6 +48,11 @@ Rules:
 
   `subject_condition_expectedResult`
 
+Scope note:
+
+- This naming rule applies only to executable test methods (for example methods annotated with `@Test`, `@ParameterizedTest`, and other JUnit test-invocation annotations).
+- It does **not** apply to lifecycle and helper methods such as `@BeforeEach`, `@BeforeAll`, `@AfterEach`, `@AfterAll`, or private utility methods; name those with normal Java conventions (for example `setUp`, `tearDown`, `createSampleFile`).
+
 Examples:
 
 - `compileConfig_validYaml_produceSingleRootGroup`


### PR DESCRIPTION
### Motivation
- Reduce duplication and make CLI command tests clearer by centralizing `CommandLine` construction into a single per-test setup method.
- Improve repository guidance by encouraging clear, fully descriptive variable names in contributor-facing docs.

### Description
- Added a `private CommandLine commandLine` field and a `@BeforeEach` setup method `setUp_commandConfigured_initializeCommandLine()` to `BaseCommandTest`, `CheckAllCommandTest`, `CheckFastCommandTest`, and `RestructureCommandTest` and updated tests to call `commandLine.execute(...)` instead of constructing `new CommandLine(...)` inline.
- Imported `org.junit.jupiter.api.BeforeEach` where required and removed in-test `CommandLine` constructions to reduce repetition.
- Added a new style guideline line to `.github/copilot-instructions.md` and `AGENTS.md` that prefers clear, fully descriptive variable names and advises against non-obvious abbreviations.

### Testing
- Ran the updated unit tests for the CLI command classes (`BaseCommandTest`, `CheckAllCommandTest`, `CheckFastCommandTest`, `RestructureCommandTest`) and they all passed.
- Ran the standard build verification (`mvn -B -ntp verify`) and the build completed successfully with tests passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c55f73e1c083259ac48ae7a90cdec5)