### PR TITLE
Add e2e test case for header-comment-already-present (separator variants)

### DIFF
--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/HeaderCommentAlreadyPresentSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/expected/HeaderCommentAlreadyPresentSample.java
@@ -1,0 +1,10 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class HeaderCommentAlreadyPresentSample {
+
+    // Header fields
+    int alpha;
+    int bravo;
+
+    void alphaMethod() {}
+}

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/input/HeaderCommentAlreadyPresentSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/input/HeaderCommentAlreadyPresentSample.java
@@ -1,0 +1,10 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class HeaderCommentAlreadyPresentSample {
+
+    // Header fields
+    int alpha;
+    int bravo;
+
+    void alphaMethod() {}
+}


### PR DESCRIPTION
### Motivation
- Add an end-to-end test case that verifies behavior when a class already contains a header comment for the separator-variants restructure scenario.

### Description
- Add `HeaderCommentAlreadyPresentSample.java` under both `core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/input` and `.../expected` to cover the existing-header-comment case.

### Testing
- Ran the core E2E restructure test set for the `08-separator-variants` cases via the project test suite and the new input/expected pair passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b78efdfc83259907d13e52eb32c0)