### PR TITLE
Rename Source* identifiers to Src* and update related APIs

### DIFF
--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -3,7 +3,7 @@ package io.github.lemon_ant.jharmonizer.cli.command;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfigMerger;
@@ -139,9 +139,9 @@ abstract class BaseCommand implements Callable<Integer> {
                 "Processing sources with flow {} in: {} using config: {}",
                 flowType,
                 commandOptions.getBaseDir(),
-                describeConfigSource(commandOptions.getConfigFilePath()));
+                describeConfigSrc(commandOptions.getConfigFilePath()));
         try {
-            createSourceProcessor(commandOptions.getConfigFilePath(), commandOptions.isNoBackup())
+            createSrcProcessor(commandOptions.getConfigFilePath(), commandOptions.isNoBackup())
                     .processSources(
                             commandOptions.getBaseDir(),
                             commandOptions.getIncludeGlobs(),
@@ -155,14 +155,14 @@ abstract class BaseCommand implements Callable<Integer> {
     }
 
     @NonNull
-    private static SourceProcessor createSourceProcessor(@Nullable Path configFilePath, boolean disableBackups) {
+    private static SrcProcessor createSrcProcessor(@Nullable Path configFilePath, boolean disableBackups) {
         FlexibleUnifiedConfig externalConfig = configFilePath != null
                 ? JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(configFilePath)
                 : null;
         FlexibleUnifiedConfig backupsOverrideConfig =
                 disableBackups ? new FlexibleUnifiedConfig(null, null, false, null, null) : null;
         FlexibleUnifiedConfig effectiveConfig = mergeFlexibleConfigs(externalConfig, backupsOverrideConfig);
-        return new SourceProcessor(effectiveConfig);
+        return new SrcProcessor(effectiveConfig);
     }
 
     @Nullable
@@ -183,7 +183,7 @@ abstract class BaseCommand implements Callable<Integer> {
     }
 
     @NonNull
-    private static String describeConfigSource(@Nullable Path configFilePath) {
+    private static String describeConfigSrc(@Nullable Path configFilePath) {
         return configFilePath != null
                 ? configFilePath.toString()
                 : "embedded default resource config (/default-config.yml)";

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
-import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats.AggregatedProcessingStatistic;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
@@ -34,11 +34,11 @@ class BaseCommandTest {
     void call_baseDirOptionInvoked_passesNormalizedAbsoluteBaseDir() {
         // When
         int exitCode;
-        SourceProcessor constructedProcessor;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+        SrcProcessor constructedProcessor;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute("--base-dir", "src");
-            constructedProcessor = sourceProcessorMocks.constructed().getFirst();
+            constructedProcessor = srcProcessorMocks.constructed().getFirst();
         }
 
         // Then
@@ -52,11 +52,11 @@ class BaseCommandTest {
     void call_includeOptionInvoked_parsesIncludePatternCorrectly() {
         // When
         int exitCode;
-        SourceProcessor constructedProcessor;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+        SrcProcessor constructedProcessor;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute("--base-dir", "src", "--include", "**/*.java");
-            constructedProcessor = sourceProcessorMocks.constructed().getFirst();
+            constructedProcessor = srcProcessorMocks.constructed().getFirst();
         }
 
         // Then
@@ -69,8 +69,8 @@ class BaseCommandTest {
     void call_mixedCollectionOptionsInvoked_combinesAllValuesCorrectly() {
         // When
         int exitCode;
-        SourceProcessor constructedProcessor;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+        SrcProcessor constructedProcessor;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute(
                     "-b",
@@ -83,7 +83,7 @@ class BaseCommandTest {
                     "**/internal/**",
                     "--exclude",
                     "**/excluded/**,**/*Test.java");
-            constructedProcessor = sourceProcessorMocks.constructed().getFirst();
+            constructedProcessor = srcProcessorMocks.constructed().getFirst();
         }
 
         // Then
@@ -103,7 +103,7 @@ class BaseCommandTest {
     void call_processingSucceeds_returnsExitCode0() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = CommandTestUtils.mockSuccessfulProcessorConstruction()) {
+        try (MockedConstruction<SrcProcessor> ignored = CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute("--base-dir", "src");
         }
 
@@ -112,15 +112,15 @@ class BaseCommandTest {
     }
 
     @Test
-    void call_noBackupOptionInvoked_disablesBackupsInSourceProcessor() {
+    void call_noBackupOptionInvoked_disablesBackupsInSrcProcessor() {
         // Given
         CommandLine cmd = new CommandLine(new TestCommand());
         AtomicReference<List<?>> constructorArguments = new AtomicReference<>();
 
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
-                mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
+                mockConstruction(SrcProcessor.class, (mock, context) -> {
                     constructorArguments.set(context.arguments());
                     when(mock.processSources(any(Path.class), any(), any(), any()))
                             .thenReturn(new AggregatedProcessingStatistic(0, 0, 0, null, null));
@@ -141,7 +141,7 @@ class BaseCommandTest {
     void call_processorThrowsRuntimeException_returnsExitCode1() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> ignored = mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckAllCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckAllCommandTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,11 +28,11 @@ class CheckAllCommandTest {
     void checkCommand_invoked_usesCheckAllFlow() {
         // When
         int exitCode;
-        SourceProcessor constructedProcessor;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+        SrcProcessor constructedProcessor;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute("--base-dir", "src");
-            constructedProcessor = sourceProcessorMocks.constructed().getFirst();
+            constructedProcessor = srcProcessorMocks.constructed().getFirst();
         }
 
         // Then
@@ -45,7 +45,7 @@ class CheckAllCommandTest {
     void checkCommand_processorThrowsRuntimeException_returnsExitCode1() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> ignored = mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckFastCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CheckFastCommandTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.flow.NotFormattedException;
 import io.github.lemon_ant.jharmonizer.core.flow.NotOrderedException;
@@ -31,11 +31,11 @@ class CheckFastCommandTest {
     void checkFastCommand_invoked_usesCheckFailFastFlow() {
         // When
         int exitCode;
-        SourceProcessor constructedProcessor;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+        SrcProcessor constructedProcessor;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute("--base-dir", "src");
-            constructedProcessor = sourceProcessorMocks.constructed().getFirst();
+            constructedProcessor = srcProcessorMocks.constructed().getFirst();
         }
 
         // Then
@@ -49,7 +49,7 @@ class CheckFastCommandTest {
     void checkFastCommand_formattingChangesDetected_returnsExitCode3() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> ignored = mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new NotFormattedException(Path.of("SomeFile.java"), "--- diff ---"));
         })) {
@@ -64,7 +64,7 @@ class CheckFastCommandTest {
     void checkFastCommand_orderingChangesDetected_returnsExitCode3() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> ignored = mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new NotOrderedException(Path.of("SomeFile.java"), List.of()));
         })) {
@@ -79,7 +79,7 @@ class CheckFastCommandTest {
     void checkFastCommand_processorThrowsRuntimeException_returnsExitCode1() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> ignored = mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CommandTestUtils.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/CommandTestUtils.java
@@ -4,8 +4,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.when;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
-import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats.AggregatedProcessingStatistic;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
 import java.nio.file.Path;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -15,8 +15,8 @@ import org.mockito.MockedConstruction;
 class CommandTestUtils {
 
     @NonNull
-    static MockedConstruction<SourceProcessor> mockSuccessfulProcessorConstruction() {
-        return mockConstruction(SourceProcessor.class, (mock, context) -> {
+    static MockedConstruction<SrcProcessor> mockSuccessfulProcessorConstruction() {
+        return mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenReturn(new AggregatedProcessingStatistic(0, 0, 0, null, null));
         });

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
@@ -7,7 +7,7 @@ import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -51,11 +51,11 @@ class RestructureCommandTest {
     void restructureCommand_invoked_usesRestructureFlow() {
         // When
         int exitCode;
-        SourceProcessor constructedProcessor;
-        try (MockedConstruction<SourceProcessor> sourceProcessorMocks =
+        SrcProcessor constructedProcessor;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
                 CommandTestUtils.mockSuccessfulProcessorConstruction()) {
             exitCode = commandLine.execute("--base-dir", "src/main/java");
-            constructedProcessor = sourceProcessorMocks.constructed().getFirst();
+            constructedProcessor = srcProcessorMocks.constructed().getFirst();
         }
 
         // Then
@@ -102,16 +102,15 @@ class RestructureCommandTest {
 
         // Then
         assertThat(exitCode).isZero();
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        assertThat(processedSourceCode.indexOf("interface Alpha"))
-                .isLessThan(processedSourceCode.indexOf("class Sample"));
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        assertThat(processedSrcCode.indexOf("interface Alpha")).isLessThan(processedSrcCode.indexOf("class Sample"));
     }
 
     @Test
     void restructureCommand_processorThrowsRuntimeException_returnsExitCode1() {
         // When
         int exitCode;
-        try (MockedConstruction<SourceProcessor> ignored = mockConstruction(SourceProcessor.class, (mock, context) -> {
+        try (MockedConstruction<SrcProcessor> ignored = mockConstruction(SrcProcessor.class, (mock, context) -> {
             when(mock.processSources(any(Path.class), any(), any(), any()))
                     .thenThrow(new RuntimeException("Unexpected error"));
         })) {

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -361,10 +361,10 @@ class JHarmonizerCliPackagedJarIT {
     }
 
     @NonNull
-    private Path copyDirectory(Path sourceDirectory, String targetDirectoryName) throws IOException {
+    private Path copyDirectory(Path srcDirectory, String targetDirectoryName) throws IOException {
         Path targetDirectory = temporaryDirectory.resolve(targetDirectoryName);
         Files.createDirectories(targetDirectory);
-        FileUtils.copyDirectory(sourceDirectory.toFile(), targetDirectory.toFile());
+        FileUtils.copyDirectory(srcDirectory.toFile(), targetDirectory.toFile());
         return targetDirectory;
     }
 

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/TemporaryProjectCopier.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/TemporaryProjectCopier.java
@@ -13,9 +13,9 @@ import org.apache.commons.io.FileUtils;
 class TemporaryProjectCopier {
 
     static Path copyProject(@NonNull String resourceRoot, @NonNull Path targetDirectory) throws IOException {
-        Path sourceDirectory = locateOriginalTestResource(resourceRoot);
+        Path srcDirectory = locateOriginalTestResource(resourceRoot);
         Files.createDirectories(targetDirectory);
-        FileUtils.copyDirectory(sourceDirectory.toFile(), targetDirectory.toFile());
+        FileUtils.copyDirectory(srcDirectory.toFile(), targetDirectory.toFile());
         return targetDirectory;
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
@@ -4,7 +4,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
-import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.CheckAllFlow;
 import io.github.lemon_ant.jharmonizer.core.flow.CheckFailFastFlow;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
@@ -13,8 +13,8 @@ import io.github.lemon_ant.jharmonizer.core.flow.RestructureFlow;
 import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.FileProcessingStatistic;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.PathDisplayFormatUtil;
-import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats;
-import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats.AggregatedProcessingStatistic;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
 import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @SuppressWarnings("PMD.GuardLogStatement")
-public final class SourceProcessor {
+public final class SrcProcessor {
 
     private static final String SINGLE_FILE_LOG_PREFIX = "JHarmonizer";
     private static final int MAX_TOTAL_PATH_LENGTH = 100;
@@ -41,22 +41,22 @@ public final class SourceProcessor {
     private final Sorter sorter;
 
     /**
-     * Creates a new SourceProcessor.
+     * Creates a new SrcProcessor.
      */
-    public SourceProcessor() {
+    public SrcProcessor() {
         this((FlexibleUnifiedConfig) null);
     }
 
     /**
-     * Primary constructor for SourceProcessor embedded into some wrapper.
+     * Primary constructor for SrcProcessor embedded into some wrapper.
      *
      * @param externalConfig optional external configuration overlay
      */
-    public SourceProcessor(@Nullable FlexibleUnifiedConfig externalConfig) {
+    public SrcProcessor(@Nullable FlexibleUnifiedConfig externalConfig) {
         this(ConfigurationManager.overrideDefaultConfig(externalConfig));
     }
 
-    private SourceProcessor(CompiledConfig compiledConfig) {
+    private SrcProcessor(CompiledConfig compiledConfig) {
         this(
                 compiledConfig,
                 new Formatter(
@@ -94,14 +94,14 @@ public final class SourceProcessor {
                     case CHECK_FAIL_FAST -> new CheckFailFastFlow(formatter, sorter);
                 };
 
-        AggregatedProcessingStatistic aggregatedProcessingStatistic = SourceFilesHandler.readJavaFiles(
+        AggregatedProcessingStatistic aggregatedProcessingStatistic = SrcFilesHandler.readJavaFiles(
                         baseDir, includeGlobs, excludeGlobs)
-                .map(flow::processSource)
+                .map(flow::processSrc)
                 .peek(flowProcessingResult -> log.info(formatSingleFileLogMessage(
                         flowProcessingResult.getPath(),
                         flowProcessingResult.getFlowProcessingStatus().name())))
                 .map(FileProcessingStatistic::convert)
-                .collect(SourceProcessingStats.statsCollector());
+                .collect(SrcProcessingStats.statsCollector());
 
         log.info(aggregatedProcessingStatistic.toString());
         return aggregatedProcessingStatistic;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandler.java
@@ -17,7 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @UtilityClass
-public class SourceFilesHandler {
+public class SrcFilesHandler {
 
     /**
      * Recursively resolves all {@code .java} files that match the provided include and exclude globs.
@@ -51,7 +51,7 @@ public class SourceFilesHandler {
     @NonNull
     public static Stream<SrcFile> readJavaFiles(
             @NonNull Path baseDir, @NonNull Collection<String> includeGlobs, @NonNull Collection<String> excludeGlobs) {
-        return findJavaFiles(baseDir, includeGlobs, excludeGlobs).map(SourceFilesHandler::readFile);
+        return findJavaFiles(baseDir, includeGlobs, excludeGlobs).map(SrcFilesHandler::readFile);
     }
 
     /**
@@ -93,15 +93,15 @@ public class SourceFilesHandler {
      * @param sourceFile the source file to back up
      */
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
-    public static void renameToBackup(@NonNull Path sourceFile) {
-        if (!Files.exists(sourceFile) || !Files.isRegularFile(sourceFile)) {
+    public static void renameToBackup(@NonNull Path srcFile) {
+        if (!Files.exists(srcFile) || !Files.isRegularFile(srcFile)) {
             throw new UncheckedIOException(
-                    new IOException("Source file does not exist or is not a valid file: " + sourceFile));
+                    new IOException("Source file does not exist or is not a valid file: " + srcFile));
         }
 
-        Path backupPath = sourceFile.resolveSibling(sourceFile.getFileName().toString() + ".bak");
+        Path backupPath = srcFile.resolveSibling(srcFile.getFileName().toString() + ".bak");
         try {
-            Files.move(sourceFile, backupPath);
+            Files.move(srcFile, backupPath);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/AbstractOptOutFlow.java
@@ -14,8 +14,8 @@ import io.github.lemon_ant.jharmonizer.core.sorter.SortingStatistic;
 import io.github.lemon_ant.jharmonizer.core.translator.ParsingResult;
 import io.github.lemon_ant.jharmonizer.core.translator.SerializationResult;
 import io.github.lemon_ant.jharmonizer.core.translator.SerializationStatistic;
-import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
-import io.github.lemon_ant.jharmonizer.core.translator.SourceAstTranslator;
+import io.github.lemon_ant.jharmonizer.core.translator.SerializedSrcWithSkippedTypeRanges;
+import io.github.lemon_ant.jharmonizer.core.translator.SrcAstTranslator;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import java.util.Map;
 import java.util.Optional;
@@ -47,16 +47,16 @@ abstract class AbstractOptOutFlow implements IFlow {
     }
 
     @NonNull
-    protected final SortingAndSerializationResult sortAndSerializeOrReuseOriginalSource(
+    protected final SortingAndSerializationResult sortAndSerializeOrReuseOriginalSrc(
             @NonNull SrcFile srcFile,
             @NonNull SpoonAstModel parsedSpoonAstModel,
             @NonNull String skippedOperationDescription) {
         Optional<JHarmonizerOptOutMode> fileOptOutMode =
                 parsedSpoonAstModel.getOptOuts().getFileOptOutMode();
-        boolean reuseOriginalSource = fileOptOutMode
+        boolean reuseOriginalSrc = fileOptOutMode
                 .map(mode -> mode == JHarmonizerOptOutMode.FULLY_OFF || mode == JHarmonizerOptOutMode.SORTING_OFF)
                 .orElse(false);
-        if (reuseOriginalSource) {
+        if (reuseOriginalSrc) {
             JHarmonizerOptOutMode reuseMode = fileOptOutMode.orElseThrow();
             logFileOptOutSkip(srcFile, skippedOperationDescription, reuseMode);
             String originalSrcCode = srcFile.getSrcCode();
@@ -64,7 +64,7 @@ abstract class AbstractOptOutFlow implements IFlow {
                     new SortingResult(parsedSpoonAstModel, new SortingStatistic(0)),
                     new SerializationResult(
                             new SerializationStatistic(originalSrcCode.length(), 0),
-                            new SerializedSourceWithSkippedTypeRanges(
+                            new SerializedSrcWithSkippedTypeRanges(
                                     originalSrcCode,
                                     reuseMode == JHarmonizerOptOutMode.SORTING_OFF
                                             ? OptOutFormattingRangeResolver.resolveFullyOffTypeRanges(
@@ -74,7 +74,7 @@ abstract class AbstractOptOutFlow implements IFlow {
         }
 
         SortingResult sortingResult = getSorter().sort(parsedSpoonAstModel);
-        SerializationResult serializationResult = SourceAstTranslator.serialize(sortingResult.getSortedSpoonAstModel());
+        SerializationResult serializationResult = SrcAstTranslator.serialize(sortingResult.getSortedSpoonAstModel());
         return new SortingAndSerializationResult(sortingResult, serializationResult, false);
     }
 
@@ -87,22 +87,22 @@ abstract class AbstractOptOutFlow implements IFlow {
      * @return the combined sorting and formatting pipeline result
      */
     @NonNull
-    protected final SortingSerializationAndFormattingResult sortSerializeAndFormatSource(
+    protected final SortingSerializationAndFormattingResult sortSerializeAndFormatSrc(
             @NonNull SrcFile srcFile, @NonNull SpoonAstModel parsedSpoonAstModel, @NonNull String sortingDescription) {
         SortingAndSerializationResult sortingAndSerializationResult =
-                sortAndSerializeOrReuseOriginalSource(srcFile, parsedSpoonAstModel, sortingDescription);
+                sortAndSerializeOrReuseOriginalSrc(srcFile, parsedSpoonAstModel, sortingDescription);
         getDebugStageRecorder()
                 .recordSrcStage(
                         srcFile.getPath(),
                         FlowDebugStageRecorder.SrcFlowStage.SORTED,
                         sortingAndSerializationResult.getSerializedSrcCode());
         FormattingResult formattingResult = getFormatter()
-                .formatSource(
+                .formatSrc(
                         sortingAndSerializationResult.getSerializedSrcCode(),
                         srcFile.getPath(),
                         OptOutFormattingRangeResolver.resolveFormattingSkippedRanges(
                                 parsedSpoonAstModel.getOptOuts(),
-                                sortingAndSerializationResult.getSerializedSourceWithSkippedTypeRanges()));
+                                sortingAndSerializationResult.getSerializedSrcWithSkippedTypeRanges()));
         getDebugStageRecorder()
                 .recordSrcStage(
                         srcFile.getPath(),
@@ -165,13 +165,13 @@ abstract class AbstractOptOutFlow implements IFlow {
         }
 
         @NonNull
-        SerializedSourceWithSkippedTypeRanges getSerializedSourceWithSkippedTypeRanges() {
-            return serializationResult.getSerializedSourceWithSkippedTypeRanges();
+        SerializedSrcWithSkippedTypeRanges getSerializedSrcWithSkippedTypeRanges() {
+            return serializationResult.getSerializedSrcWithSkippedTypeRanges();
         }
 
         @NonNull
         String getSerializedSrcCode() {
-            return getSerializedSourceWithSkippedTypeRanges().getSerializedSrcCode();
+            return getSerializedSrcWithSkippedTypeRanges().getSerializedSrcCode();
         }
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckAllFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckAllFlow.java
@@ -12,7 +12,7 @@ import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
 import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOutMode;
 import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
 import io.github.lemon_ant.jharmonizer.core.translator.ParsingResult;
-import io.github.lemon_ant.jharmonizer.core.translator.SourceAstTranslator;
+import io.github.lemon_ant.jharmonizer.core.translator.SrcAstTranslator;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import java.util.List;
 import lombok.NonNull;
@@ -39,16 +39,16 @@ public class CheckAllFlow extends AbstractOptOutFlow {
      */
     @NonNull
     @Override
-    public FlowProcessingResult processSource(@NonNull SrcFile srcFile) {
+    public FlowProcessingResult processSrc(@NonNull SrcFile srcFile) {
         getDebugStageRecorder().recordSrcStage(srcFile.getPath(), SrcFlowStage.ORIGINAL, srcFile.getSrcCode());
-        ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
+        ParsingResult parsingResult = SrcAstTranslator.parse(srcFile);
         SpoonAstModel parsedSpoonAstModel = parsingResult.getSpoonAstModel();
         if (parsedSpoonAstModel.getOptOuts().hasFileOptOutMode(JHarmonizerOptOutMode.FULLY_OFF)) {
             return buildFullyOffFileSkippedResult(srcFile, parsingResult, "all harmonization checks");
         }
 
         SortingSerializationAndFormattingResult sortingSerializationAndFormattingResult =
-                sortSerializeAndFormatSource(srcFile, parsedSpoonAstModel, "sorting checks");
+                sortSerializeAndFormatSrc(srcFile, parsedSpoonAstModel, "sorting checks");
         SortingAndSerializationResult sortingAndSerializationResult =
                 sortingSerializationAndFormattingResult.getSortingAndSerializationResult();
         SpoonAstModel sortedSpoonAstModel = sortingSerializationAndFormattingResult.getSortedSpoonAstModel();

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckFailFastFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/CheckFailFastFlow.java
@@ -12,7 +12,7 @@ import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOutMode;
 import io.github.lemon_ant.jharmonizer.core.optout.OptOutFormattingRangeResolver;
 import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
 import io.github.lemon_ant.jharmonizer.core.translator.ParsingResult;
-import io.github.lemon_ant.jharmonizer.core.translator.SourceAstTranslator;
+import io.github.lemon_ant.jharmonizer.core.translator.SrcAstTranslator;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import java.util.List;
 import lombok.NonNull;
@@ -42,16 +42,16 @@ public class CheckFailFastFlow extends AbstractOptOutFlow {
      * @return the result
      */
     @Override
-    public @NonNull FlowProcessingResult processSource(@NonNull SrcFile srcFile) {
+    public @NonNull FlowProcessingResult processSrc(@NonNull SrcFile srcFile) {
         getDebugStageRecorder().recordSrcStage(srcFile.getPath(), SrcFlowStage.ORIGINAL, srcFile.getSrcCode());
-        ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
+        ParsingResult parsingResult = SrcAstTranslator.parse(srcFile);
         SpoonAstModel parsedSpoonAstModel = parsingResult.getSpoonAstModel();
         if (parsedSpoonAstModel.getOptOuts().hasFileOptOutMode(JHarmonizerOptOutMode.FULLY_OFF)) {
             return buildFullyOffFileSkippedResult(srcFile, parsingResult, "all harmonization checks");
         }
 
         SortingAndSerializationResult sortingAndSerializationResult =
-                sortAndSerializeOrReuseOriginalSource(srcFile, parsedSpoonAstModel, "sorting checks");
+                sortAndSerializeOrReuseOriginalSrc(srcFile, parsedSpoonAstModel, "sorting checks");
         SpoonAstModel sortedSpoonAstModel = sortingAndSerializationResult.getSortedSpoonAstModel();
         List<Pair<CtElement, Integer>> elementRelocations = sortingAndSerializationResult.isSortingSkipped()
                 ? List.of()
@@ -70,12 +70,12 @@ public class CheckFailFastFlow extends AbstractOptOutFlow {
         }
 
         FormattingResult formattingResult = getFormatter()
-                .formatSource(
+                .formatSrc(
                         sortingAndSerializationResult.getSerializedSrcCode(),
                         srcFile.getPath(),
                         OptOutFormattingRangeResolver.resolveFormattingSkippedRanges(
                                 sortedSpoonAstModel.getOptOuts(),
-                                sortingAndSerializationResult.getSerializedSourceWithSkippedTypeRanges()));
+                                sortingAndSerializationResult.getSerializedSrcWithSkippedTypeRanges()));
         getDebugStageRecorder()
                 .recordSrcStage(
                         srcFile.getPath(),

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowDebugStageRecorder.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/FlowDebugStageRecorder.java
@@ -71,9 +71,7 @@ final class FlowDebugStageRecorder {
      */
     @SuppressWarnings("PMD.GuardLogStatement")
     void recordSrcStage(
-            @NonNull Path fileName,
-            @NonNull FlowDebugStageRecorder.SrcFlowStage stage,
-            @NonNull String javaSourceText) {
+            @NonNull Path fileName, @NonNull FlowDebugStageRecorder.SrcFlowStage stage, @NonNull String javaSrcText) {
         if (!enabled) {
             return;
         }
@@ -88,7 +86,7 @@ final class FlowDebugStageRecorder {
         Path outputFile = flowOutputDirectory.resolve(outputFileName);
 
         try {
-            Files.writeString(outputFile, javaSourceText, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
+            Files.writeString(outputFile, javaSrcText, StandardCharsets.UTF_8, StandardOpenOption.CREATE_NEW);
             log.debug("Saved debug stage: {}", outputFile.toAbsolutePath());
         } catch (IOException ioException) {
             throw new UncheckedIOException("Failed to write debug stage file: " + outputFile, ioException);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/IFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/IFlow.java
@@ -17,5 +17,5 @@ public interface IFlow {
      * @return the processing result for the source file
      */
     @NonNull
-    FlowProcessingResult processSource(@NonNull SrcFile srcFile);
+    FlowProcessingResult processSrc(@NonNull SrcFile srcFile);
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/RestructureFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/RestructureFlow.java
@@ -4,14 +4,14 @@ import static io.github.lemon_ant.jharmonizer.core.flow.FlowProcessingStatus.def
 import static io.github.lemon_ant.jharmonizer.core.flow.FlowType.RESTRUCTURE;
 import static io.github.lemon_ant.jharmonizer.core.translator.spoon.RelocationDetector.isRelocated;
 
-import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFile;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowDebugStageRecorder.SrcFlowStage;
 import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
 import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOutMode;
 import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
 import io.github.lemon_ant.jharmonizer.core.translator.ParsingResult;
-import io.github.lemon_ant.jharmonizer.core.translator.SourceAstTranslator;
+import io.github.lemon_ant.jharmonizer.core.translator.SrcAstTranslator;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import lombok.NonNull;
 
@@ -43,16 +43,16 @@ public class RestructureFlow extends AbstractOptOutFlow {
      */
     @NonNull
     @Override
-    public FlowProcessingResult processSource(@NonNull SrcFile srcFile) {
+    public FlowProcessingResult processSrc(@NonNull SrcFile srcFile) {
         getDebugStageRecorder().recordSrcStage(srcFile.getPath(), SrcFlowStage.ORIGINAL, srcFile.getSrcCode());
-        ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
+        ParsingResult parsingResult = SrcAstTranslator.parse(srcFile);
         SpoonAstModel parsedSpoonAstModel = parsingResult.getSpoonAstModel();
         if (parsedSpoonAstModel.getOptOuts().hasFileOptOutMode(JHarmonizerOptOutMode.FULLY_OFF)) {
             return buildFullyOffFileSkippedResult(srcFile, parsingResult, "all harmonization");
         }
 
         SortingSerializationAndFormattingResult sortingSerializationAndFormattingResult =
-                sortSerializeAndFormatSource(srcFile, parsedSpoonAstModel, "sorting");
+                sortSerializeAndFormatSrc(srcFile, parsedSpoonAstModel, "sorting");
         SortingAndSerializationResult sortingAndSerializationResult =
                 sortingSerializationAndFormattingResult.getSortingAndSerializationResult();
         SpoonAstModel sortedSpoonAstModel = sortingSerializationAndFormattingResult.getSortedSpoonAstModel();
@@ -61,10 +61,9 @@ public class RestructureFlow extends AbstractOptOutFlow {
                 !srcFile.getSrcCode().equals(sortingSerializationAndFormattingResult.getFormattedSrcCode());
         if (hasChanges) {
             if (backupsEnabled) {
-                SourceFilesHandler.renameToBackup(srcFile.getPath());
+                SrcFilesHandler.renameToBackup(srcFile.getPath());
             }
-            SourceFilesHandler.overwrite(
-                    srcFile.getPath(), sortingSerializationAndFormattingResult.getFormattedSrcCode());
+            SrcFilesHandler.overwrite(srcFile.getPath(), sortingSerializationAndFormattingResult.getFormattedSrcCode());
         }
 
         return FlowProcessingResult.builder()

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/formatter/Formatter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/formatter/Formatter.java
@@ -55,7 +55,7 @@ public final class Formatter {
     }
 
     @NonNull
-    public FormattingResult formatSource(
+    public FormattingResult formatSrc(
             @NonNull String srcCode,
             @NonNull Path srcPath,
             @NonNull List<@NonNull SrcCharacterRange> formattingSkippedRanges) {
@@ -63,9 +63,9 @@ public final class Formatter {
         TimedResult<String> formattingResult =
                 StopWatch.measure(() -> applyFormatting(srcCode, formattingSkippedRanges));
 
-        String formattedSource = formattingResult.getResult();
+        String formattedSrc = formattingResult.getResult();
         return new FormattingResult(
-                formattedSource, new FormattingStatistic(formattedSource.length(), formattingResult.getNanos()));
+                formattedSrc, new FormattingStatistic(formattedSrc.length(), formattingResult.getNanos()));
     }
 
     @NonNull
@@ -102,8 +102,8 @@ public final class Formatter {
      * Inverts excluded ranges into the complementary ranges that should be formatted.
      */
     @NonNull
-    private static List<Range<Integer>> invertExcludedRanges(int sourceLength, List<SrcCharacterRange> excludedRanges) {
-        Validate.isTrue(sourceLength >= 0, "Source length must be non-negative: %s", sourceLength);
+    private static List<Range<Integer>> invertExcludedRanges(int srcLength, List<SrcCharacterRange> excludedRanges) {
+        Validate.isTrue(srcLength >= 0, "Source length must be non-negative: %s", srcLength);
 
         List<SrcCharacterRange> normalizedRanges = excludedRanges.stream()
                 .sorted(comparingInt(SrcCharacterRange::getStartInclusive)
@@ -114,11 +114,11 @@ public final class Formatter {
 
         for (SrcCharacterRange excludedRange : normalizedRanges) {
             Validate.isTrue(
-                    excludedRange.getEndExclusive() <= sourceLength,
+                    excludedRange.getEndExclusive() <= srcLength,
                     "Excluded range [%s, %s) exceeds source length %s",
                     excludedRange.getStartInclusive(),
                     excludedRange.getEndExclusive(),
-                    sourceLength);
+                    srcLength);
             Validate.isTrue(
                     excludedRange.getStartInclusive() >= nextStart,
                     "Excluded ranges must be sorted and non-overlapping, but [%s, %s) overlaps before %s",
@@ -132,8 +132,8 @@ public final class Formatter {
             nextStart = excludedRange.getEndExclusive();
         }
 
-        if (nextStart < sourceLength) {
-            includedRanges.add(Range.closedOpen(nextStart, sourceLength));
+        if (nextStart < srcLength) {
+            includedRanges.add(Range.closedOpen(nextStart, srcLength));
         }
 
         return Collections.unmodifiableList(includedRanges);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/optout/JHarmonizerOptOutCommentUtilities.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/optout/JHarmonizerOptOutCommentUtilities.java
@@ -140,8 +140,8 @@ class JHarmonizerOptOutCommentUtilities {
      * @return formatted location string
      */
     @NonNull
-    static String formatLocation(@NonNull SrcFile srcFile, @NonNull SourcePosition sourcePosition) {
-        return srcFile.getPath() + ":" + sourcePosition.getLine() + ":" + sourcePosition.getColumn();
+    static String formatLocation(@NonNull SrcFile srcFile, @NonNull SourcePosition srcPosition) {
+        return srcFile.getPath() + ":" + srcPosition.getLine() + ":" + srcPosition.getColumn();
     }
 
     /**
@@ -152,11 +152,11 @@ class JHarmonizerOptOutCommentUtilities {
      * @return formatted location string
      */
     @NonNull
-    static String formatLocation(@NonNull SrcFile srcFile, int sourceOffset) {
+    static String formatLocation(@NonNull SrcFile srcFile, int srcOffset) {
         int line = 1;
         int column = 1;
         String srcCode = srcFile.getSrcCode();
-        for (int index = 0; index < sourceOffset && index < srcCode.length(); index++) {
+        for (int index = 0; index < srcOffset && index < srcCode.length(); index++) {
             if (srcCode.charAt(index) == LINE_FEED) {
                 line++;
                 column = 1;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/optout/JHarmonizerOptOutFileScopeResolver.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/optout/JHarmonizerOptOutFileScopeResolver.java
@@ -38,13 +38,13 @@ final class JHarmonizerOptOutFileScopeResolver {
 
     @Nullable
     private JHarmonizerOptOutMode resolveFileOptOutMode() {
-        if (requiresRawSourceFallback()) {
-            return resolveFromRawSource();
+        if (requiresRawSrcFallback()) {
+            return resolveFromRawSrc();
         }
         return resolveFromAstComments();
     }
 
-    private boolean requiresRawSourceFallback() {
+    private boolean requiresRawSrcFallback() {
         CtCompilationUnit.UNIT_TYPE unitType = compilationUnit.getUnitType();
         if (unitType == CtCompilationUnit.UNIT_TYPE.PACKAGE_DECLARATION
                 || unitType == CtCompilationUnit.UNIT_TYPE.MODULE_DECLARATION) {
@@ -69,7 +69,7 @@ final class JHarmonizerOptOutFileScopeResolver {
     }
 
     @Nullable
-    private JHarmonizerOptOutMode resolveFromRawSource() {
+    private JHarmonizerOptOutMode resolveFromRawSrc() {
         List<FileScopeOptOutCandidate> rawFileComments =
                 JHarmonizerOptOutCommentUtilities.collectRawCommentsByRegex(srcFile.getSrcCode()).stream()
                         .map(rawCommentMatch -> new FileScopeOptOutCandidate(

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/optout/OptOutFormattingRangeResolver.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/optout/OptOutFormattingRangeResolver.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.optout;
 
-import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
+import io.github.lemon_ant.jharmonizer.core.translator.SerializedSrcWithSkippedTypeRanges;
 import io.github.lemon_ant.jharmonizer.core.translator.SrcCharacterRange;
 import io.github.lemon_ant.jharmonizer.core.utilities.SrcCodeUtils;
 import java.util.List;
@@ -24,9 +24,9 @@ public class OptOutFormattingRangeResolver {
     @NonNull
     public List<@NonNull SrcCharacterRange> resolveFormattingSkippedRanges(
             @NonNull JHarmonizerOptOuts optOuts,
-            @NonNull SerializedSourceWithSkippedTypeRanges serializedSourceWithSkippedTypeRanges) {
+            @NonNull SerializedSrcWithSkippedTypeRanges serializedSrcWithSkippedTypeRanges) {
         Map<CtType<?>, SrcCharacterRange> sortingSkippedTypeRanges =
-                serializedSourceWithSkippedTypeRanges.getSortingSkippedTypeRanges();
+                serializedSrcWithSkippedTypeRanges.getSortingSkippedTypeRanges();
         return optOuts.getTypeOptOutModes().entrySet().stream()
                 .filter(entry -> entry.getValue() == JHarmonizerOptOutMode.FULLY_OFF)
                 .map(Map.Entry::getKey)

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/FileProcessingStatistic.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/FileProcessingStatistic.java
@@ -34,6 +34,6 @@ public class FileProcessingStatistic {
         return new FileProcessingStatistic(
                 flowProcessingResult.getPath(),
                 processingTime,
-                flowProcessingResult.getParsingStatistic().getOriginalSourceCodeLength());
+                flowProcessingResult.getParsingStatistic().getOriginalSrcCodeLength());
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/SrcProcessingStats.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/SrcProcessingStats.java
@@ -21,7 +21,7 @@ import lombok.experimental.UtilityClass;
  */
 @UtilityClass
 // TODO Review this
-public class SourceProcessingStats {
+public class SrcProcessingStats {
 
     // Collector for parallel processing
     /**

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/ComparatorUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/ComparatorUtils.java
@@ -66,7 +66,7 @@ class ComparatorUtils {
         Comparator<SortableTypeMember.OrderingKey> configuredComparator = orderingRules.stream()
                 .map(ComparatorUtils::buildOrderingComparatorForOrderingRule)
                 .reduce(Comparator::thenComparing)
-                .orElseGet(() -> Comparator.comparingInt(SortableTypeMember.OrderingKey::getSourceStart)
+                .orElseGet(() -> Comparator.comparingInt(SortableTypeMember.OrderingKey::getSrcStart)
                         .thenComparing(SortableTypeMember.OrderingKey::getAlphaKey));
 
         // Deterministic tie-breakers regardless of configured keys.
@@ -144,7 +144,7 @@ class ComparatorUtils {
     private static Comparator<SortableTypeMember.OrderingKey> buildOrderingComparatorForOrderingRule(
             OrderingRule orderingRule) {
         return switch (orderingRule) {
-            case PRESERVE -> Comparator.comparingInt(SortableTypeMember.OrderingKey::getSourceStart);
+            case PRESERVE -> Comparator.comparingInt(SortableTypeMember.OrderingKey::getSrcStart);
             case ALPHA ->
                 Comparator.comparingInt(SortableTypeMember.OrderingKey::getAlphaSortingRank)
                         .thenComparing(SortableTypeMember.OrderingKey::getAlphaKey);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupBoundaryMarker.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupBoundaryMarker.java
@@ -1,7 +1,7 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon;
 
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedSeparator;
-import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils;
+import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils;
 import java.util.List;
 import java.util.Optional;
 import lombok.NonNull;
@@ -27,12 +27,12 @@ class GroupBoundaryMarker {
                 .map(memberGroupBlock -> Pair.of(
                         memberGroupBlock.getTypeMembers().getFirst(),
                         switch (memberGroupBlock.getCompiledMemberGroup().getSeparator()) {
-                            case UnifiedSeparator.NEW_LINE -> SpoonSourcePrinterUtils.GROUP_SEPARATOR_NEW_LINE;
+                            case UnifiedSeparator.NEW_LINE -> SpoonSrcPrinterUtils.GROUP_SEPARATOR_NEW_LINE;
                             case UnifiedSeparator.HEADER ->
                                 Optional.ofNullable(memberGroupBlock
                                                 .getCompiledMemberGroup()
                                                 .getName())
-                                        .orElse(SpoonSourcePrinterUtils.GROUP_SEPARATOR_NEW_LINE);
+                                        .orElse(SpoonSrcPrinterUtils.GROUP_SEPARATOR_NEW_LINE);
                             case UnifiedSeparator.NONE -> null;
                         }))
                 .filter(firstMemberAndSeparatorText -> firstMemberAndSeparatorText.getValue() != null)
@@ -41,6 +41,6 @@ class GroupBoundaryMarker {
     }
 
     private static void writeGroupBoundaryMetadata(CtTypeMember firstMember, String separatorText) {
-        firstMember.putMetadata(SpoonSourcePrinterUtils.GROUP_HEADER_METADATA, separatorText);
+        firstMember.putMetadata(SpoonSrcPrinterUtils.GROUP_HEADER_METADATA, separatorText);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SortableTypeMember.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SortableTypeMember.java
@@ -3,7 +3,7 @@ package io.github.lemon_ant.jharmonizer.core.sorter.spoon;
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.deriveAlphaKey;
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.deriveAlphaSortingRank;
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.deriveVisibilityRank;
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.extractSourceStart;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.extractSrcStart;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -88,7 +88,7 @@ class SortableTypeMember {
     @NonNull
     private static SortableTypeMember.OrderingKey deriveOrderingKey(CtTypeMember typeMember) {
         return new SortableTypeMember.OrderingKey(
-                extractSourceStart(typeMember),
+                extractSrcStart(typeMember),
                 deriveAlphaKey(typeMember),
                 deriveAlphaSortingRank(typeMember),
                 deriveVisibilityRank(typeMember));
@@ -115,7 +115,7 @@ class SortableTypeMember {
                     typeMember2OrderingKey.computeIfAbsent(typeMember, SortableTypeMember::deriveOrderingKey);
         }
 
-        int sourceStart;
+        int srcStart;
 
         @NonNull
         String alphaKey;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonMemberDescriptorFactory.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonMemberDescriptorFactory.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.config.unified.DeclarationModifier;
@@ -61,7 +61,7 @@ class SpoonMemberDescriptorFactory {
      */
     @NonNull
     Map<@NonNull CtTypeMember, @NonNull MemberDescriptor> describeMembers(@NonNull CtType<?> type) {
-        return streamExplicitSourceTypeMembers(type)
+        return streamExplicitSrcTypeMembers(type)
                 .collect(Collectors.toUnmodifiableMap(
                         Function.identity(), SpoonMemberDescriptorFactory::describeMember));
     }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonTypeMemberUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonTypeMemberUtils.java
@@ -80,7 +80,7 @@ public class SpoonTypeMemberUtils {
      * @param typeMember the type member
      * @return the result
      */
-    static int extractSourceStart(@NonNull CtTypeMember typeMember) {
+    static int extractSrcStart(@NonNull CtTypeMember typeMember) {
         if (typeMember.getPosition() == null || !typeMember.getPosition().isValidPosition()) {
             return Integer.MAX_VALUE;
         }
@@ -128,7 +128,7 @@ public class SpoonTypeMemberUtils {
             }
             default -> {
                 // Defensive fallback for any unexpected Spoon CtTypeMember implementation.
-                return typeMember.getClass().getSimpleName() + ":" + extractSourceStart(typeMember);
+                return typeMember.getClass().getSimpleName() + ":" + extractSrcStart(typeMember);
             }
         }
     }
@@ -150,7 +150,7 @@ public class SpoonTypeMemberUtils {
      * @return the stream of explicit source type members
      */
     @NonNull
-    public static Stream<@NonNull CtTypeMember> streamExplicitSourceTypeMembers(@NonNull CtType<?> declaringType) {
+    public static Stream<@NonNull CtTypeMember> streamExplicitSrcTypeMembers(@NonNull CtType<?> declaringType) {
         return declaringType.getTypeMembers().stream()
                 .filter(typeMember -> typeMember.getPosition() != null
                         && typeMember.getPosition().isValidPosition())

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/AbstractExplicitInitializerForwardReferenceDependencyProvider.java
@@ -1,7 +1,7 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireDeclaringType;
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireSourceStart;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireSrcStart;
 
 import java.util.List;
 import java.util.Objects;
@@ -113,11 +113,11 @@ abstract class AbstractExplicitInitializerForwardReferenceDependencyProvider imp
 
     @NonNull
     private Set<CtTypeMember> findEarlierReferrerFieldsWithExplicitReferenceTo(CtField<?> referencedField) {
-        int referencedFieldSourceStart = requireSourceStart(referencedField);
+        int referencedFieldSrcStart = requireSrcStart(referencedField);
 
         return referencedField.getDeclaringType().getTypeMembers().stream()
                 .filter(typeMember -> typeMember instanceof CtField<?>)
-                .filter(typeMember -> requireSourceStart(typeMember) < referencedFieldSourceStart)
+                .filter(typeMember -> requireSrcStart(typeMember) < referencedFieldSrcStart)
                 .map(typeMember -> (CtField<?>) typeMember)
                 .filter(this::isSupportedReferrerField)
                 .filter(referrerField -> hasExplicitReferenceTo(referrerField, referencedField))

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/BlankFinalDefiniteAssignmentDependencyProvider.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/BlankFinalDefiniteAssignmentDependencyProvider.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireSourceStart;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireSrcStart;
 
 import java.util.Optional;
 import java.util.Set;
@@ -46,12 +46,13 @@ final class BlankFinalDefiniteAssignmentDependencyProvider implements MemberDepe
             return Set.of();
         }
 
-        int dependentSourceStart = requireSourceStart(dependentMember);
+        int dependentSrcStart = requireSrcStart(dependentMember);
 
         return blankFinalFieldsReadByDependentMember.stream()
-                .flatMap(blankFinalField -> InitializationOrderDependencyUtils.resolveProviderMembersForBlankFinalRead(
-                        dependentMember, blankFinalField, dependentSourceStart)
-                        .stream())
+                .flatMap(
+                        blankFinalField -> InitializationOrderDependencyUtils.resolveProviderMembersForBlankFinalRead(
+                                dependentMember, blankFinalField, dependentSrcStart)
+                                .stream())
                 .map(providerMember ->
                         new MemberDependencyArc(providerMember, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY))
                 .collect(Collectors.toUnmodifiableSet());

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
@@ -125,9 +125,9 @@ class DeclaringTypeFieldReferenceUtils {
 
     private static boolean isProviderDeclaredBeforeDependentMember(
             CtTypeMember providerMember, CtTypeMember dependentMember) {
-        int dependentSourceStart = requireSourceStart(dependentMember);
-        int providerSourceStart = requireSourceStart(providerMember);
-        return providerSourceStart < dependentSourceStart;
+        int dependentSrcStart = requireSrcStart(dependentMember);
+        int providerSrcStart = requireSrcStart(providerMember);
+        return providerSrcStart < dependentSrcStart;
     }
 
     /**
@@ -135,7 +135,7 @@ class DeclaringTypeFieldReferenceUtils {
      * @param typeMember the type member
      * @return the result
      */
-    static int requireSourceStart(@NonNull CtTypeMember typeMember) {
+    static int requireSrcStart(@NonNull CtTypeMember typeMember) {
         SourcePosition memberPosition = typeMember.getPosition();
         if (memberPosition != null && memberPosition.isValidPosition()) {
             return memberPosition.getSourceStart();

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/InitializationOrderDependencyUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/InitializationOrderDependencyUtils.java
@@ -1,8 +1,8 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireDeclaringType;
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireSourceStart;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph.DeclaringTypeFieldReferenceUtils.requireSrcStart;
 
 import java.util.Optional;
 import java.util.Set;
@@ -92,17 +92,17 @@ final class InitializationOrderDependencyUtils {
      */
     @NonNull
     static Set<CtTypeMember> resolveProviderMembersForBlankFinalRead(
-            @NonNull CtTypeMember dependentMember, @NonNull CtField<?> blankFinalField, int dependentSourceStart) {
+            @NonNull CtTypeMember dependentMember, @NonNull CtField<?> blankFinalField, int dependentSrcStart) {
 
         CtType<?> declaringType = requireDeclaringType(dependentMember);
         boolean blankFinalFieldIsStatic = blankFinalField.getModifiers().contains(ModifierKind.STATIC);
 
-        return streamExplicitSourceTypeMembers(declaringType)
+        return streamExplicitSrcTypeMembers(declaringType)
                 .filter(typeMember -> typeMember != dependentMember)
                 .filter(typeMember -> matchesInitializationMemberStaticness(typeMember, blankFinalFieldIsStatic))
                 .map(candidateProviderMember ->
-                        new ProviderCandidate(candidateProviderMember, requireSourceStart(candidateProviderMember)))
-                .filter(candidate -> candidate.getSourceStart() < dependentSourceStart)
+                        new ProviderCandidate(candidateProviderMember, requireSrcStart(candidateProviderMember)))
+                .filter(candidate -> candidate.getSrcStart() < dependentSrcStart)
                 .map(ProviderCandidate::getProviderMember)
                 .filter(providerMember -> isFieldWrittenByMember(providerMember, blankFinalField))
                 .collect(Collectors.toUnmodifiableSet());
@@ -121,6 +121,6 @@ final class InitializationOrderDependencyUtils {
         @NonNull
         CtTypeMember providerMember;
 
-        int sourceStart;
+        int srcStart;
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/SpoonJavaBeansAccessorUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/SpoonJavaBeansAccessorUtils.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 import static java.beans.Introspector.decapitalize;
 import static java.util.Objects.requireNonNull;
 
@@ -49,7 +49,7 @@ class SpoonJavaBeansAccessorUtils {
                 "Expected CtMethod to have a declaring type, but it is detached from the Spoon model. methodName="
                         + accessorMethod.getSimpleName());
 
-        return streamExplicitSourceTypeMembers(declaringType)
+        return streamExplicitSrcTypeMembers(declaringType)
                 .filter(typeMember -> typeMember instanceof CtMethod<?>)
                 .map(typeMember -> (CtMethod<?>) typeMember)
                 .filter(candidateMethod -> candidateMethod != accessorMethod)

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/spoon/SpoonTypeUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/spoon/SpoonTypeUtils.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.spoon;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
@@ -114,7 +114,7 @@ public class SpoonTypeUtils {
     @NonNull
     private static Stream<CtElement> streamTypeAndNestedElements(CtType<?> ownerType) {
         Stream<CtElement> self = Stream.of(ownerType);
-        Stream<CtElement> membersAndNested = streamExplicitSourceTypeMembers(ownerType)
+        Stream<CtElement> membersAndNested = streamExplicitSrcTypeMembers(ownerType)
                 .flatMap(member -> {
                     if (member instanceof CtType<?> nestedType) {
                         // include the nested type declaration, then descend into its own members

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingStatistic.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingStatistic.java
@@ -7,7 +7,7 @@ import lombok.Value;
  */
 @Value
 public class ParsingStatistic {
-    long originalSourceCodeLength;
+    long originalSrcCodeLength;
     int parsedMembersCount;
     int parsedRootTypesCount;
     int parsedTypesTotalCount;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializationResult.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializationResult.java
@@ -13,5 +13,5 @@ public class SerializationResult {
     SerializationStatistic serializationStatistic;
 
     @NonNull
-    SerializedSourceWithSkippedTypeRanges serializedSourceWithSkippedTypeRanges;
+    SerializedSrcWithSkippedTypeRanges serializedSrcWithSkippedTypeRanges;
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializedSrcWithSkippedTypeRanges.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializedSrcWithSkippedTypeRanges.java
@@ -7,14 +7,14 @@ import lombok.Value;
 import spoon.reflect.declaration.CtType;
 
 @Value
-public class SerializedSourceWithSkippedTypeRanges {
+public class SerializedSrcWithSkippedTypeRanges {
     @NonNull
     String serializedSrcCode;
 
     @NonNull
     Map<@NonNull CtType<?>, @NonNull SrcCharacterRange> sortingSkippedTypeRanges;
 
-    public SerializedSourceWithSkippedTypeRanges(
+    public SerializedSrcWithSkippedTypeRanges(
             @NonNull String serializedSrcCode,
             @NonNull Map<@NonNull CtType<?>, @NonNull SrcCharacterRange> sortingSkippedTypeRanges) {
         this.serializedSrcCode = serializedSrcCode;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SrcAstTranslator.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SrcAstTranslator.java
@@ -23,7 +23,7 @@ import spoon.reflect.declaration.CtTypeMember;
  */
 @Slf4j
 @UtilityClass
-public final class SourceAstTranslator {
+public final class SrcAstTranslator {
 
     /**
      * Parses the source file.
@@ -54,18 +54,17 @@ public final class SourceAstTranslator {
     public static SerializationResult serialize(@NonNull SpoonAstModel sortedSpoonAstModel) {
         log.debug("Serializing {}", sortedSpoonAstModel.getPath());
 
-        TimedResult<SerializedSourceWithSkippedTypeRanges> serializationTimedResult = StopWatch.measure(
+        TimedResult<SerializedSrcWithSkippedTypeRanges> serializationTimedResult = StopWatch.measure(
                 () -> sortedSpoonAstModel.getSerializedSrcCode().get());
-        SerializedSourceWithSkippedTypeRanges serializedSourceWithSkippedTypeRanges =
-                serializationTimedResult.getResult();
+        SerializedSrcWithSkippedTypeRanges serializedSrcWithSkippedTypeRanges = serializationTimedResult.getResult();
 
         return new SerializationResult(
                 new SerializationStatistic(
-                        serializedSourceWithSkippedTypeRanges
+                        serializedSrcWithSkippedTypeRanges
                                 .getSerializedSrcCode()
                                 .length(),
                         serializationTimedResult.getNanos()),
-                serializedSourceWithSkippedTypeRanges);
+                serializedSrcWithSkippedTypeRanges);
     }
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonAstModel.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonAstModel.java
@@ -6,7 +6,7 @@ import static lombok.AccessLevel.PRIVATE;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOuts;
-import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
+import io.github.lemon_ant.jharmonizer.core.translator.SerializedSrcWithSkippedTypeRanges;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
@@ -42,7 +42,7 @@ public class SpoonAstModel {
     Path path;
 
     @NonNull
-    Supplier<SerializedSourceWithSkippedTypeRanges> serializedSrcCode;
+    Supplier<SerializedSrcWithSkippedTypeRanges> serializedSrcCode;
 
     @NonNull
     JHarmonizerOptOuts optOuts;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinter.java
@@ -1,9 +1,9 @@
 package io.github.lemon_ant.jharmonizer.core.translator.spoon;
 
-import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils.detectDominantLineSeparator;
+import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils.detectDominantLineSeparator;
 
 import io.github.lemon_ant.jharmonizer.core.spoon.SpoonTypeUtils;
-import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
+import io.github.lemon_ant.jharmonizer.core.translator.SerializedSrcWithSkippedTypeRanges;
 import java.lang.annotation.Annotation;
 import java.util.List;
 import java.util.Set;
@@ -24,20 +24,20 @@ import spoon.reflect.visitor.printer.CommentOffset;
  * preserves the original source fragments for opt-out ranges,
  * and normalises line separators to match the dominant separator of the original file.
  */
-class SpoonCustomSourcePrinter extends DefaultJavaPrettyPrinter {
+class SpoonCustomSrcPrinter extends DefaultJavaPrettyPrinter {
 
     @NonNull
     private final SpoonTypePrinter typeStructurePrinter;
 
     /**
-     * Creates a new SpoonCustomSourcePrinter.
+     * Creates a new SpoonCustomSrcPrinter.
      *
      * @param env the Spoon printing environment
      * @param srcCode the original source text being re-serialized
      * @param sortingSkippedTypes the types that must be copied without sorting
      */
     @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
-    SpoonCustomSourcePrinter(
+    SpoonCustomSrcPrinter(
             @NonNull Environment env, @NonNull String srcCode, @NonNull Set<CtType<?>> sortingSkippedTypes) {
         super(env);
         String lineSeparator = detectDominantLineSeparator(srcCode);
@@ -98,10 +98,9 @@ class SpoonCustomSourcePrinter extends DefaultJavaPrettyPrinter {
      * @return the serialized source with skipped-type ranges
      */
     @NonNull
-    SerializedSourceWithSkippedTypeRanges serializeCompilationUnit(@NonNull CtCompilationUnit compilationUnit) {
+    SerializedSrcWithSkippedTypeRanges serializeCompilationUnit(@NonNull CtCompilationUnit compilationUnit) {
         printCompilationUnit(compilationUnit);
-        return new SerializedSourceWithSkippedTypeRanges(
-                getResult(), typeStructurePrinter.getSortingSkippedTypeRanges());
+        return new SerializedSrcWithSkippedTypeRanges(getResult(), typeStructurePrinter.getSortingSkippedTypeRanges());
     }
 
     /**

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonParser.java
@@ -4,7 +4,7 @@ import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFile;
 import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOutResolver;
 import io.github.lemon_ant.jharmonizer.core.optout.JHarmonizerOptOuts;
 import io.github.lemon_ant.jharmonizer.core.spoon.SpoonTypeUtils;
-import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
+import io.github.lemon_ant.jharmonizer.core.translator.SerializedSrcWithSkippedTypeRanges;
 import java.util.Map;
 import java.util.function.Supplier;
 import lombok.NonNull;
@@ -41,12 +41,12 @@ public class SpoonParser {
         CtCompilationUnit compilationUnit = extractCompilationUnit(srcFile, launcher);
         CtType<?> mainType = SpoonTypeUtils.findMainType(compilationUnit);
         JHarmonizerOptOuts optOuts = JHarmonizerOptOutResolver.resolve(srcFile, compilationUnit);
-        Supplier<SerializedSourceWithSkippedTypeRanges> serializedSrcCode = () -> {
+        Supplier<SerializedSrcWithSkippedTypeRanges> serializedSrcCode = () -> {
             if (SpoonTypeUtils.hasNoDeclaredTypes(compilationUnit)) {
-                return new SerializedSourceWithSkippedTypeRanges(srcFile.getSrcCode(), Map.of());
+                return new SerializedSrcWithSkippedTypeRanges(srcFile.getSrcCode(), Map.of());
             }
 
-            SpoonCustomSourcePrinter printer = new SpoonCustomSourcePrinter(
+            SpoonCustomSrcPrinter printer = new SpoonCustomSrcPrinter(
                     launcher.getEnvironment(), srcFile.getSrcCode(), optOuts.getSortingSkippedTypes());
             return printer.serializeCompilationUnit(compilationUnit);
         };

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonSrcPrinterUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonSrcPrinterUtils.java
@@ -12,7 +12,7 @@ import spoon.reflect.declaration.CtTypeMember;
  * and deciding whether a member group separator is needed before or after a given member.
  */
 @UtilityClass
-public class SpoonSourcePrinterUtils {
+public class SpoonSrcPrinterUtils {
 
     public static final String GROUP_HEADER_METADATA = "GROUP_HEADER";
     public static final String GROUP_SEPARATOR_NEW_LINE = "\n";
@@ -25,8 +25,8 @@ public class SpoonSourcePrinterUtils {
      */
     @NonNull
     @SuppressWarnings({"PMD.AvoidLiteralsInIfCondition", "PMD.AvoidReassigningLoopVariables"})
-    static String detectDominantLineSeparator(@NonNull String source) {
-        if (source.isEmpty()) {
+    static String detectDominantLineSeparator(@NonNull String src) {
+        if (src.isEmpty()) {
             return System.lineSeparator();
         }
 
@@ -34,12 +34,12 @@ public class SpoonSourcePrinterUtils {
         int lfCount = 0;
         int crCount = 0;
 
-        for (int index = 0; index < source.length(); index++) {
-            char currentChar = source.charAt(index);
+        for (int index = 0; index < src.length(); index++) {
+            char currentChar = src.charAt(index);
 
             if (currentChar == '\r') {
-                boolean hasNextChar = (index + 1) < source.length();
-                if (hasNextChar && source.charAt(index + 1) == '\n') {
+                boolean hasNextChar = (index + 1) < src.length();
+                if (hasNextChar && src.charAt(index + 1) == '\n') {
                     crlfCount++;
                     index++; // skip '\n' in CRLF
                 } else {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -1,9 +1,9 @@
 package io.github.lemon_ant.jharmonizer.core.translator.spoon;
 
-import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils.GROUP_HEADER_METADATA;
-import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils.GROUP_SEPARATOR_NEW_LINE;
-import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils.needsSeparatorAfter;
-import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils.needsSeparatorBefore;
+import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils.GROUP_HEADER_METADATA;
+import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils.GROUP_SEPARATOR_NEW_LINE;
+import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils.needsSeparatorAfter;
+import static io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils.needsSeparatorBefore;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.translator.SrcCharacterRange;

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
@@ -24,37 +24,37 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-class OptOutSourceProcessorIntegrationTest {
+class OptOutSrcProcessorIntegrationTest {
     private static final FlexibleUnifiedConfig OPT_OUT_TEST_CONFIG = createOptOutTestConfig();
 
     @TempDir
     Path temporaryDirectory;
 
     @Test
-    void processSources_fileOptOutOff_keepOriginalSource() throws Exception {
+    void processSources_fileOptOutOff_keepOriginalSrc() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 // @jharmonizer:fully-off
                 import java.util.List;
                 class Z{int b;int a;}
                 class A{}
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
 
         // Then
-        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSourceCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSrcCode);
     }
 
     @Test
-    void processSources_fileFullyOffWithNestedOverrides_keepOriginalSource() throws Exception {
+    void processSources_fileFullyOffWithNestedOverrides_keepOriginalSrc() throws Exception {
         // Given
         // Keep the nested declarations compact and intentionally out of order so byte-for-byte preservation
         // proves that file-level fully-off ignores nested override directives and extra declarations.
-        String originalSourceCode = """
+        String originalSrcCode = """
                 // @jharmonizer:fully-off
                 class ZuluHelper{static String label(){return "zulu";}}
                 public class Sample{int zebra;
@@ -73,58 +73,58 @@ class OptOutSourceProcessorIntegrationTest {
                 }
                 class AlphaHelper{static String label(){return "alpha";}}
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
 
         // Then
-        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSourceCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSrcCode);
     }
 
     @Test
     void processSources_fileOptOutSortOff_formatWithoutSortingTopLevelTypes() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 // @jharmonizer:sort-off
                 import java.util.List;
                 class Z{int b;int a;}
                 class A{}
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).doesNotContain("import java.util.List;");
-        assertThat(processedSourceCode).containsSubsequence("class Z", "class A");
-        assertThat(processedSourceCode).contains("int a;").contains("int b;");
+        assertThat(processedSrcCode).doesNotContain("import java.util.List;");
+        assertThat(processedSrcCode).containsSubsequence("class Z", "class A");
+        assertThat(processedSrcCode).contains("int a;").contains("int b;");
     }
 
     @Test
     void processSources_fileMixedCaseSortOffDirective_formatWithoutSortingTopLevelTypes() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 // @JHarmonizer:SoRt-OfF
                 import java.util.List;
                 class Z{int b;int a;}
                 class A{}
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).doesNotContain("import java.util.List;");
-        assertThat(processedSourceCode).containsSubsequence("class Z", "class A");
-        assertThat(processedSourceCode).contains("int a;").contains("int b;");
+        assertThat(processedSrcCode).doesNotContain("import java.util.List;");
+        assertThat(processedSrcCode).containsSubsequence("class Z", "class A");
+        assertThat(processedSrcCode).contains("int a;").contains("int b;");
     }
 
     @Test
@@ -135,23 +135,23 @@ class OptOutSourceProcessorIntegrationTest {
                     // @jharmonizer:fully-off
                     static class Inner{int z;  int a;}
                 """.stripTrailing();
-        String originalSourceCode = """
+        String originalSrcCode = """
                 // @jharmonizer:sort-off
                 class Outer{int b;int a;
                 %s
                 }
                 """.formatted(expectedFullyOffFragment);
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).contains(expectedFullyOffFragment);
-        assertThat(processedSourceCode).contains("static class Inner{int z;  int a;}");
-        assertThat(processedSourceCode).contains("class Outer {");
+        assertThat(processedSrcCode).contains(expectedFullyOffFragment);
+        assertThat(processedSrcCode).contains("static class Inner{int z;  int a;}");
+        assertThat(processedSrcCode).contains("class Outer {");
     }
 
     @Test
@@ -163,7 +163,7 @@ class OptOutSourceProcessorIntegrationTest {
                     int z;   int a;
                 }
                 """;
-        String originalSourceCode = """
+        String originalSrcCode = """
                 class Gamma {}
 
                 /* @jharmonizer:fully-off */
@@ -174,22 +174,22 @@ class OptOutSourceProcessorIntegrationTest {
                 class Delta {}
                 class Alpha {}
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).contains(ignoredFragment);
-        assertThat(processedSourceCode).containsSubsequence("class Alpha", "class Beta", "class Delta", "class Gamma");
+        assertThat(processedSrcCode).contains(ignoredFragment);
+        assertThat(processedSrcCode).containsSubsequence("class Alpha", "class Beta", "class Delta", "class Gamma");
     }
 
     @Test
     void processSources_topLevelTypeOptOutSortOff_keepTypeBodyOrderButFormatType() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 class Gamma {}
 
                 // @jharmonizer:sort-off
@@ -198,16 +198,16 @@ class OptOutSourceProcessorIntegrationTest {
                 class Delta {}
                 class Alpha {}
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).containsSubsequence("class Alpha", "class Beta", "class Delta", "class Gamma");
-        assertThat(processedSourceCode)
+        assertThat(processedSrcCode).containsSubsequence("class Alpha", "class Beta", "class Delta", "class Gamma");
+        assertThat(processedSrcCode)
                 .contains("class Beta {\n    int z;\n    int a;\n}")
                 .doesNotContain("class Beta {\n    int a;\n    int z;\n}");
     }
@@ -222,7 +222,7 @@ class OptOutSourceProcessorIntegrationTest {
                         int z;   int a;
                     }
                 """;
-        String originalSourceCode = """
+        String originalSrcCode = """
                 class Outer {
                     int b;
                     int a;
@@ -234,24 +234,22 @@ class OptOutSourceProcessorIntegrationTest {
                     }
                 }
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).contains(ignoredFragment);
-        assertThat(processedSourceCode)
-                .containsSubsequence("int a;", "int b;")
-                .contains("java.util.List<String> values;");
+        assertThat(processedSrcCode).contains(ignoredFragment);
+        assertThat(processedSrcCode).containsSubsequence("int a;", "int b;").contains("java.util.List<String> values;");
     }
 
     @Test
     void processSources_nestedTypeOptOutSortOff_keepNestedMemberOrderAndFormatType() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 class Outer {
                     int b;
                     int a;
@@ -260,15 +258,15 @@ class OptOutSourceProcessorIntegrationTest {
                     static class Inner{int z;int a;}
                 }
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode)
+        assertThat(processedSrcCode)
                 .containsSubsequence("int a;", "int b;")
                 .contains("static class Inner {\n        int z;\n        int a;\n    }")
                 .doesNotContain("static class Inner {\n        int a;\n        int z;\n    }");
@@ -277,7 +275,7 @@ class OptOutSourceProcessorIntegrationTest {
     @Test
     void processSources_nestedTypeOptOutSortOff_moveNestedTypeWithinParentOrdering() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 class Outer {
                     int z;
 
@@ -287,15 +285,15 @@ class OptOutSourceProcessorIntegrationTest {
                     int a;
                 }
                 """;
-        Path javaFilePath = writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        Path javaFilePath = writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, List.of("*.java"), List.of(), FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode)
+        assertThat(processedSrcCode)
                 .containsSubsequence("static class Inner", "int a;", "int z;")
                 .contains("static class Inner {\n        int z;\n        int a;\n    }");
     }
@@ -303,7 +301,7 @@ class OptOutSourceProcessorIntegrationTest {
     @Test
     void processSources_nestedTypeOptOutOff_failFastReportsParentLevelRelocation() throws Exception {
         // Given
-        String originalSourceCode = """
+        String originalSrcCode = """
                 class Outer {
                     int a;
                     int b;
@@ -312,11 +310,11 @@ class OptOutSourceProcessorIntegrationTest {
                     static class Inner{int z;int a;}
                 }
                 """;
-        writeJavaFile("Sample.java", originalSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor(OPT_OUT_TEST_CONFIG);
+        writeJavaFile("Sample.java", originalSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(OPT_OUT_TEST_CONFIG);
 
         // When / Then
-        assertThatThrownBy(() -> sourceProcessor.processSources(
+        assertThatThrownBy(() -> srcProcessor.processSources(
                         temporaryDirectory, List.of("*.java"), List.of(), FlowType.CHECK_FAIL_FAST))
                 .isInstanceOf(NotOrderedException.class)
                 .hasMessageContaining("Outer$Inner expected to relocate UP")

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
@@ -11,7 +11,7 @@ import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfigMerger;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.FileProcessingStatistic;
-import io.github.lemon_ant.jharmonizer.core.processing_stat.SourceProcessingStats.AggregatedProcessingStatistic;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
 import io.github.lemon_ant.jharmonizer.core.testutils.TestCaseResourceUtils;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -33,11 +33,11 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 
 /**
- * Integration-like tests for SourceProcessor.processSources.
+ * Integration-like tests for SrcProcessor.processSources.
  * They work against a real temporary file system and exercise
  * the full flow: config → parser → sorter → formatter.
  */
-class SourceProcessorTest {
+class SrcProcessorTest {
 
     private static final Collection<String> INCLUDE_ALL_JAVA_FILES = Set.of();
     private static final Collection<String> EXCLUDE_NO_FILES = List.of();
@@ -67,60 +67,58 @@ class SourceProcessorTest {
     @Test
     void processSources_singleJavaFile_restructureFlowRewritesFile() throws Exception {
         // Given
-        String sampleSourceCode = TestCaseResourceUtils.readClasspathResourceAsString(SAMPLE_ALL_JAVA21_RESOURCE_URL);
-        Path javaFilePath = writeJavaFile(temporaryDirectory, "SampleAllJava21FeaturesList.java", sampleSourceCode);
-        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SourceProcessor sourceProcessor = new SourceProcessor();
+        String sampleSrcCode = TestCaseResourceUtils.readClasspathResourceAsString(SAMPLE_ALL_JAVA21_RESOURCE_URL);
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "SampleAllJava21FeaturesList.java", sampleSrcCode);
+        String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        SrcProcessor srcProcessor = new SrcProcessor();
 
         // When
-        sourceProcessor.processSources(
-                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(processedSourceCode).isNotBlank().isNotEqualTo(originalSourceCode);
+        assertThat(processedSrcCode).isNotBlank().isNotEqualTo(originalSrcCode);
     }
 
     @Test
     void processSources_multipleJavaFiles_onlyIncludedFilesAreProcessed() throws Exception {
         // Given
-        String unformattedSourceCode = "package demo; public class Included {private int x;}";
-        Path includedJavaFilePath = writeJavaFile(temporaryDirectory, "IncludedSample.java", unformattedSourceCode);
-        Path excludedJavaFilePath = writeJavaFile(temporaryDirectory, "ExcludedSample.java", unformattedSourceCode);
-        String includedOriginalSourceCode = Files.readString(includedJavaFilePath, StandardCharsets.UTF_8);
-        String excludedOriginalSourceCode = Files.readString(excludedJavaFilePath, StandardCharsets.UTF_8);
+        String unformattedSrcCode = "package demo; public class Included {private int x;}";
+        Path includedJavaFilePath = writeJavaFile(temporaryDirectory, "IncludedSample.java", unformattedSrcCode);
+        Path excludedJavaFilePath = writeJavaFile(temporaryDirectory, "ExcludedSample.java", unformattedSrcCode);
+        String includedOriginalSrcCode = Files.readString(includedJavaFilePath, StandardCharsets.UTF_8);
+        String excludedOriginalSrcCode = Files.readString(excludedJavaFilePath, StandardCharsets.UTF_8);
         Collection<String> includeGlobs = Set.of("Included*.java");
-        SourceProcessor sourceProcessor = new SourceProcessor();
+        SrcProcessor srcProcessor = new SrcProcessor();
 
         // When
-        sourceProcessor.processSources(temporaryDirectory, includeGlobs, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
-        String includedProcessedSourceCode = Files.readString(includedJavaFilePath, StandardCharsets.UTF_8);
-        String excludedProcessedSourceCode = Files.readString(excludedJavaFilePath, StandardCharsets.UTF_8);
+        srcProcessor.processSources(temporaryDirectory, includeGlobs, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        String includedProcessedSrcCode = Files.readString(includedJavaFilePath, StandardCharsets.UTF_8);
+        String excludedProcessedSrcCode = Files.readString(excludedJavaFilePath, StandardCharsets.UTF_8);
 
         // Then
-        assertThat(includedProcessedSourceCode)
+        assertThat(includedProcessedSrcCode)
                 .as("Included file must be processed")
-                .isNotEqualTo(includedOriginalSourceCode);
-        assertThat(excludedProcessedSourceCode)
+                .isNotEqualTo(includedOriginalSrcCode);
+        assertThat(excludedProcessedSrcCode)
                 .as("Excluded file must remain unchanged")
-                .isEqualTo(excludedOriginalSourceCode);
+                .isEqualTo(excludedOriginalSrcCode);
     }
 
     @Test
     void processSources_alreadyRestructuredFile_checkFailFastFlowCompletesWithoutExceptions() throws Exception {
         // Given
-        String sampleSourceCode = TestCaseResourceUtils.readClasspathResourceAsString(SAMPLE_ALL_JAVA21_RESOURCE_URL);
-        Path javaFilePath = writeJavaFile(temporaryDirectory, "SampleAllJava21FeaturesList.java", sampleSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor();
-        sourceProcessor.processSources(
-                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        String sampleSrcCode = TestCaseResourceUtils.readClasspathResourceAsString(SAMPLE_ALL_JAVA21_RESOURCE_URL);
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "SampleAllJava21FeaturesList.java", sampleSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor();
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
 
         // When / Then
-        assertThatCode(() -> sourceProcessor.processSources(
+        assertThatCode(() -> srcProcessor.processSources(
                         temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.CHECK_FAIL_FAST))
                 .doesNotThrowAnyException();
-        String finalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        assertThat(finalSourceCode).isNotBlank();
+        String finalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        assertThat(finalSrcCode).isNotBlank();
     }
 
     @Test
@@ -129,14 +127,14 @@ class SourceProcessorTest {
         Path scenarioRoot = copyScenarioInputToWorkingDirectory(temporaryDirectory, "check-all");
         Map<String, String> expectedSources = readScenarioExpectedSources("check-all");
         List<String> orderedInputFiles = List.of("A_Checked.java", "B_Reordered.java", "C_Formatted.java");
-        SourceProcessor sourceProcessor = new SourceProcessor();
+        SrcProcessor srcProcessor = new SrcProcessor();
         ListAppender<ILoggingEvent> listAppender = attachListAppender();
 
         // When
         AggregatedProcessingStatistic aggregatedProcessingStatistic;
         try {
-            aggregatedProcessingStatistic = sourceProcessor.processSources(
-                    scenarioRoot, orderedInputFiles, EXCLUDE_NO_FILES, FlowType.CHECK_ALL);
+            aggregatedProcessingStatistic =
+                    srcProcessor.processSources(scenarioRoot, orderedInputFiles, EXCLUDE_NO_FILES, FlowType.CHECK_ALL);
         } finally {
             detachListAppender(listAppender);
         }
@@ -173,12 +171,12 @@ class SourceProcessorTest {
                 nestedDirectoryPath,
                 "InternalToolForLoggingVerification.java",
                 "package demo; public class InternalToolForLoggingVerification {}");
-        SourceProcessor sourceProcessor = new SourceProcessor();
+        SrcProcessor srcProcessor = new SrcProcessor();
         ListAppender<ILoggingEvent> listAppender = attachListAppender();
 
         // When
         try {
-            sourceProcessor.processSources(
+            srcProcessor.processSources(
                     temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
         } finally {
             detachListAppender(listAppender);
@@ -203,15 +201,15 @@ class SourceProcessorTest {
     @Test
     void processSources_fullyOffFile_logsSkippedStatus() throws Exception {
         // Given
-        String fullyOffSourceCode = "// @jharmonizer:fully-off\npackage demo; public class FullyOffSample {}";
-        Path javaFilePath = writeJavaFile(temporaryDirectory, "FullyOffSample.java", fullyOffSourceCode);
-        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SourceProcessor sourceProcessor = new SourceProcessor();
+        String fullyOffSrcCode = "// @jharmonizer:fully-off\npackage demo; public class FullyOffSample {}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "FullyOffSample.java", fullyOffSrcCode);
+        String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        SrcProcessor srcProcessor = new SrcProcessor();
         ListAppender<ILoggingEvent> listAppender = attachListAppender();
 
         // When
         try {
-            sourceProcessor.processSources(
+            srcProcessor.processSources(
                     temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
         } finally {
             detachListAppender(listAppender);
@@ -221,7 +219,7 @@ class SourceProcessorTest {
         // Then
         assertThat(logs).contains("FullyOffSample.java");
         assertThat(logs).contains("JHarmonizer SKIPPED");
-        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSourceCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSrcCode);
     }
 
     @Test
@@ -231,77 +229,72 @@ class SourceProcessorTest {
         Path customConfigFilePath = writeConfigFile(temporaryDirectory.resolve("custom-config.yml"));
         FlexibleUnifiedConfig externalConfig =
                 JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(customConfigFilePath);
-        SourceProcessor sourceProcessor = new SourceProcessor(externalConfig);
+        SrcProcessor srcProcessor = new SrcProcessor(externalConfig);
 
         // When
-        sourceProcessor.processSources(
-                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
 
         // Then
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        assertThat(processedSourceCode.indexOf("interface Alpha"))
-                .isLessThan(processedSourceCode.indexOf("class Sample"));
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        assertThat(processedSrcCode.indexOf("interface Alpha")).isLessThan(processedSrcCode.indexOf("class Sample"));
     }
 
     @Test
-    void processSources_restructureWithBackupsEnabled_createsBackupNextToSource() throws Exception {
+    void processSources_restructureWithBackupsEnabled_createsBackupNextToSrc() throws Exception {
         // Given
-        String unformattedSourceCode = "package demo; public class BackupEnabled {private int x;}";
-        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupEnabled.java", unformattedSourceCode);
-        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SourceProcessor sourceProcessor = new SourceProcessor(new FlexibleUnifiedConfig(null, null, true, null, null));
+        String unformattedSrcCode = "package demo; public class BackupEnabled {private int x;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupEnabled.java", unformattedSrcCode);
+        String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null));
 
         // When
-        sourceProcessor.processSources(
-                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
 
         // Then
         Path backupFilePath =
                 javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
         assertThat(backupFilePath).exists();
-        assertThat(Files.readString(backupFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSourceCode);
-        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSourceCode);
+        assertThat(Files.readString(backupFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSrcCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSrcCode);
     }
 
     @Test
     void processSources_restructureWithBackupsDisabled_doesNotCreateBackup() throws Exception {
         // Given
-        String unformattedSourceCode = "package demo; public class BackupDisabled {private int x;}";
-        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSourceCode);
-        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SourceProcessor sourceProcessor = new SourceProcessor(new FlexibleUnifiedConfig(null, null, false, null, null));
+        String unformattedSrcCode = "package demo; public class BackupDisabled {private int x;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSrcCode);
+        String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, false, null, null));
 
         // When
-        sourceProcessor.processSources(
-                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
 
         // Then
         Path backupFilePath =
                 javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
         assertThat(backupFilePath).doesNotExist();
-        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSourceCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSrcCode);
     }
 
     @Test
     void processSources_restructureWithNoBackupOverride_doesNotCreateBackup() throws Exception {
         // Given
-        String unformattedSourceCode = "package demo; public class BackupOverrideDisabled {private int x;}";
-        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupOverrideDisabled.java", unformattedSourceCode);
-        String originalSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        String unformattedSrcCode = "package demo; public class BackupOverrideDisabled {private int x;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupOverrideDisabled.java", unformattedSrcCode);
+        String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
         FlexibleUnifiedConfig effectiveConfig = UnifiedConfigMerger.merge(
                 new FlexibleUnifiedConfig(null, null, true, null, null),
                 new FlexibleUnifiedConfig(null, null, false, null, null));
-        SourceProcessor sourceProcessor = new SourceProcessor(effectiveConfig);
+        SrcProcessor srcProcessor = new SrcProcessor(effectiveConfig);
 
         // When
-        sourceProcessor.processSources(
-                temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
 
         // Then
         Path backupFilePath =
                 javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
         assertThat(backupFilePath).doesNotExist();
-        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSourceCode);
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSrcCode);
     }
 
     @NonNull
@@ -317,7 +310,7 @@ class SourceProcessorTest {
 
     @NonNull
     private static ListAppender<ILoggingEvent> attachListAppender() {
-        Logger logger = (Logger) LoggerFactory.getLogger(SourceProcessor.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(SrcProcessor.class);
         ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
         listAppender.start();
         logger.addAppender(listAppender);
@@ -325,7 +318,7 @@ class SourceProcessorTest {
     }
 
     private static void detachListAppender(ListAppender<ILoggingEvent> listAppender) {
-        Logger logger = (Logger) LoggerFactory.getLogger(SourceProcessor.class);
+        Logger logger = (Logger) LoggerFactory.getLogger(SrcProcessor.class);
         logger.detachAppender(listAppender);
         listAppender.stop();
     }
@@ -339,17 +332,16 @@ class SourceProcessorTest {
 
     @NonNull
     private static Path copyScenarioInputToWorkingDirectory(Path temporaryRoot, String scenarioName) {
-        Path sourceInputDirectory =
-                FLOW_LEVEL_FIXTURES_ROOT.resolve(scenarioName).resolve("input");
+        Path srcInputDirectory = FLOW_LEVEL_FIXTURES_ROOT.resolve(scenarioName).resolve("input");
         Path workingDirectory = temporaryRoot.resolve("flow-level").resolve(scenarioName);
-        try (Stream<Path> sourceFiles = Files.list(sourceInputDirectory)) {
+        try (Stream<Path> srcFiles = Files.list(srcInputDirectory)) {
             Files.createDirectories(workingDirectory);
-            sourceFiles.filter(Files::isRegularFile).forEach(sourceFile -> {
-                Path targetFile = workingDirectory.resolve(sourceFile.getFileName());
+            srcFiles.filter(Files::isRegularFile).forEach(srcFile -> {
+                Path targetFile = workingDirectory.resolve(srcFile.getFileName());
                 try {
-                    Files.copy(sourceFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                    Files.copy(srcFile, targetFile, StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException exception) {
-                    throw new IllegalStateException("Failed to copy fixture file: " + sourceFile, exception);
+                    throw new IllegalStateException("Failed to copy fixture file: " + srcFile, exception);
                 }
             });
             return workingDirectory;
@@ -378,7 +370,7 @@ class SourceProcessorTest {
                     .sorted(Comparator.comparing(path -> path.getFileName().toString()))
                     .collect(Collectors.toMap(
                             path -> path.getFileName().toString(),
-                            SourceProcessorTest::readSourceFile,
+                            SrcProcessorTest::readSrcFile,
                             (left, right) -> left,
                             java.util.LinkedHashMap::new));
         } catch (IOException exception) {
@@ -387,11 +379,11 @@ class SourceProcessorTest {
     }
 
     @NonNull
-    private static String readSourceFile(Path sourceFile) {
+    private static String readSrcFile(Path srcFile) {
         try {
-            return Files.readString(sourceFile, StandardCharsets.UTF_8);
+            return Files.readString(srcFile, StandardCharsets.UTF_8);
         } catch (IOException exception) {
-            throw new IllegalStateException("Failed to read fixture source file: " + sourceFile, exception);
+            throw new IllegalStateException("Failed to read fixture source file: " + srcFile, exception);
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/DefaultConfigOrderingIntegrationTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/DefaultConfigOrderingIntegrationTest.java
@@ -2,7 +2,7 @@ package io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.testutils.TestCaseResourceUtils;
 import java.net.URL;
@@ -24,33 +24,32 @@ class DefaultConfigOrderingIntegrationTest {
     @Test
     void applyEmbeddedDefaultConfig_sampleAllJava21FeaturesList_matchExpectedOrdering() throws Exception {
         // Given
-        String sampleSourceCode =
+        String sampleSrcCode =
                 TestCaseResourceUtils.readClasspathResourceAsString(Constants.SAMPLE_ALL_JAVA21_RESOURCE_URL);
-        Path javaFilePath = writeJavaFile(temporaryDirectory, Constants.SAMPLE_ALL_JAVA21_FILE_NAME, sampleSourceCode);
-        SourceProcessor sourceProcessor = new SourceProcessor();
+        Path javaFilePath = writeJavaFile(temporaryDirectory, Constants.SAMPLE_ALL_JAVA21_FILE_NAME, sampleSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor();
 
         // When
-        sourceProcessor.processSources(
+        srcProcessor.processSources(
                 temporaryDirectory, Constants.INCLUDE_ALL_JAVA_FILES, Constants.EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
-        String processedSourceCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
+        String processedSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
 
         // Then
         int publicStaticMainMethodIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PUBLIC_STATIC_MAIN_METHOD_FRAGMENT);
-        int publicConstructorIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PUBLIC_CONSTRUCTOR_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PUBLIC_STATIC_MAIN_METHOD_FRAGMENT);
+        int publicConstructorIndex = requireSrcFragmentIndex(processedSrcCode, Constants.PUBLIC_CONSTRUCTOR_FRAGMENT);
         int publicAssertionTestMethodIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PUBLIC_ASSERTION_TEST_METHOD_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PUBLIC_ASSERTION_TEST_METHOD_FRAGMENT);
         int publicEnhancedForLoopMethodIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PUBLIC_ENHANCED_FOR_LOOP_METHOD_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PUBLIC_ENHANCED_FOR_LOOP_METHOD_FRAGMENT);
         int publicRecordPersonIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PUBLIC_RECORD_PERSON_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PUBLIC_RECORD_PERSON_FRAGMENT);
         int publicInterfaceDefaultMethodIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PUBLIC_INTERFACE_DEFAULT_METHOD_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PUBLIC_INTERFACE_DEFAULT_METHOD_FRAGMENT);
         int packagePrivateInnerClassIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PACKAGE_PRIVATE_INNER_CLASS_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PACKAGE_PRIVATE_INNER_CLASS_FRAGMENT);
         int packagePrivateStaticNestedClassIndex =
-                requireSourceFragmentIndex(processedSourceCode, Constants.PACKAGE_PRIVATE_STATIC_NESTED_CLASS_FRAGMENT);
+                requireSrcFragmentIndex(processedSrcCode, Constants.PACKAGE_PRIVATE_STATIC_NESTED_CLASS_FRAGMENT);
 
         assertThat(publicStaticMainMethodIndex)
                 .as("Default config should place public static methods before public constructors")
@@ -72,12 +71,12 @@ class DefaultConfigOrderingIntegrationTest {
         return Files.writeString(javaFilePath, fileContent, StandardCharsets.UTF_8);
     }
 
-    private static int requireSourceFragmentIndex(String sourceCode, String sourceFragment) {
-        int sourceFragmentIndex = sourceCode.indexOf(sourceFragment);
-        if (sourceFragmentIndex < 0) {
-            throw new IllegalStateException("Source fragment not found: " + sourceFragment);
+    private static int requireSrcFragmentIndex(String srcCode, String srcFragment) {
+        int srcFragmentIndex = srcCode.indexOf(srcFragment);
+        if (srcFragmentIndex < 0) {
+            throw new IllegalStateException("Source fragment not found: " + srcFragment);
         }
-        return sourceFragmentIndex;
+        return srcFragmentIndex;
     }
 
     private static final class Constants {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java
@@ -1,15 +1,15 @@
 package io.github.lemon_ant.jharmonizer.core.e2e;
 
-import static io.github.lemon_ant.jharmonizer.core.e2e.JavaCompileTestUtils.compileJavaSourceWithRelease21;
+import static io.github.lemon_ant.jharmonizer.core.e2e.JavaCompileTestUtils.compileJavaSrcWithRelease21;
 import static io.github.lemon_ant.jharmonizer.core.e2e.JavaRunMainTestUtils.runJavaMainMethod;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.github.lemon_ant.jharmonizer.core.SourceProcessor;
+import io.github.lemon_ant.jharmonizer.core.SrcProcessor;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
-import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -25,26 +25,26 @@ import java.util.stream.Stream;
 import lombok.NonNull;
 import org.junit.jupiter.params.provider.Arguments;
 
-abstract class AbstractSourceProcessorScenarioE2ETest {
+abstract class AbstractSrcProcessorScenarioE2ETest {
 
     private static final String INPUT_DIRECTORY = "input";
     private static final String EXPECTED_DIRECTORY = "expected";
     private static final Pattern SCENARIO_PREFIX_PATTERN = Pattern.compile("^(\\d+)-.+$");
 
     protected final void processFixtureInputFileMatchesExpectedAndCompileAfter(
-            Path temporaryDirectory, Path scenarioDir, Path sourceFile) throws Exception {
+            Path temporaryDirectory, Path scenarioDir, Path srcFile) throws Exception {
         // Given
         Path fixtureScenario = getFixturesRoot().resolve(scenarioDir);
-        Path fixtureInputFile = resolveInput(fixtureScenario).resolve(sourceFile);
-        Path expectedSourceFile = resolveExpected(fixtureScenario).resolve(sourceFile);
+        Path fixtureInputFile = resolveInput(fixtureScenario).resolve(srcFile);
+        Path expectedSrcFile = resolveExpected(fixtureScenario).resolve(srcFile);
         String scenarioName = scenarioDir.toString();
-        String inputSourceCode = Files.readString(fixtureInputFile, StandardCharsets.UTF_8);
-        String expectedSourceCode = Files.readString(expectedSourceFile, StandardCharsets.UTF_8);
+        String inputSrcCode = Files.readString(fixtureInputFile, StandardCharsets.UTF_8);
+        String expectedSrcCode = Files.readString(expectedSrcFile, StandardCharsets.UTF_8);
 
         Path workingScenarioRoot =
                 temporaryDirectory.resolve(resolveWorkspaceDirectoryName()).resolve(scenarioName);
         Path workingInputFile = copyInputJavaFile(fixtureInputFile, workingScenarioRoot);
-        boolean unchangedFixture = inputSourceCode.equals(expectedSourceCode);
+        boolean unchangedFixture = inputSrcCode.equals(expectedSrcCode);
 
         Path compileBeforeOutput =
                 temporaryDirectory.resolve(resolveCompileBeforeDirectoryName()).resolve(scenarioName);
@@ -52,7 +52,7 @@ abstract class AbstractSourceProcessorScenarioE2ETest {
                 temporaryDirectory.resolve(resolveCompileAfterDirectoryName()).resolve(scenarioName);
 
         JavaCompileTestUtils.CompileResult compileBeforeResult =
-                compileJavaSourceWithRelease21(workingInputFile, compileBeforeOutput);
+                compileJavaSrcWithRelease21(workingInputFile, compileBeforeOutput);
         assertThat(compileBeforeResult.getExitCode())
                 .as(
                         "Expected javac --release 21 to compile file %s. Diagnostics:%n%s",
@@ -70,7 +70,7 @@ abstract class AbstractSourceProcessorScenarioE2ETest {
         assertFileProcessingIsDeterministic(fixtureScenario, workingInputFile);
 
         JavaCompileTestUtils.CompileResult compileAfterResult =
-                compileJavaSourceWithRelease21(workingInputFile, compileAfterOutput);
+                compileJavaSrcWithRelease21(workingInputFile, compileAfterOutput);
         assertThat(compileAfterResult.getExitCode())
                 .as(
                         "Expected javac --release 21 to compile file %s. Diagnostics:%n%s",
@@ -80,7 +80,7 @@ abstract class AbstractSourceProcessorScenarioE2ETest {
         assertMainMethodExecutionSucceedsWhenPresent(workingInputFile, compileAfterOutput);
 
         String workingInputFileSrc = Files.readString(workingInputFile, StandardCharsets.UTF_8);
-        assertThat(workingInputFileSrc).isEqualTo(expectedSourceCode);
+        assertThat(workingInputFileSrc).isEqualTo(expectedSrcCode);
     }
 
     protected final void fixtureScenarioDirectoriesNumberingValidatedHaveUniqueSequentialNumbersWithoutGaps()
@@ -122,13 +122,12 @@ abstract class AbstractSourceProcessorScenarioE2ETest {
         Comparator<Path> fixtureExecutionOrder = Comparator.comparing(
                         this::resolveScenarioDirectoryName, Comparator.reverseOrder())
                 .thenComparing(Path::getFileName, Comparator.naturalOrder());
-        return SourceFilesHandler.findJavaFiles(
-                        getFixturesRoot(), List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())
+        return SrcFilesHandler.findJavaFiles(getFixturesRoot(), List.of("**/" + INPUT_DIRECTORY + "/*.java"), List.of())
                 .sorted(fixtureExecutionOrder)
                 .map(fixtureInputFile -> {
                     Path scenarioDir = fixtureInputFile.getParent().getParent().getFileName();
-                    Path sourceFile = fixtureInputFile.getFileName();
-                    return Arguments.of(scenarioDir, sourceFile);
+                    Path srcFile = fixtureInputFile.getFileName();
+                    return Arguments.of(scenarioDir, srcFile);
                 });
     }
 
@@ -204,22 +203,22 @@ abstract class AbstractSourceProcessorScenarioE2ETest {
                 .doesNotThrowAnyException();
     }
 
-    private void runProcessorForSingleFile(Path sourceFilePath, Optional<Path> scenarioConfigPath, FlowType flowType) {
-        SourceProcessor sourceProcessor = buildSourceProcessor(scenarioConfigPath);
-        sourceProcessor.processSources(
-                sourceFilePath.getParent(), List.of(sourceFilePath.getFileName().toString()), List.of(), flowType);
+    private void runProcessorForSingleFile(Path srcFilePath, Optional<Path> scenarioConfigPath, FlowType flowType) {
+        SrcProcessor srcProcessor = buildSrcProcessor(scenarioConfigPath);
+        srcProcessor.processSources(
+                srcFilePath.getParent(), List.of(srcFilePath.getFileName().toString()), List.of(), flowType);
     }
 
     @NonNull
-    private static SourceProcessor buildSourceProcessor(Optional<Path> scenarioConfigPath) {
+    private static SrcProcessor buildSrcProcessor(Optional<Path> scenarioConfigPath) {
         if (scenarioConfigPath.isEmpty()) {
-            return new SourceProcessor();
+            return new SrcProcessor();
         }
 
         FlexibleUnifiedConfig flexibleConfig =
                 JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromClasspathResource(
                         E2EFileUtils.toUrl(scenarioConfigPath.orElseThrow()));
-        return new SourceProcessor(flexibleConfig);
+        return new SrcProcessor(flexibleConfig);
     }
 
     @NonNull

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/E2EFileUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/E2EFileUtils.java
@@ -10,9 +10,9 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 class E2EFileUtils {
 
-    static void requireRegularFile(@NonNull Path sourceFilePath, @NonNull String messagePrefix) {
-        if (!Files.isRegularFile(sourceFilePath)) {
-            throw new IllegalArgumentException(messagePrefix + sourceFilePath);
+    static void requireRegularFile(@NonNull Path srcFilePath, @NonNull String messagePrefix) {
+        if (!Files.isRegularFile(srcFilePath)) {
+            throw new IllegalArgumentException(messagePrefix + srcFilePath);
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaCompileTestUtils.java
@@ -17,10 +17,10 @@ class JavaCompileTestUtils {
     private static final int JAVA_RELEASE = 21;
     private static final String TEST_COMPILE_PREFIX = "test-compile-";
 
-    static CompileResult compileJavaSourceWithRelease21(@NonNull Path sourceFilePath, @NonNull Path outputDirectoryPath)
+    static CompileResult compileJavaSrcWithRelease21(@NonNull Path srcFilePath, @NonNull Path outputDirectoryPath)
             throws IOException, InterruptedException {
         ensureOutputDirectoryExists(outputDirectoryPath);
-        E2EFileUtils.requireRegularFile(sourceFilePath, "Expected Java source file to compile, but got: ");
+        E2EFileUtils.requireRegularFile(srcFilePath, "Expected Java source file to compile, but got: ");
 
         Path diagnosticsPath = outputDirectoryPath.resolve(TEST_COMPILE_PREFIX + "logs.txt");
 
@@ -32,7 +32,7 @@ class JavaCompileTestUtils {
                 StandardCharsets.UTF_8.name(),
                 "-d",
                 outputDirectoryPath.toString(),
-                sourceFilePath.toAbsolutePath().toString());
+                srcFilePath.toAbsolutePath().toString());
 
         Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
         String javacOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaRunMainTestUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/JavaRunMainTestUtils.java
@@ -16,11 +16,11 @@ class JavaRunMainTestUtils {
 
     private static final String TEST_RUN_PREFIX = "test-run-";
 
-    static RunResult runJavaMainMethod(@NonNull Path sourceFilePath, @NonNull Path classesOutputDirectoryPath)
+    static RunResult runJavaMainMethod(@NonNull Path srcFilePath, @NonNull Path classesOutputDirectoryPath)
             throws IOException, InterruptedException {
-        E2EFileUtils.requireRegularFile(sourceFilePath, "Expected Java source file to run main method from, but got: ");
+        E2EFileUtils.requireRegularFile(srcFilePath, "Expected Java source file to run main method from, but got: ");
 
-        String className = resolveClassName(sourceFilePath);
+        String className = resolveClassName(srcFilePath);
         List<String> command = List.of("java", "-cp", classesOutputDirectoryPath.toString(), className);
         Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
         String javaOutput = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SrcProcessorE2EFixtureTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SrcProcessorE2EFixtureTest.java
@@ -6,31 +6,34 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Optional;
 import lombok.NonNull;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+// PER_CLASS allows non-static @MethodSource from the shared base class.
+// This test keeps only immutable constants plus @TempDir, and each scenario is processed in its own
+// subdirectory, so no mutable scenario state leaks between parameterized invocations.
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SourceProcessorRegressionTest extends AbstractSourceProcessorScenarioE2ETest {
+class SrcProcessorE2EFixtureTest extends AbstractSrcProcessorScenarioE2ETest {
 
-    private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/regression/";
+    private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
     private static final URL FIXTURE_RESOURCES_ROOT_DIR =
             TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
 
     @NonNull
     private static final Path FIXTURES_ROOT = resolveFixturesRoot();
 
+    private static final String CONFIG_FILE = "config.yml";
+
     @TempDir
     Path temporaryDirectory;
 
     @ParameterizedTest(name = "[{index}] {0}/{1}")
     @MethodSource("fixtureInputFiles")
-    @Disabled
-    void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path sourceFile) throws Exception {
-        processFixtureInputFileMatchesExpectedAndCompileAfter(temporaryDirectory, scenarioDir, sourceFile);
+    void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path srcFile) throws Exception {
+        processFixtureInputFileMatchesExpectedAndCompileAfter(temporaryDirectory, scenarioDir, srcFile);
     }
 
     @Test
@@ -47,26 +50,25 @@ class SourceProcessorRegressionTest extends AbstractSourceProcessorScenarioE2ETe
     @Override
     @NonNull
     protected Optional<Path> findScenarioConfigPath(Path fixtureScenario) {
-        Path scenarioConfigPath = fixtureScenario.resolve("config.yml");
-        return java.nio.file.Files.exists(scenarioConfigPath) ? Optional.of(scenarioConfigPath) : Optional.empty();
+        return Optional.of(fixtureScenario.resolve(CONFIG_FILE));
     }
 
     @Override
     @NonNull
     protected String resolveWorkspaceDirectoryName() {
-        return "SourceProcessorRegressionE2E-working-dir";
+        return "SrcProcessorE2E-working-dir";
     }
 
     @Override
     @NonNull
     protected String resolveCompileBeforeDirectoryName() {
-        return "SourceProcessorRegressionE2E-compile-before";
+        return "SrcProcessorE2E-compile-before";
     }
 
     @Override
     @NonNull
     protected String resolveCompileAfterDirectoryName() {
-        return "SourceProcessorRegressionE2E-compile-after";
+        return "SrcProcessorE2E-compile-after";
     }
 
     @NonNull

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SrcProcessorRegressionTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/SrcProcessorRegressionTest.java
@@ -6,34 +6,31 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.Optional;
 import lombok.NonNull;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-// PER_CLASS allows non-static @MethodSource from the shared base class.
-// This test keeps only immutable constants plus @TempDir, and each scenario is processed in its own
-// subdirectory, so no mutable scenario state leaks between parameterized invocations.
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class SourceProcessorE2EFixtureTest extends AbstractSourceProcessorScenarioE2ETest {
+class SrcProcessorRegressionTest extends AbstractSrcProcessorScenarioE2ETest {
 
-    private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/restructure/";
+    private static final String FIXTURES_RESOURCE = "/test-cases/core/e2e/regression/";
     private static final URL FIXTURE_RESOURCES_ROOT_DIR =
             TestCaseResourceUtils.requireClasspathDirectoryUrl(FIXTURES_RESOURCE);
 
     @NonNull
     private static final Path FIXTURES_ROOT = resolveFixturesRoot();
 
-    private static final String CONFIG_FILE = "config.yml";
-
     @TempDir
     Path temporaryDirectory;
 
     @ParameterizedTest(name = "[{index}] {0}/{1}")
     @MethodSource("fixtureInputFiles")
-    void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path sourceFile) throws Exception {
-        processFixtureInputFileMatchesExpectedAndCompileAfter(temporaryDirectory, scenarioDir, sourceFile);
+    @Disabled
+    void processFixtureInputFile_matchesExpectedAndCompileAfter(Path scenarioDir, Path srcFile) throws Exception {
+        processFixtureInputFileMatchesExpectedAndCompileAfter(temporaryDirectory, scenarioDir, srcFile);
     }
 
     @Test
@@ -50,25 +47,26 @@ class SourceProcessorE2EFixtureTest extends AbstractSourceProcessorScenarioE2ETe
     @Override
     @NonNull
     protected Optional<Path> findScenarioConfigPath(Path fixtureScenario) {
-        return Optional.of(fixtureScenario.resolve(CONFIG_FILE));
+        Path scenarioConfigPath = fixtureScenario.resolve("config.yml");
+        return java.nio.file.Files.exists(scenarioConfigPath) ? Optional.of(scenarioConfigPath) : Optional.empty();
     }
 
     @Override
     @NonNull
     protected String resolveWorkspaceDirectoryName() {
-        return "SourceProcessorE2E-working-dir";
+        return "SrcProcessorRegressionE2E-working-dir";
     }
 
     @Override
     @NonNull
     protected String resolveCompileBeforeDirectoryName() {
-        return "SourceProcessorE2E-compile-before";
+        return "SrcProcessorRegressionE2E-compile-before";
     }
 
     @Override
     @NonNull
     protected String resolveCompileAfterDirectoryName() {
-        return "SourceProcessorE2E-compile-after";
+        return "SrcProcessorRegressionE2E-compile-after";
     }
 
     @NonNull

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandlerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandlerTest.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-class SourceFilesHandlerTest {
+class SrcFilesHandlerTest {
 
     @TempDir
     Path tempDir;
@@ -21,15 +21,15 @@ class SourceFilesHandlerTest {
     @Test
     void backup_existingFile_renamedWithBakExtension() throws IOException {
         // Given
-        Path sourceFile = Files.writeString(tempDir.resolve("Example.java"), "class Example {}");
+        Path srcFile = Files.writeString(tempDir.resolve("Example.java"), "class Example {}");
 
         // When
-        SourceFilesHandler.renameToBackup(sourceFile);
+        SrcFilesHandler.renameToBackup(srcFile);
 
         // Then
         Path expectedBackup = tempDir.resolve("Example.java.bak");
         assertThat(expectedBackup).exists();
-        assertThat(sourceFile).doesNotExist();
+        assertThat(srcFile).doesNotExist();
     }
 
     @Test
@@ -38,7 +38,7 @@ class SourceFilesHandlerTest {
         Path missingFile = tempDir.resolve("DoesNotExist.java");
 
         // When / Then
-        assertThatThrownBy(() -> SourceFilesHandler.renameToBackup(missingFile))
+        assertThatThrownBy(() -> SrcFilesHandler.renameToBackup(missingFile))
                 .isInstanceOf(UncheckedIOException.class)
                 .hasMessageContaining("does not exist");
     }
@@ -66,7 +66,7 @@ class SourceFilesHandlerTest {
         Path txtFile = Files.writeString(tempDir.resolve("notes.txt"), "not java");
 
         // When
-        List<Path> result = SourceFilesHandler.findJavaFiles(tempDir, Set.of("**.java"), Set.of())
+        List<Path> result = SrcFilesHandler.findJavaFiles(tempDir, Set.of("**.java"), Set.of())
                 .collect(Collectors.toList());
 
         // Then
@@ -78,14 +78,14 @@ class SourceFilesHandlerTest {
     @Test
     void overwrite_existingFile_replacesFileContent() throws IOException {
         // Given
-        Path sourceFile = Files.writeString(tempDir.resolve("Overwrite.java"), "old content");
-        SrcFile srcFile = new SrcFile("new content", sourceFile);
+        Path srcFile = Files.writeString(tempDir.resolve("Overwrite.java"), "old content");
+        SrcFile srcFile = new SrcFile("new content", srcFile);
 
         // When
-        SourceFilesHandler.overwrite(srcFile.getPath(), srcFile.getSrcCode());
+        SrcFilesHandler.overwrite(srcFile.getPath(), srcFile.getSrcCode());
 
         // Then
-        String newText = Files.readString(sourceFile);
+        String newText = Files.readString(srcFile);
         assertThat(newText).isEqualTo("new content");
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandlerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandlerTest.java
@@ -78,14 +78,14 @@ class SrcFilesHandlerTest {
     @Test
     void overwrite_existingFile_replacesFileContent() throws IOException {
         // Given
-        Path srcFile = Files.writeString(tempDir.resolve("Overwrite.java"), "old content");
-        SrcFile srcFile = new SrcFile("new content", srcFile);
+        Path srcPath = Files.writeString(tempDir.resolve("Overwrite.java"), "old content");
+        SrcFile srcFile = new SrcFile("new content", srcPath);
 
         // When
         SrcFilesHandler.overwrite(srcFile.getPath(), srcFile.getSrcCode());
 
         // Then
-        String newText = Files.readString(srcFile);
+        String newText = Files.readString(srcPath);
         assertThat(newText).isEqualTo("new content");
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/flow/CheckFailFastFlowIntegrationTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/flow/CheckFailFastFlowIntegrationTest.java
@@ -21,16 +21,16 @@ class CheckFailFastFlowIntegrationTest {
     void processSource_firstViolationDetected_stopsSequentialProcessing() {
         // Given
         CheckFailFastFlow flow = createFlow();
-        List<SrcFile> sourceFiles = List.of(
+        List<SrcFile> srcFiles = List.of(
                 createSrcFile("class BViolation { int z; int a; }", Path.of("B_Violation.java")),
                 createSrcFile("class CFormatted{int a;}", Path.of("C_Formatted.java")));
         AtomicInteger processedSources = new AtomicInteger();
 
         // When / Then
-        assertThatThrownBy(() -> sourceFiles.stream()
-                        .map(sourceFile -> {
+        assertThatThrownBy(() -> srcFiles.stream()
+                        .map(srcFile -> {
                             processedSources.incrementAndGet();
-                            return flow.processSource(sourceFile);
+                            return flow.processSrc(srcFile);
                         })
                         .toList())
                 .isInstanceOf(NotOrderedException.class)

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/formatter/FormatterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/formatter/FormatterTest.java
@@ -54,11 +54,11 @@ class FormatterTest {
         String srcCode = "class Person {  }\n";
 
         // When
-        FormattingResult formatingResult = formatter.formatSrc(
+        FormattingResult formattingResult = formatter.formatSrc(
                 srcCode, Path.of("Person.java"), List.of(new SrcCharacterRange(0, srcCode.length())));
 
         // Then
-        assertThat(formatingResult.getFormattedSrcCode()).isEqualTo(srcCode);
+        assertThat(formattingResult.getFormattedSrcCode()).isEqualTo(srcCode);
     }
 
     @Test

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/formatter/FormatterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/formatter/FormatterTest.java
@@ -12,14 +12,14 @@ import org.junit.jupiter.api.Test;
 class FormatterTest {
 
     @Test
-    void fixImports_validSourceClass_returnsExpectedFormattedClass() {
+    void fixImports_validSrcClass_returnsExpectedFormattedClass() {
         // Given
         Formatter formatter = new Formatter(PALANTIR, true);
-        String sourceClass = "import junit.framework.TestCase; \npublic class Person {}";
+        String srcClass = "import junit.framework.TestCase; \npublic class Person {}";
         String expectedClass = "public class Person {}\n";
 
         // When
-        FormattingResult formattingResult = formatter.formatSource(sourceClass, Path.of(""), List.of());
+        FormattingResult formattingResult = formatter.formatSrc(srcClass, Path.of(""), List.of());
         FormattingStatistic formattingStatistic = formattingResult.getFormattingStatistic();
 
         // Then
@@ -30,14 +30,14 @@ class FormatterTest {
     }
 
     @Test
-    void formatSourceAndFixImports_validSourceClass_returnsExpectedFormattedClass() {
+    void formatSourceAndFixImports_validSrcClass_returnsExpectedFormattedClass() {
         // Given
         Formatter formatter = new Formatter(PALANTIR, false);
-        String sourceClass = "public class Person {}";
+        String srcClass = "public class Person {}";
         String expectedClass = "public class Person {}\n";
 
         // When
-        FormattingResult formattingResult = formatter.formatSource(sourceClass, Path.of(""), List.of());
+        FormattingResult formattingResult = formatter.formatSrc(srcClass, Path.of(""), List.of());
         FormattingStatistic formattingStatistic = formattingResult.getFormattingStatistic();
 
         // Then
@@ -48,17 +48,17 @@ class FormatterTest {
     }
 
     @Test
-    void formatSource_withFullExclusionRange_keepSourceUnchanged() {
+    void formatSource_withFullExclusionRange_keepSrcUnchanged() {
         // Given
         Formatter formatter = new Formatter(PALANTIR, false);
-        String sourceCode = "class Person {  }\n";
+        String srcCode = "class Person {  }\n";
 
         // When
-        FormattingResult formatingResult = formatter.formatSource(
-                sourceCode, Path.of("Person.java"), List.of(new SrcCharacterRange(0, sourceCode.length())));
+        FormattingResult formatingResult = formatter.formatSrc(
+                srcCode, Path.of("Person.java"), List.of(new SrcCharacterRange(0, srcCode.length())));
 
         // Then
-        assertThat(formatingResult.getFormattedSrcCode()).isEqualTo(sourceCode);
+        assertThat(formatingResult.getFormattedSrcCode()).isEqualTo(srcCode);
     }
 
     @Test
@@ -66,13 +66,13 @@ class FormatterTest {
         // Given
         Formatter formatter = new Formatter(PALANTIR, false);
         String excludedFragment = "int  preserved;";
-        String sourceCode = "class Person{int a;  %s}\n".formatted(excludedFragment);
-        int excludedStart = sourceCode.indexOf(excludedFragment);
+        String srcCode = "class Person{int a;  %s}\n".formatted(excludedFragment);
+        int excludedStart = srcCode.indexOf(excludedFragment);
         int excludedEnd = excludedStart + excludedFragment.length();
 
         // When
-        FormattingResult formattingResult = formatter.formatSource(
-                sourceCode, Path.of("Person.java"), List.of(new SrcCharacterRange(excludedStart, excludedEnd)));
+        FormattingResult formattingResult = formatter.formatSrc(
+                srcCode, Path.of("Person.java"), List.of(new SrcCharacterRange(excludedStart, excludedEnd)));
 
         // Then
         assertThat(formattingResult.getFormattedSrcCode())
@@ -85,12 +85,12 @@ class FormatterTest {
     void formatSource_overlappingExclusionRanges_throwIllegalArgumentException() {
         // Given
         Formatter formatter = new Formatter(PALANTIR, false);
-        String sourceCode = "class Person{int a; int b;}\n";
+        String srcCode = "class Person{int a; int b;}\n";
         List<SrcCharacterRange> formattingSkippedRanges =
                 List.of(new SrcCharacterRange(0, 10), new SrcCharacterRange(8, 15));
 
         // When / Then
-        assertThatThrownBy(() -> formatter.formatSource(sourceCode, Path.of("Person.java"), formattingSkippedRanges))
+        assertThatThrownBy(() -> formatter.formatSrc(srcCode, Path.of("Person.java"), formattingSkippedRanges))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Excluded ranges must be sorted and non-overlapping");
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/optout/JHarmonizerOptOutResolverTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/optout/JHarmonizerOptOutResolverTest.java
@@ -13,9 +13,9 @@ import spoon.reflect.declaration.CtType;
 class JHarmonizerOptOutResolverTest {
 
     @Test
-    void parseJavaSourceResource_fileOptOutBeforePackage_resolveFileOptOutOff() {
+    void parseJavaSrcResource_fileOptOutBeforePackage_resolveFileOptOutOff() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 // @jharmonizer:fully-off
                 package demo;
 
@@ -23,16 +23,16 @@ class JHarmonizerOptOutResolverTest {
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Sample.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Sample.java")));
 
         // Then
         assertThat(spoonAstModel.getOptOuts().getFileOptOutMode()).contains(JHarmonizerOptOutMode.FULLY_OFF);
     }
 
     @Test
-    void parseJavaSourceResource_fileOptOutBetweenPackageAndImport_resolveFileSortOffOptOut() {
+    void parseJavaSrcResource_fileOptOutBetweenPackageAndImport_resolveFileSortOffOptOut() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 package demo;
 
                 /* @jharmonizer:sort-off */
@@ -42,16 +42,16 @@ class JHarmonizerOptOutResolverTest {
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Sample.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Sample.java")));
 
         // Then
         assertThat(spoonAstModel.getOptOuts().getFileOptOutMode()).contains(JHarmonizerOptOutMode.SORTING_OFF);
     }
 
     @Test
-    void parseJavaSourceResource_typeOptOutBeforeAnnotatedTopLevelType_resolveTypeOptOut() {
+    void parseJavaSrcResource_typeOptOutBeforeAnnotatedTopLevelType_resolveTypeOptOut() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 package demo;
 
                 // @jharmonizer:fully-off
@@ -60,7 +60,7 @@ class JHarmonizerOptOutResolverTest {
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Sample.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Sample.java")));
         CtType<?> sampleType =
                 spoonAstModel.getCompilationUnit().getDeclaredTypes().getFirst();
 
@@ -69,9 +69,9 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_typeOptOutBeforeNestedType_resolveNestedTypeOptOut() {
+    void parseJavaSrcResource_typeOptOutBeforeNestedType_resolveNestedTypeOptOut() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 package demo;
 
                 class Outer {
@@ -81,7 +81,7 @@ class JHarmonizerOptOutResolverTest {
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Outer.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Outer.java")));
         CtCompilationUnit compilationUnit = spoonAstModel.getCompilationUnit();
         CtType<?> outerType = compilationUnit.getDeclaredTypes().getFirst();
         CtType<?> nestedType = outerType.getNestedTypes().stream().findFirst().orElseThrow();
@@ -92,7 +92,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_packageInfoFullyOffBeforeJavadoc_resolveFileOptOutOff() {
+    void parseJavaSrcResource_packageInfoFullyOffBeforeJavadoc_resolveFileOptOutOff() {
         // Given
         String srcCode = """
                 // @jharmonizer:fully-off
@@ -112,7 +112,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_packageInfoFullyOffThenSortOff_resolveFileFullyOff() {
+    void parseJavaSrcResource_packageInfoFullyOffThenSortOff_resolveFileFullyOff() {
         // Given
         String srcCode = """
                 // @jharmonizer:fully-off
@@ -133,7 +133,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_moduleInfoFullyOffThenSortOff_resolveFileFullyOff() {
+    void parseJavaSrcResource_moduleInfoFullyOffThenSortOff_resolveFileFullyOff() {
         // Given
         String srcCode = """
                 // @jharmonizer:fully-off
@@ -152,7 +152,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_commentOnlyFullyOff_resolveFileFullyOff() {
+    void parseJavaSrcResource_commentOnlyFullyOff_resolveFileFullyOff() {
         // Given
         String srcCode = """
                 // @jharmonizer:fully-off
@@ -168,7 +168,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_commentOnlyIndentedLineDirectiveFullyOff_resolveFileFullyOff() {
+    void parseJavaSrcResource_commentOnlyIndentedLineDirectiveFullyOff_resolveFileFullyOff() {
         // Given
         String srcCode = """
                 //     @jharmonizer:fully-off
@@ -184,7 +184,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_blockDirectiveWithLeadingNewline_resolveFileSortOff() {
+    void parseJavaSrcResource_blockDirectiveWithLeadingNewline_resolveFileSortOff() {
         // Given
         String srcCode = """
                 package demo;
@@ -206,9 +206,9 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_memberOptOutBeforeField_ignoreInvalidOptOut() {
+    void parseJavaSrcResource_memberOptOutBeforeField_ignoreInvalidOptOut() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 package demo;
 
                 class Sample {
@@ -218,16 +218,16 @@ class JHarmonizerOptOutResolverTest {
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Sample.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Sample.java")));
 
         // Then
         assertThat(spoonAstModel.getOptOuts().isEmpty()).isTrue();
     }
 
     @Test
-    void parseJavaSourceResource_unsupportedOptOutToken_ignoreInvalidOptOut() {
+    void parseJavaSrcResource_unsupportedOptOutToken_ignoreInvalidOptOut() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 package demo;
 
                 // @jharmonizer:format-off
@@ -235,22 +235,22 @@ class JHarmonizerOptOutResolverTest {
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Sample.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Sample.java")));
 
         // Then
         assertThat(spoonAstModel.getOptOuts().isEmpty()).isTrue();
     }
 
     @Test
-    void parseJavaSourceResource_mixedCaseOptOutToken_resolveIgnoringCase() {
+    void parseJavaSrcResource_mixedCaseOptOutToken_resolveIgnoringCase() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 // @JHarmonizer:SoRt-OfF
                 class Sample {}
                 """;
 
         // When
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Sample.java")));
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Sample.java")));
 
         // Then
         assertThat(spoonAstModel.getOptOuts().getFileOptOutMode()).contains(JHarmonizerOptOutMode.SORTING_OFF);
@@ -322,7 +322,7 @@ class JHarmonizerOptOutResolverTest {
     }
 
     @Test
-    void parseJavaSourceResource_legacyOffAlias_ignoreInvalidOptOut() {
+    void parseJavaSrcResource_legacyOffAlias_ignoreInvalidOptOut() {
         // Given
         String srcCode = """
                 // @jharmonizer:off

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupBoundaryMarkerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupBoundaryMarkerTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedSeparator;
 import io.github.lemon_ant.jharmonizer.core.testutils.SpoonTestCaseUtils;
-import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSourcePrinterUtils;
+import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonSrcPrinterUtils;
 import java.net.URL;
 import java.util.List;
 import lombok.NonNull;
@@ -39,13 +39,13 @@ class GroupBoundaryMarkerTest {
         GroupBoundaryMarker.markGroupBoundaries(orderedBlocks);
 
         // Then
-        assertThat(alphaFieldMember.getMetadata(SpoonSourcePrinterUtils.GROUP_HEADER_METADATA))
+        assertThat(alphaFieldMember.getMetadata(SpoonSrcPrinterUtils.GROUP_HEADER_METADATA))
                 .isEqualTo("Header fields");
-        assertThat(bravoFieldMember.getMetadata(SpoonSourcePrinterUtils.GROUP_HEADER_METADATA))
+        assertThat(bravoFieldMember.getMetadata(SpoonSrcPrinterUtils.GROUP_HEADER_METADATA))
                 .isNull();
-        assertThat(charlieMethodMember.getMetadata(SpoonSourcePrinterUtils.GROUP_HEADER_METADATA))
-                .isEqualTo(SpoonSourcePrinterUtils.GROUP_SEPARATOR_NEW_LINE);
-        assertThat(deltaMethodMember.getMetadata(SpoonSourcePrinterUtils.GROUP_HEADER_METADATA))
+        assertThat(charlieMethodMember.getMetadata(SpoonSrcPrinterUtils.GROUP_HEADER_METADATA))
+                .isEqualTo(SpoonSrcPrinterUtils.GROUP_SEPARATOR_NEW_LINE);
+        assertThat(deltaMethodMember.getMetadata(SpoonSrcPrinterUtils.GROUP_HEADER_METADATA))
                 .isNull();
     }
 
@@ -63,7 +63,7 @@ class GroupBoundaryMarkerTest {
         GroupBoundaryMarker.markGroupBoundaries(orderedBlocks);
 
         // Then
-        assertThat(alphaFieldMember.getMetadata(SpoonSourcePrinterUtils.GROUP_HEADER_METADATA))
+        assertThat(alphaFieldMember.getMetadata(SpoonSrcPrinterUtils.GROUP_HEADER_METADATA))
                 .isNull();
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererComplexDependenciesTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererComplexDependenciesTest.java
@@ -35,11 +35,11 @@ class GroupMembersOrdererComplexDependenciesTest {
         URL fixtureResourceUrl =
                 requireClasspathResourceUrl(Constants.GROUP_MEMBER_ORDERING_COMPLEX_FIXTURE_CLASSPATH_PATH);
         CtType<?> mainType = SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(fixtureResourceUrl);
-        List<CtTypeMember> explicitSourceTypeMembers =
-                SpoonTypeMemberUtils.streamExplicitSourceTypeMembers(mainType).toList();
+        List<CtTypeMember> explicitSrcTypeMembers =
+                SpoonTypeMemberUtils.streamExplicitSrcTypeMembers(mainType).toList();
         CompiledMemberGroup compiledMemberGroup =
                 CompiledMemberGroupTestCreator.createCompiledMemberGroup("complex", true, List.of(OrderingRule.ALPHA));
-        Map<CtTypeMember, CompiledMemberGroup> memberToNaturalGroup = explicitSourceTypeMembers.stream()
+        Map<CtTypeMember, CompiledMemberGroup> memberToNaturalGroup = explicitSrcTypeMembers.stream()
                 .collect(Collectors.toUnmodifiableMap(Function.identity(), typeMember -> compiledMemberGroup));
         MemberDependencyGraph dependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(memberToNaturalGroup);
         List<MemberGroupBlock> groupBlocks = TypeMemberGrouper.groupMembersByEffectiveGroups(memberToNaturalGroup);
@@ -52,15 +52,15 @@ class GroupMembersOrdererComplexDependenciesTest {
                 .withFailMessage(
                         "Expected a single ordered block but got %s.%n%s",
                         orderedGroupBlocks.size(),
-                        buildDiagnosticReport(explicitSourceTypeMembers, List.of(), dependencyGraph))
+                        buildDiagnosticReport(explicitSrcTypeMembers, List.of(), dependencyGraph))
                 .hasSize(1);
 
         MemberGroupBlock orderedGroupBlock = orderedGroupBlocks.getFirst();
         List<CtTypeMember> orderedTypeMembers = orderedGroupBlock.getTypeMembers();
-        List<String> sourceAlphaKeys = deriveAlphaKeys(explicitSourceTypeMembers);
+        List<String> srcAlphaKeys = deriveAlphaKeys(explicitSrcTypeMembers);
         List<String> orderedAlphaKeys = deriveAlphaKeys(orderedTypeMembers);
         String stateSnapshot = buildStateSnapshot(
-                explicitSourceTypeMembers,
+                explicitSrcTypeMembers,
                 orderedTypeMembers,
                 dependencyGraph,
                 memberToNaturalGroup,
@@ -69,27 +69,27 @@ class GroupMembersOrdererComplexDependenciesTest {
 
         // TODO Flaky test
         assertProvidersAreReorderedAlphabeticallyButStillBeforeDependents(
-                sourceAlphaKeys, orderedAlphaKeys, explicitSourceTypeMembers, orderedTypeMembers, dependencyGraph);
+                srcAlphaKeys, orderedAlphaKeys, explicitSrcTypeMembers, orderedTypeMembers, dependencyGraph);
         assertTransitiveDependencyChainIsRespected(
-                orderedAlphaKeys, explicitSourceTypeMembers, orderedTypeMembers, dependencyGraph);
+                orderedAlphaKeys, explicitSrcTypeMembers, orderedTypeMembers, dependencyGraph);
         assertInitializerBlockIsAfterTheDeepestDependent(
-                orderedAlphaKeys, explicitSourceTypeMembers, orderedTypeMembers, dependencyGraph);
+                orderedAlphaKeys, explicitSrcTypeMembers, orderedTypeMembers, dependencyGraph);
         assertAccessorBundlingPreventsInterleaving(
-                sourceAlphaKeys, orderedAlphaKeys, explicitSourceTypeMembers, orderedTypeMembers, dependencyGraph);
+                srcAlphaKeys, orderedAlphaKeys, explicitSrcTypeMembers, orderedTypeMembers, dependencyGraph);
 
         emitSuccessfulRunSnapshot(stateSnapshot);
     }
 
     private static void assertProvidersAreReorderedAlphabeticallyButStillBeforeDependents(
-            List<String> sourceAlphaKeys,
+            List<String> srcAlphaKeys,
             List<String> orderedAlphaKeys,
-            List<CtTypeMember> sourceTypeMembers,
+            List<CtTypeMember> srcTypeMembers,
             List<CtTypeMember> orderedTypeMembers,
             MemberDependencyGraph dependencyGraph) {
-        List<String> providerKeysInSourceOrder = sourceAlphaKeys.stream()
+        List<String> providerKeysInSrcOrder = srcAlphaKeys.stream()
                 .filter(Constants.PROVIDER_ALPHA_KEYS::contains)
                 .toList();
-        assertThat(providerKeysInSourceOrder)
+        assertThat(providerKeysInSrcOrder)
                 .containsExactly(
                         Constants.Y_PROVIDER_ALPHA_KEY,
                         Constants.W_PROVIDER_ALPHA_KEY,
@@ -102,7 +102,7 @@ class GroupMembersOrdererComplexDependenciesTest {
         assertThat(providerKeysInOrderedResult)
                 .withFailMessage(
                         "Provider keys are expected to be alphabetically ordered in the result.%n%s",
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .containsExactly(
                         Constants.W_PROVIDER_ALPHA_KEY,
                         Constants.X_PROVIDER_ALPHA_KEY,
@@ -116,14 +116,14 @@ class GroupMembersOrdererComplexDependenciesTest {
                             "Provider key '%s' should be before dependent '%s'.%n%s",
                             providerAlphaKey,
                             Constants.A_DEPENDENT_ALPHA_KEY,
-                            buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                            buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                     .isLessThan(dependentIndex);
         });
     }
 
     private static void assertTransitiveDependencyChainIsRespected(
             List<String> orderedAlphaKeys,
-            List<CtTypeMember> sourceTypeMembers,
+            List<CtTypeMember> srcTypeMembers,
             List<CtTypeMember> orderedTypeMembers,
             MemberDependencyGraph dependencyGraph) {
         int aDependentIndex = requireIndex(orderedAlphaKeys, Constants.A_DEPENDENT_ALPHA_KEY);
@@ -135,27 +135,27 @@ class GroupMembersOrdererComplexDependenciesTest {
                         "Expected '%s' before '%s'.%n%s",
                         Constants.A_DEPENDENT_ALPHA_KEY,
                         Constants.C_DEPENDENT_ALPHA_KEY,
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .isLessThan(cDependentIndex);
         assertThat(cDependentIndex)
                 .withFailMessage(
                         "Expected '%s' before '%s'.%n%s",
                         Constants.C_DEPENDENT_ALPHA_KEY,
                         Constants.B_DEPENDENT_ALPHA_KEY,
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .isLessThan(bDependentIndex);
         assertThat(bDependentIndex)
                 .withFailMessage(
                         "Expected '%s' before '%s'.%n%s",
                         Constants.B_DEPENDENT_ALPHA_KEY,
                         Constants.D_DEPENDENT_ALPHA_KEY,
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .isLessThan(dDependentIndex);
     }
 
     private static void assertInitializerBlockIsAfterTheDeepestDependent(
             List<String> orderedAlphaKeys,
-            List<CtTypeMember> sourceTypeMembers,
+            List<CtTypeMember> srcTypeMembers,
             List<CtTypeMember> orderedTypeMembers,
             MemberDependencyGraph dependencyGraph) {
         int deepestDependentIndex = requireIndex(orderedAlphaKeys, Constants.C_DEPENDENT_ALPHA_KEY);
@@ -164,20 +164,20 @@ class GroupMembersOrdererComplexDependenciesTest {
                 .withFailMessage(
                         "Initializer block should be after '%s'.%n%s",
                         Constants.C_DEPENDENT_ALPHA_KEY,
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .isGreaterThan(deepestDependentIndex);
     }
 
     private static void assertAccessorBundlingPreventsInterleaving(
-            List<String> sourceAlphaKeys,
+            List<String> srcAlphaKeys,
             List<String> orderedAlphaKeys,
-            List<CtTypeMember> sourceTypeMembers,
+            List<CtTypeMember> srcTypeMembers,
             List<CtTypeMember> orderedTypeMembers,
             MemberDependencyGraph dependencyGraph) {
-        List<String> methodKeysInSourceOrder = sourceAlphaKeys.stream()
+        List<String> methodKeysInSrcOrder = srcAlphaKeys.stream()
                 .filter(Constants.METHOD_ALPHA_KEYS::contains)
                 .toList();
-        assertThat(methodKeysInSourceOrder)
+        assertThat(methodKeysInSrcOrder)
                 .containsExactly(
                         Constants.SET_ENABLED_FLAG_ALPHA_KEY,
                         Constants.IS_ENABLED_FLAG_ALPHA_KEY,
@@ -190,7 +190,7 @@ class GroupMembersOrdererComplexDependenciesTest {
         assertThat(accessorKeysInOrderedResult)
                 .withFailMessage(
                         "Accessor methods should stay bundled and alphabetically ordered.%n%s",
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .containsExactly(
                         Constants.GET_ENABLED_FLAG_ALPHA_KEY,
                         Constants.HAS_ENABLED_FLAG_ALPHA_KEY,
@@ -210,61 +210,61 @@ class GroupMembersOrdererComplexDependenciesTest {
                 .withFailMessage(
                         "Method '%s' should be after accessor bundle.%n%s",
                         Constants.HELLO_ENABLED_FLAG_ALPHA_KEY,
-                        buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph))
+                        buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph))
                 .isGreaterThan(lastAccessorIndex);
     }
 
     @NonNull
     private static String buildDiagnosticReport(
-            List<CtTypeMember> sourceTypeMembers,
+            List<CtTypeMember> srcTypeMembers,
             List<CtTypeMember> orderedTypeMembers,
             MemberDependencyGraph dependencyGraph) {
-        List<String> sourceAlphaKeys = deriveAlphaKeys(sourceTypeMembers);
+        List<String> srcAlphaKeys = deriveAlphaKeys(srcTypeMembers);
         List<String> orderedAlphaKeys = deriveAlphaKeys(orderedTypeMembers);
-        Map<String, CtTypeMember> sourceMembersByAlphaKey = sourceTypeMembers.stream()
+        Map<String, CtTypeMember> srcMembersByAlphaKey = srcTypeMembers.stream()
                 .collect(Collectors.toMap(
                         SpoonTypeMemberUtils::deriveAlphaKey,
                         Function.identity(),
                         (leftMember, ignored) -> leftMember,
                         LinkedHashMap::new));
 
-        String diagnostic = "Diagnostic report for flaky ordering test:\n" + "- sourceAlphaKeys=" + sourceAlphaKeys
+        String diagnostic = "Diagnostic report for flaky ordering test:\n" + "- sourceAlphaKeys=" + srcAlphaKeys
                 + '\n' + "- orderedAlphaKeys="
                 + orderedAlphaKeys + '\n' + "- trackedIndexes="
                 + renderTrackedIndexes(orderedAlphaKeys)
                 + '\n'
                 + "- declarationDirectDependencies="
                 + renderDirectDependenciesByMember(
-                        sourceMembersByAlphaKey, dependencyGraph, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY)
+                        srcMembersByAlphaKey, dependencyGraph, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY)
                 + '\n'
                 + "- declarationTransitiveDependencies="
                 + renderTransitiveDependenciesByMember(
-                        sourceMembersByAlphaKey, dependencyGraph, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY)
+                        srcMembersByAlphaKey, dependencyGraph, MemberDependencyEdgeKind.DECLARATION_DEPENDENCY)
                 + '\n'
                 + "- accessorBundleDirectDependencies="
                 + renderDirectDependenciesByMember(
-                        sourceMembersByAlphaKey, dependencyGraph, MemberDependencyEdgeKind.ACCESSOR_BUNDLE);
+                        srcMembersByAlphaKey, dependencyGraph, MemberDependencyEdgeKind.ACCESSOR_BUNDLE);
         return diagnostic;
     }
 
     @NonNull
     private static String buildStateSnapshot(
-            List<CtTypeMember> sourceTypeMembers,
+            List<CtTypeMember> srcTypeMembers,
             List<CtTypeMember> orderedTypeMembers,
             MemberDependencyGraph dependencyGraph,
             Map<CtTypeMember, CompiledMemberGroup> memberToNaturalGroup,
-            List<MemberGroupBlock> sourceGroupBlocks,
+            List<MemberGroupBlock> srcGroupBlocks,
             List<MemberGroupBlock> orderedGroupBlocks) {
         String snapshot = "State snapshot for complex ordering test:\n" + "- memberToNaturalGroup="
                 + renderMemberToGroup(memberToNaturalGroup)
                 + '\n'
                 + "- sourceGroupBlocks="
-                + renderGroupBlocks(sourceGroupBlocks)
+                + renderGroupBlocks(srcGroupBlocks)
                 + '\n'
                 + "- orderedGroupBlocks="
                 + renderGroupBlocks(orderedGroupBlocks)
                 + '\n'
-                + buildDiagnosticReport(sourceTypeMembers, orderedTypeMembers, dependencyGraph);
+                + buildDiagnosticReport(srcTypeMembers, orderedTypeMembers, dependencyGraph);
         return snapshot;
     }
 
@@ -322,16 +322,14 @@ class GroupMembersOrdererComplexDependenciesTest {
 
     @NonNull
     private static Map<String, List<String>> renderDirectDependenciesByMember(
-            Map<String, CtTypeMember> sourceMembersByAlphaKey,
+            Map<String, CtTypeMember> srcMembersByAlphaKey,
             MemberDependencyGraph dependencyGraph,
             MemberDependencyEdgeKind edgeKind) {
-        return sourceMembersByAlphaKey.entrySet().stream()
+        return srcMembersByAlphaKey.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
-                        sourceEntry ->
-                                dependencyGraph
-                                        .findDirectDependents(sourceEntry.getValue(), EnumSet.of(edgeKind))
-                                        .stream()
+                        srcEntry ->
+                                dependencyGraph.findDirectDependents(srcEntry.getValue(), EnumSet.of(edgeKind)).stream()
                                         .map(SpoonTypeMemberUtils::deriveAlphaKey)
                                         .sorted()
                                         .toList(),
@@ -341,15 +339,15 @@ class GroupMembersOrdererComplexDependenciesTest {
 
     @NonNull
     private static Map<String, List<String>> renderTransitiveDependenciesByMember(
-            Map<String, CtTypeMember> sourceMembersByAlphaKey,
+            Map<String, CtTypeMember> srcMembersByAlphaKey,
             MemberDependencyGraph dependencyGraph,
             MemberDependencyEdgeKind edgeKind) {
-        return sourceMembersByAlphaKey.entrySet().stream()
+        return srcMembersByAlphaKey.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
-                        sourceEntry ->
+                        srcEntry ->
                                 dependencyGraph
-                                        .findTransitiveDependents(sourceEntry.getValue(), EnumSet.of(edgeKind))
+                                        .findTransitiveDependents(srcEntry.getValue(), EnumSet.of(edgeKind))
                                         .stream()
                                         .map(SpoonTypeMemberUtils::deriveAlphaKey)
                                         .sorted()

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererOrderingRulesTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererOrderingRulesTest.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -38,7 +38,7 @@ import spoon.reflect.reference.CtTypeReference;
 class GroupMembersOrdererOrderingRulesTest {
 
     @Test
-    void orderMembersInsideGroups_orderingRulePreserve_keepOriginalSourceOrder() {
+    void orderMembersInsideGroups_orderingRulePreserve_keepOriginalSrcOrder() {
         // Given
         CompiledMemberGroup compiledMemberGroup = CompiledMemberGroupTestCreator.createCompiledMemberGroup(
                 "preserve", false, List.of(OrderingRule.PRESERVE));
@@ -78,7 +78,7 @@ class GroupMembersOrdererOrderingRulesTest {
     }
 
     @Test
-    void orderMembersInsideGroups_orderingRulePreserveWithEqualSourceStart_applyAlphaTieBreakerDeterministically() {
+    void orderMembersInsideGroups_orderingRulePreserveWithEqualSrcStart_applyAlphaTieBreakerDeterministically() {
         // Given
         CompiledMemberGroup compiledMemberGroup = CompiledMemberGroupTestCreator.createCompiledMemberGroup(
                 "preserve-equal-keys", false, List.of(OrderingRule.PRESERVE));
@@ -393,7 +393,7 @@ class GroupMembersOrdererOrderingRulesTest {
     }
 
     @Test
-    void orderMembersInsideGroups_orderingRuleAlphaWithEqualAlphaKey_applySourceStartTieBreaker() {
+    void orderMembersInsideGroups_orderingRuleAlphaWithEqualAlphaKey_applySrcStartTieBreaker() {
         // Given
         CompiledMemberGroup compiledMemberGroup = CompiledMemberGroupTestCreator.createCompiledMemberGroup(
                 "alpha-source-start-tie", false, List.of(OrderingRule.ALPHA));
@@ -464,13 +464,13 @@ class GroupMembersOrdererOrderingRulesTest {
     }
 
     @NonNull
-    private static CtTypeMember createFieldTypeMember(String fieldName, int sourceStart) {
+    private static CtTypeMember createFieldTypeMember(String fieldName, int srcStart) {
         CtField<?> fieldTypeMember = mock(CtField.class);
-        SourcePosition sourcePosition = mock(SourcePosition.class);
+        SourcePosition srcPosition = mock(SourcePosition.class);
         CtTypeReference<?> fieldTypeReference = mock(CtTypeReference.class);
-        when(sourcePosition.isValidPosition()).thenReturn(true);
-        when(sourcePosition.getSourceStart()).thenReturn(sourceStart);
-        when(fieldTypeMember.getPosition()).thenReturn(sourcePosition);
+        when(srcPosition.isValidPosition()).thenReturn(true);
+        when(srcPosition.getSourceStart()).thenReturn(srcStart);
+        when(fieldTypeMember.getPosition()).thenReturn(srcPosition);
         when(fieldTypeMember.getSimpleName()).thenReturn(fieldName);
         doReturn(fieldTypeReference).when(fieldTypeMember).getType();
         when(fieldTypeReference.getQualifiedName()).thenReturn("int");
@@ -486,7 +486,7 @@ class GroupMembersOrdererOrderingRulesTest {
                         FIELD_INITIALIZER_TIE_FIXTURE_CLASSPATH_RESOURCE);
         private static final CtType<?> FIELD_INITIALIZER_TIE_FIXTURE_MAIN_TYPE =
                 SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(FIELD_INITIALIZER_TIE_FIXTURE_RESOURCE_URL);
-        private static final List<CtTypeMember> FIELD_INITIALIZER_TIE_FIXTURE_MEMBERS = streamExplicitSourceTypeMembers(
+        private static final List<CtTypeMember> FIELD_INITIALIZER_TIE_FIXTURE_MEMBERS = streamExplicitSrcTypeMembers(
                         FIELD_INITIALIZER_TIE_FIXTURE_MAIN_TYPE)
                 .toList();
 
@@ -496,9 +496,8 @@ class GroupMembersOrdererOrderingRulesTest {
                 GroupMembersOrdererOrderingRulesTest.class.getResource(SOURCE_START_TIE_FIXTURE_CLASSPATH_RESOURCE);
         private static final CtType<?> SOURCE_START_TIE_FIXTURE_MAIN_TYPE =
                 SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(SOURCE_START_TIE_FIXTURE_RESOURCE_URL);
-        private static final List<CtTypeMember> SOURCE_START_TIE_FIXTURE_MEMBERS = streamExplicitSourceTypeMembers(
-                        SOURCE_START_TIE_FIXTURE_MAIN_TYPE)
-                .toList();
+        private static final List<CtTypeMember> SOURCE_START_TIE_FIXTURE_MEMBERS =
+                streamExplicitSrcTypeMembers(SOURCE_START_TIE_FIXTURE_MAIN_TYPE).toList();
 
         private static final String LOCALE_FIXTURE_CLASSPATH_RESOURCE =
                 "/test-cases/core/sorter/spoon/group-ordering-rule/valid/GroupOrderingRuleLocaleFixture.java";
@@ -507,7 +506,7 @@ class GroupMembersOrdererOrderingRulesTest {
         private static final CtType<?> LOCALE_FIXTURE_MAIN_TYPE =
                 SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(LOCALE_FIXTURE_RESOURCE_URL);
         private static final List<CtTypeMember> LOCALE_FIXTURE_MEMBERS =
-                streamExplicitSourceTypeMembers(LOCALE_FIXTURE_MAIN_TYPE).toList();
+                streamExplicitSrcTypeMembers(LOCALE_FIXTURE_MAIN_TYPE).toList();
 
         private static final String FIXTURE_CLASSPATH_RESOURCE =
                 "/test-cases/core/sorter/spoon/group-ordering-rule/valid/GroupOrderingRuleFixture.java";
@@ -516,7 +515,7 @@ class GroupMembersOrdererOrderingRulesTest {
         private static final CtType<?> FIXTURE_MAIN_TYPE =
                 SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(FIXTURE_RESOURCE_URL);
         private static final List<CtTypeMember> FIXTURE_MEMBERS =
-                streamExplicitSourceTypeMembers(FIXTURE_MAIN_TYPE).toList();
+                streamExplicitSrcTypeMembers(FIXTURE_MAIN_TYPE).toList();
 
         private static final Set<MemberDependencyEdgeKind> ACCESSOR_BUNDLE_ONLY =
                 EnumSet.of(MemberDependencyEdgeKind.ACCESSOR_BUNDLE);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererSortableModelTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/GroupMembersOrdererSortableModelTest.java
@@ -1,6 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon;
 
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,7 +28,7 @@ class GroupMembersOrdererSortableModelTest {
     private static final CtType<?> FIXTURE_MAIN_TYPE =
             SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(FIXTURE_RESOURCE_URL);
     private static final List<CtTypeMember> FIXTURE_MEMBERS =
-            streamExplicitSourceTypeMembers(FIXTURE_MAIN_TYPE).toList();
+            streamExplicitSrcTypeMembers(FIXTURE_MAIN_TYPE).toList();
 
     @Test
     void convertTypeMembers2SortableTypeMembers_representativeChainPresent_cachedSortableMembersReused() {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -1,7 +1,7 @@
 package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
 
 import static io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledMemberGroupTestCreator.createTrivialMemberGroup;
-import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSourceTypeMembers;
+import static io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonTypeMemberUtils.streamExplicitSrcTypeMembers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
@@ -101,7 +101,7 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
-    void buildDependencyGraph_explicitThisForwardReference_preservesSourceDeclarationOrder() {
+    void buildDependencyGraph_explicitThisForwardReference_preservesSrcDeclarationOrder() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
                 Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MEMBERS);
@@ -237,7 +237,7 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
-    void buildDependencyGraph_explicitDeclaringTypeForwardReference_preservesSourceDeclarationOrder() {
+    void buildDependencyGraph_explicitDeclaringTypeForwardReference_preservesSrcDeclarationOrder() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
                 Constants.FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_MEMBERS);
@@ -439,14 +439,14 @@ class MemberDependencyGraphBuilderTest {
     @NonNull
     private static Map<CtTypeMember, CompiledMemberGroup> buildTypeMember2NaturalGroup(
             CtType<?> mainType, CompiledMemberGroup compiledMemberGroup) {
-        return streamExplicitSourceTypeMembers(mainType)
+        return streamExplicitSrcTypeMembers(mainType)
                 .collect(Collectors.toUnmodifiableMap(typeMember -> typeMember, ignoredMember -> compiledMemberGroup));
     }
 
     @NonNull
     private static CtTypeMember requireUniqueInitializerBlockMember(
             CtType<?> declaringType, boolean requiredStaticness) {
-        List<CtAnonymousExecutable> initializerBlocks = streamExplicitSourceTypeMembers(declaringType)
+        List<CtAnonymousExecutable> initializerBlocks = streamExplicitSrcTypeMembers(declaringType)
                 .filter(typeMember -> typeMember instanceof CtAnonymousExecutable)
                 .map(typeMember -> (CtAnonymousExecutable) typeMember)
                 .filter(initializerBlock ->

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/testutils/SpoonTestCaseUtils.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/testutils/SpoonTestCaseUtils.java
@@ -32,9 +32,9 @@ public class SpoonTestCaseUtils {
     public static SpoonAstModel parseAstModelFromJavaFixtureResource(URL javaFixtureResource) {
         requireNonNull(javaFixtureResource, "javaFixtureResource cannot be null");
 
-        String sourceCode = TestCaseResourceUtils.readClasspathResourceAsString(javaFixtureResource);
+        String srcCode = TestCaseResourceUtils.readClasspathResourceAsString(javaFixtureResource);
         return SpoonParser.parseJavaSrcFile(
-                createSrcFile(sourceCode, Path.of(extractFileNameWithExtension(javaFixtureResource))));
+                createSrcFile(srcCode, Path.of(extractFileNameWithExtension(javaFixtureResource))));
     }
 
     /**

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/ParseAllJava21FeaturesTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/ParseAllJava21FeaturesTest.java
@@ -21,12 +21,12 @@ class ParseAllJava21FeaturesTest {
     private static final Path SAMPLE_ALL_JAVA21_PSEUDO_SOURCE_PATH = Path.of("SampleAllJava21FeaturesList.java");
 
     @Test
-    void parseSourceFile_validSampleAllJava21FeaturesList_returnExpectedParsingResult() {
+    void parseSrcFile_validSampleAllJava21FeaturesList_returnExpectedParsingResult() {
         // Given
         SrcFile srcFile = createSrcFile(SAMPLE_ALL_JAVA21_SOURCE_CODE, SAMPLE_ALL_JAVA21_PSEUDO_SOURCE_PATH);
 
         // When
-        ParsingResult parsingResult = SourceAstTranslator.parse(srcFile);
+        ParsingResult parsingResult = SrcAstTranslator.parse(srcFile);
         ParsingStatistic parsingStatistic = parsingResult.getParsingStatistic();
 
         // Then
@@ -36,7 +36,7 @@ class ParseAllJava21FeaturesTest {
         assertThat(spoonAstModel.getMainType()).isNotNull();
         assertThat(spoonAstModel.getCompilationUnit()).isNotNull();
         assertThat(parsingStatistic).isNotNull();
-        assertThat(parsingStatistic.getOriginalSourceCodeLength())
+        assertThat(parsingStatistic.getOriginalSrcCodeLength())
                 .isCloseTo(ORIGINAL_SOURCE_CODE_LENGTH, withPercentage(10));
         assertThat(parsingStatistic.getParsedRootTypesCount()).isEqualTo(8);
         assertThat(parsingStatistic.getParsedTypesTotalCount()).isEqualTo(19);
@@ -45,19 +45,17 @@ class ParseAllJava21FeaturesTest {
     }
 
     @Test
-    void serialize_validSpoonASTModelWithAllJava21Features_returnExpectedSourceCode() {
+    void serialize_validSpoonASTModelWithAllJava21Features_returnExpectedSrcCode() {
         // Given
         SpoonAstModel spoonASTModel = SpoonParser.parseJavaSrcFile(
                 createSrcFile(SAMPLE_ALL_JAVA21_SOURCE_CODE, SAMPLE_ALL_JAVA21_PSEUDO_SOURCE_PATH));
 
         // When
-        SerializationResult serializationResult = SourceAstTranslator.serialize(spoonASTModel);
+        SerializationResult serializationResult = SrcAstTranslator.serialize(spoonASTModel);
 
         // Then
         assertThat(serializationResult).isNotNull();
-        assertThat(serializationResult
-                        .getSerializedSourceWithSkippedTypeRanges()
-                        .getSerializedSrcCode())
+        assertThat(serializationResult.getSerializedSrcWithSkippedTypeRanges().getSerializedSrcCode())
                 .contains("SampleAllJava21FeaturesList");
         assertThat(serializationResult.getSerializationStatistic()).isNotNull();
         SerializationStatistic serializationStatistic = serializationResult.getSerializationStatistic();

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/SrcAstTranslatorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/SrcAstTranslatorTest.java
@@ -4,8 +4,8 @@ import static io.github.lemon_ant.jharmonizer.core.files_handler.SrcFileCreator.
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.github.lemon_ant.jharmonizer.core.files_handler.SourceFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFile;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.optout.OptOutFormattingRangeResolver;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import java.nio.charset.StandardCharsets;
@@ -17,21 +17,21 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-class SourceAstTranslatorTest {
+class SrcAstTranslatorTest {
 
-    SourceFilesHandler sourceFilesHandler;
+    SrcFilesHandler srcFilesHandler;
 
     @TempDir
     Path tempDir;
 
     @Test
-    void parseSourceFile_validJavaSrc_returnParsingResult() throws Exception {
+    void parseSrcFile_validJavaSrc_returnParsingResult() throws Exception {
         // Given
         Path file = Files.writeString(tempDir.resolve("TestClass.java"), "class TestClass { int value = 42; }");
         SrcFile srcFile = createSrcFile(Files.readString(file, StandardCharsets.UTF_8), file);
 
         // When
-        ParsingResult result = SourceAstTranslator.parse(srcFile);
+        ParsingResult result = SrcAstTranslator.parse(srcFile);
 
         // Then
         assertThat(result).isNotNull();
@@ -45,16 +45,16 @@ class SourceAstTranslatorTest {
     @Test
     void serialize_validSpoonAstModel_returnSerializedCode() {
         // Given: simple source code
-        String source = "class Demo { void m() {} }";
-        SrcFile srcFile = createSrcFile(source, Path.of("Demo.java"));
-        SpoonAstModel model = SourceAstTranslator.parse(srcFile).getSpoonAstModel();
+        String src = "class Demo { void m() {} }";
+        SrcFile srcFile = createSrcFile(src, Path.of("Demo.java"));
+        SpoonAstModel model = SrcAstTranslator.parse(srcFile).getSpoonAstModel();
 
         // When
-        SerializationResult result = SourceAstTranslator.serialize(model);
+        SerializationResult result = SrcAstTranslator.serialize(model);
 
         // Then
         assertThat(result).isNotNull();
-        assertThat(result.getSerializedSourceWithSkippedTypeRanges().getSerializedSrcCode())
+        assertThat(result.getSerializedSrcWithSkippedTypeRanges().getSerializedSrcCode())
                 .contains("class Demo");
         assertThat(result.getSerializationStatistic().getSerializedCodeLength()).isGreaterThan(0);
         assertThat(result.getSerializationStatistic().getProcessingTimeInNanos())
@@ -72,22 +72,22 @@ class SourceAstTranslatorTest {
                 // @jharmonizer:fully-off
                 class Gamma{int y;  int x;}
                 """;
-        String sourceCode = """
+        String srcCode = """
                 class Alpha {}
 
                 %s
 
                 %s
                 """.formatted(sortOffFragment.stripTrailing(), fullyOffFragment.stripTrailing());
-        SrcFile srcFile = createSrcFile(sourceCode, Path.of("Sample.java"));
-        SpoonAstModel spoonAstModel = SourceAstTranslator.parse(srcFile).getSpoonAstModel();
+        SrcFile srcFile = createSrcFile(srcCode, Path.of("Sample.java"));
+        SpoonAstModel spoonAstModel = SrcAstTranslator.parse(srcFile).getSpoonAstModel();
 
         // When
-        SerializationResult result = SourceAstTranslator.serialize(spoonAstModel);
+        SerializationResult result = SrcAstTranslator.serialize(spoonAstModel);
         List<SrcCharacterRange> formattingSkippedRanges = OptOutFormattingRangeResolver.resolveFormattingSkippedRanges(
-                spoonAstModel.getOptOuts(), result.getSerializedSourceWithSkippedTypeRanges());
+                spoonAstModel.getOptOuts(), result.getSerializedSrcWithSkippedTypeRanges());
         String serializedSrcCode =
-                result.getSerializedSourceWithSkippedTypeRanges().getSerializedSrcCode();
+                result.getSerializedSrcWithSkippedTypeRanges().getSerializedSrcCode();
 
         // Then
         assertThat(serializedSrcCode).contains(sortOffFragment).contains(fullyOffFragment);
@@ -99,20 +99,18 @@ class SourceAstTranslatorTest {
     }
 
     @Test
-    void serializedSourceWithSkippedTypeRanges_mutableInputMap_returnsUnmodifiableMap() {
+    void serializedSrcWithSkippedTypeRanges_mutableInputMap_returnsUnmodifiableMap() {
         // Given
-        String sourceCode = "class Gamma {}";
-        SrcFile srcFile = createSrcFile(sourceCode, Path.of("Gamma.java"));
-        SpoonAstModel spoonAstModel = SourceAstTranslator.parse(srcFile).getSpoonAstModel();
-        SerializedSourceWithSkippedTypeRanges serializedSourceWithSkippedTypeRanges =
-                new SerializedSourceWithSkippedTypeRanges(
-                        sourceCode,
-                        new HashMap<>(Map.of(
-                                spoonAstModel.getMainType().orElseThrow(),
-                                new SrcCharacterRange(0, sourceCode.length()))));
+        String srcCode = "class Gamma {}";
+        SrcFile srcFile = createSrcFile(srcCode, Path.of("Gamma.java"));
+        SpoonAstModel spoonAstModel = SrcAstTranslator.parse(srcFile).getSpoonAstModel();
+        SerializedSrcWithSkippedTypeRanges serializedSrcWithSkippedTypeRanges = new SerializedSrcWithSkippedTypeRanges(
+                srcCode,
+                new HashMap<>(
+                        Map.of(spoonAstModel.getMainType().orElseThrow(), new SrcCharacterRange(0, srcCode.length()))));
 
         // When
-        Map<?, ?> sortingSkippedTypeRanges = serializedSourceWithSkippedTypeRanges.getSortingSkippedTypeRanges();
+        Map<?, ?> sortingSkippedTypeRanges = serializedSrcWithSkippedTypeRanges.getSortingSkippedTypeRanges();
 
         // Then
         assertThat(sortingSkippedTypeRanges).hasSize(1);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinterTest.java
@@ -4,33 +4,33 @@ import static io.github.lemon_ant.jharmonizer.core.files_handler.SrcFileCreator.
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.github.lemon_ant.jharmonizer.core.translator.SerializedSourceWithSkippedTypeRanges;
+import io.github.lemon_ant.jharmonizer.core.translator.SerializedSrcWithSkippedTypeRanges;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
-class SpoonCustomSourcePrinterTest {
+class SpoonCustomSrcPrinterTest {
 
     @Test
     void serializeCompilationUnit_afterSkippedRangesHandedOff_throwIllegalStateException() {
         // Given
-        String sourceCode = """
+        String srcCode = """
                 class Alpha {}
 
                 // @jharmonizer:sort-off
                 class Beta { int z; int a; }
                 """;
-        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(sourceCode, Path.of("Beta.java")));
-        SpoonCustomSourcePrinter printer = new SpoonCustomSourcePrinter(
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Beta.java")));
+        SpoonCustomSrcPrinter printer = new SpoonCustomSrcPrinter(
                 spoonAstModel.getCompilationUnit().getFactory().getEnvironment(),
-                sourceCode,
+                srcCode,
                 spoonAstModel.getOptOuts().getSortingSkippedTypes());
 
         // When
-        SerializedSourceWithSkippedTypeRanges serializedSourceWithSkippedTypeRanges =
+        SerializedSrcWithSkippedTypeRanges serializedSrcWithSkippedTypeRanges =
                 printer.serializeCompilationUnit(spoonAstModel.getCompilationUnit());
 
         // Then
-        assertThat(serializedSourceWithSkippedTypeRanges.getSortingSkippedTypeRanges())
+        assertThat(serializedSrcWithSkippedTypeRanges.getSortingSkippedTypeRanges())
                 .hasSize(1);
         assertThatThrownBy(() -> printer.serializeCompilationUnit(spoonAstModel.getCompilationUnit()))
                 .isInstanceOf(IllegalStateException.class)


### PR DESCRIPTION
### Motivation

- Standardize and shorten naming across the codebase by replacing "Source" prefixes with "Src" in core types, utilities and method names to improve consistency and readability.
- Propagate the identifier changes through the CLI surface and test suites so the public API and tests remain coherent.

### Description

- Renamed core runtime types and utilities: `SourceProcessor` → `SrcProcessor`, `SourceFilesHandler` → `SrcFilesHandler`, `SourceAstTranslator` → `SrcAstTranslator`, `SerializedSourceWithSkippedTypeRanges` → `SerializedSrcWithSkippedTypeRanges`, and related types.
- Updated API method names to the new form: `processSource` → `processSrc`, `formatSource` → `formatSrc`, and other method/variable renames (`findJavaFiles`/`readJavaFiles` usages updated, internal parameter renames like `source`→`src`, `sourceLength`→`srcLength`, etc.).
- Adjusted flow and translator plumbing and debugging support to use the new names, including `IFlow` contract and `FlowDebugStageRecorder` signatures/params.
- Propagated all changes to the CLI: `BaseCommand` now creates `SrcProcessor` and updated config description helper names.
- Updated the entire test suite and e2e fixtures to match the renames (many test classes, helpers and variable names updated accordingly) without behavioral changes to the logic.

### Testing

- Updated and executed the full automated test suite with the project test command `mvn -DskipTests=false test`, including unit, integration and e2e tests updated for the renames; the updated test suite completed successfully.
- Verified compilation of the CLI and core modules after renames by running the standard build and test tasks (`mvn verify` / test lifecycle phases).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7b7b8dc748325aa8f1d1c15f3cf90)