### PR TITLE
chore: update Maven dependencies and clarify Jackson transitive-security workaround

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,8 @@
         <argLine/>
         <!-- Late-bound by Failsafe so integration-test coverage can inject its agent without unresolved placeholders. -->
         <failsafeArgLine/>
-        <jackson.version>2.21.1</jackson.version>
-        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <jackson.version>2.21.2</jackson.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <jacoco.minimum.line.coverage>0.75</jacoco.minimum.line.coverage>
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
@@ -33,13 +33,13 @@
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven.compiler.release>21</maven.compiler.release>
-        <palantir-java-format.version>2.89.0</palantir-java-format.version>
-        <pmd.version>7.22.0</pmd.version>
+        <palantir-java-format.version>2.90.0</palantir-java-format.version>
+        <pmd.version>7.23.0</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
         <spotbugs.version>4.9.8</spotbugs.version>
-        <spotless-maven-plugin.version>3.3.0</spotless-maven-plugin.version>
+        <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -52,8 +52,8 @@
                 <scope>import</scope>
             </dependency>
             <!--
-                Temporary transitive vulnerability workaround: palantir-java-format 2.89.0 currently resolves Jackson
-                modules to 2.21.0, which overrides this project's intended patched Jackson line.
+                Temporary transitive vulnerability workaround: palantir-java-format 2.90.0 still resolves Jackson
+                modules to 2.21.1, which is behind this project's patched Jackson line.
                 Import the BOM here so all Jackson modules stay pinned to ${jackson.version} until that upstream
                 dependency tree is updated and no longer forces an older Jackson version. Remove this override once
                 palantir-java-format (or any other direct dependency that brings Jackson transitively) stops resolving


### PR DESCRIPTION
### Motivation
- Keep build tooling and libraries on the latest stable lines from Maven Central to pick up bug fixes and security patches. 
- Ensure any explicit transitive-security overrides remain necessary and documented so we do not silently reintroduce vulnerable transitives.

### Description
- Updated versions in `pom.xml` for managed tooling and plugins: `jackson.version` `2.21.1 -> 2.21.2`, `jacoco-maven-plugin.version` `0.8.13 -> 0.8.14`, `palantir-java-format.version` `2.89.0 -> 2.90.0`, `pmd.version` `7.22.0 -> 7.23.0`, and `spotless-maven-plugin.version` `3.3.0 -> 3.4.0`.
- Adjusted the existing Jackson BOM transitive-workaround comment to reflect that `palantir-java-format:2.90.0` still pulls older Jackson modules (2.21.1) so the explicit `jackson-bom` pin remains required and the removal condition is documented.
- Kept plugin choices compatible with Maven 3 (did not migrate to Maven 4-only beta/milestone releases).

### Testing
- Ran `mvn -DskipTests -DprocessAllModules=true versions:display-property-updates versions:display-dependency-updates versions:display-plugin-updates` to find and confirm available updates, which completed successfully.
- Verified Jackson transitive resolution with `mvn -pl core dependency:tree -Dincludes=com.fasterxml.jackson.*:* -Dverbose` and confirmed `palantir-java-format:2.90.0` still requests older Jackson modules (so override is still necessary).
- Performed a full module build `mvn -DskipTests verify` which completed with `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b832b850832588b394c3b2ec8edb)