### PR TITLE
Add SKIPPED processing status for fully opted-out files

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java
@@ -115,7 +115,6 @@ abstract class AbstractOptOutFlow implements IFlow {
     protected static FlowProcessingResult buildFullyOffFileSkippedResult(
             @NonNull SrcFile srcFile,
             @NonNull ParsingResult parsingResult,
-            boolean checkingOnly,
             @NonNull String skippedOperationDescription) {
         logFileOptOutSkip(srcFile, skippedOperationDescription, JHarmonizerOptOutMode.FULLY_OFF);
         return FlowProcessingResult.builder()

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.flow;
 
-import static io.github.lemon_ant.jharmonizer.core.flow.FlowProcessingStatus.defineFlowProcessingStatus;
+import static io.github.lemon_ant.jharmonizer.core.flow.FlowProcessingStatus.SKIPPED;
 
 import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFile;
 import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
@@ -128,7 +128,7 @@ abstract class AbstractOptOutFlow implements IFlow {
                         new SerializationStatistic(srcFile.getSrcCode().length(), 0))
                 .formattingStatistic(
                         new FormattingStatistic(srcFile.getSrcCode().length(), 0))
-                .flowProcessingStatus(defineFlowProcessingStatus(false, false, checkingOnly))
+                .flowProcessingStatus(SKIPPED)
                 .build();
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckAllFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckAllFlow.java
@@ -44,7 +44,7 @@ public class CheckAllFlow extends AbstractOptOutFlow {
         ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
         SpoonAstModel parsedSpoonAstModel = parsingResult.getSpoonAstModel();
         if (parsedSpoonAstModel.getOptOuts().hasFileOptOutMode(JHarmonizerOptOutMode.FULLY_OFF)) {
-            return buildFullyOffFileSkippedResult(srcFile, parsingResult, true, "all harmonization checks");
+            return buildFullyOffFileSkippedResult(srcFile, parsingResult, "all harmonization checks");
         }
 
         SortingSerializationAndFormattingResult sortingSerializationAndFormattingResult =

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckFailFastFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckFailFastFlow.java
@@ -47,7 +47,7 @@ public class CheckFailFastFlow extends AbstractOptOutFlow {
         ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
         SpoonAstModel parsedSpoonAstModel = parsingResult.getSpoonAstModel();
         if (parsedSpoonAstModel.getOptOuts().hasFileOptOutMode(JHarmonizerOptOutMode.FULLY_OFF)) {
-            return buildFullyOffFileSkippedResult(srcFile, parsingResult, true, "all harmonization checks");
+            return buildFullyOffFileSkippedResult(srcFile, parsingResult, "all harmonization checks");
         }
 
         SortingAndSerializationResult sortingAndSerializationResult =

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowProcessingStatus.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowProcessingStatus.java
@@ -6,12 +6,14 @@ import lombok.NonNull;
  * Outcome status of processing a single source file through a flow.
  * {@code REORDERED} means member order changed, {@code FORMATTED} means only formatting changed,
  * {@code CHECKED} means the file was verified and no changes were needed,
+ * {@code SKIPPED} means the file was intentionally skipped due to a file-level opt-out directive,
  * and {@code UNCHANGED} means the file was left as-is in a non-checking flow.
  */
 public enum FlowProcessingStatus {
     REORDERED,
     FORMATTED,
     CHECKED,
+    SKIPPED,
     UNCHANGED,
     ;
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/RestructureFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/RestructureFlow.java
@@ -48,7 +48,7 @@ public class RestructureFlow extends AbstractOptOutFlow {
         ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
         SpoonAstModel parsedSpoonAstModel = parsingResult.getSpoonAstModel();
         if (parsedSpoonAstModel.getOptOuts().hasFileOptOutMode(JHarmonizerOptOutMode.FULLY_OFF)) {
-            return buildFullyOffFileSkippedResult(srcFile, parsingResult, false, "all harmonization");
+            return buildFullyOffFileSkippedResult(srcFile, parsingResult, "all harmonization");
         }
 
         SortingSerializationAndFormattingResult sortingSerializationAndFormattingResult =

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java
@@ -201,6 +201,30 @@ class SourceProcessorTest {
     }
 
     @Test
+    void processSources_fullyOffFile_logsSkippedStatus() throws Exception {
+        // Given
+        String fullyOffSourceCode = "// @jharmonizer:fully-off\npackage demo; public class FullyOffSample {}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "FullyOffSample.java", fullyOffSourceCode);
+        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        SourceProcessor sourceProcessor = new SourceProcessor();
+        ListAppender<ILoggingEvent> listAppender = attachListAppender();
+
+        // When
+        try {
+            sourceProcessor.processSources(
+                    temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        } finally {
+            detachListAppender(listAppender);
+        }
+        String logs = collectLogMessages(listAppender);
+
+        // Then
+        assertThat(logs).contains("FullyOffSample.java");
+        assertThat(logs).contains("JHarmonizer SKIPPED");
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSourceCode);
+    }
+
+    @Test
     void processSources_partialConfigFile_reordersUsingMergedDefaults() throws Exception {
         // Given
         Path javaFilePath = writeJavaFile(temporaryDirectory, "Sample.java", SOURCE_WITH_MULTIPLE_TOP_LEVEL_TYPES);


### PR DESCRIPTION
### Motivation
- Make files that are fully excluded from harmonization via the file-level opt-out directive explicitly visible in per-file logs as skipped so their processing status is consistent with other outcomes.

### Description
- Add a new enum constant `SKIPPED` to `FlowProcessingStatus` to represent files intentionally skipped due to a file-level opt-out.
- Return `FlowProcessingStatus.SKIPPED` from `AbstractOptOutFlow.buildFullyOffFileSkippedResult` instead of deriving a status via `defineFlowProcessingStatus`.
- Add an integration-style test `processSources_fullyOffFile_logsSkippedStatus` in `SourceProcessorTest` that asserts the `JHarmonizer SKIPPED` log entry is emitted and the file content remains unchanged.
- Modified files: `core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowProcessingStatus.java`, `core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java`, and `core/src/test/java/io/github/lemon_ant/jharmonizer/core/SourceProcessorTest.java`.

### Testing
- Executed `mvn -pl core -Dpmd.skip=true -Dtest=SourceProcessorTest test` and the `SourceProcessorTest` class completed successfully (BUILD SUCCESS).
- Running `mvn -pl core -Dtest=SourceProcessorTest test` without skipping PMD fails due to an existing, unrelated PMD violation in `UnifiedConfigMerger`, not introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c66996923083259e0ba3ca1e7da2b4)