### PR TITLE
Avoid leading blank line before first type member group separator

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -148,7 +148,7 @@ final class SpoonTypePrinter {
 
         String groupHeader = findGroupHeader(member);
         if (GROUP_SEPARATOR_NEW_LINE.equals(groupHeader)) {
-            if (!hasSeparatorAlreadyPrinted) {
+            if (!hasSeparatorAlreadyPrinted && !first) {
                 tokenWriter.writeln();
             }
         } else if (groupHeader != null && !hasMatchingLeadingComment(member, groupHeader)) {

--- a/core/src/test/resources/test-cases/core/e2e/regression/01-self-type-class-literal-logger-factory/expected/SelfTypeClassLiteralLoggerFactorySample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/01-self-type-class-literal-logger-factory/expected/SelfTypeClassLiteralLoggerFactorySample.java
@@ -1,7 +1,6 @@
 package io.github.lemon_ant.jharmonizer.core.e2e;
 
 public class SelfTypeClassLiteralLoggerFactorySample {
-
     private static final Object logger = SelfLoggerFactory.resolve(SelfTypeClassLiteralLoggerFactorySample.class);
 
     private static final String message = "ok";


### PR DESCRIPTION
### Motivation
- Avoid emitting an extra blank line before the first type member when a group header requests a new-line separator, so generated source matches original formatting and expected fixtures.

### Description
- Change the condition in `SpoonTypePrinter.printTypeMember` to skip writing the extra newline when the member is the first element (`&& !first`) and update the expected E2E fixture `SelfTypeClassLiteralLoggerFactorySample.java` to reflect the corrected output.

### Testing
- Ran the project unit test suite and the core E2E regression `01-self-type-class-literal-logger-factory` test using the updated `SelfTypeClassLiteralLoggerFactorySample.java`, and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7fe083b78832599354f47141386f9)