### PR TITLE
docs: reorganize TODO backlog and add multiple future feature proposals

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,11 +22,12 @@ To keep planning explicit, this backlog is split into two categories:
 
 ## Planned future features (new product functionality)
 
-### 1. Compile group sorting once and precompute ordering rule values in `MemberDescriptor`
+### 1. Compile group sorting once and precompute ordering rule values in `MemberDescriptor` (performance-focused)
 
 #### Status
 - [ ] Not implemented (captured as a future improvement)
 - [ ] Revisit after: tool runs end-to-end + tests are green
+- [ ] Priority context: performance/scalability improvement for large source sets
 
 #### Background
 JHarmonizer already has a compiled layer for grouping/classification:
@@ -451,22 +452,18 @@ without redundant braces when syntax and semantics stay equivalent.
 
 ---
 
-### 9. Constants and enum ordering expansion (future version)
+### 9. Constants ordering expansion (future version)
 
 #### Status
-- [ ] Partially captured in existing backlog; expanded here for completeness
-
-#### Existing related item
-- Enum constants ordering is already tracked in **Section 3** and should not be duplicated.
+- [ ] Not implemented (explicitly deferred)
 
 #### Additional future scope
 - explicit ordering policies for regular constants groups beyond current defaults;
-- shared configurable policy layer so constants/enum ordering rules stay consistent.
+- shared configurable policy layer so constants ordering rules stay consistent.
 
 #### Implementation outline (when revisited)
-- [ ] Reuse Section 3 enum implementation as the baseline.
 - [ ] Add constants-group ordering options with stable tie-breakers.
-- [ ] Add consistency tests (constants vs enum constants).
+- [ ] Add deterministic ordering tests for constants-heavy classes.
 
 ---
 
@@ -525,7 +522,35 @@ Add dependency-graph analysis to detect members that can safely become static:
 
 ---
 
-### 12. Visibility minimization pass (future version)
+### 12. Package dependency cycle detector (future version)
+
+#### Status
+- [ ] Not implemented (explicitly deferred)
+
+#### Problem statement
+Packages inside one application/module should form a clean hierarchy.
+Cyclic package dependencies are a design smell and should be detected early.
+
+#### Proposed solution (next version)
+Add an analyzer that builds package-level dependency graph and reports cycles:
+- construct directed graph from inter-package type references;
+- detect strongly connected components (SCC);
+- report cycle chains with actionable refactoring hints.
+
+#### Safety requirements
+- support exclusions for generated code and known external bridge packages;
+- keep analysis deterministic and reproducible in CI;
+- provide configurable severity (warning/error) and fail-on-cycle mode.
+
+#### Implementation outline (when revisited)
+- [ ] Add package-graph extractor from existing AST/model pipeline.
+- [ ] Implement SCC detection and cycle reporting formatter.
+- [ ] Add config for include/exclude packages and severity mode.
+- [ ] Add fixtures with single-cycle and multi-cycle package graphs.
+
+---
+
+### 13. Visibility minimization pass (future version)
 
 #### Status
 - [ ] Not implemented (explicitly deferred)
@@ -554,7 +579,7 @@ Introduce a configurable pass that lowers visibility to the minimal safe level:
 
 ---
 
-### 13. Nullability interfaces / annotations enforcer (future version)
+### 14. Nullability interfaces / annotations enforcer (future version)
 
 #### Status
 - [ ] Not implemented (explicitly deferred)
@@ -582,7 +607,7 @@ and method parameters according to configured scope.
 
 ---
 
-### 14. Lombok policy enforcer and optimizer (future version)
+### 15. Lombok policy enforcer and optimizer (future version)
 
 #### Status
 - [ ] Not implemented (explicitly deferred)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -22,13 +22,13 @@ To keep planning explicit, this backlog is split into two categories:
 
 ## Planned future features (new product functionality)
 
-## 1. Compile group sorting once and precompute ordering rule values in `MemberDescriptor`
+### 1. Compile group sorting once and precompute ordering rule values in `MemberDescriptor`
 
-### Status
+#### Status
 - [ ] Not implemented (captured as a future improvement)
 - [ ] Revisit after: tool runs end-to-end + tests are green
 
-### Background
+#### Background
 JHarmonizer already has a compiled layer for grouping/classification:
 selectors and rule blocks are compiled once into “ready-to-run” predicates, so we can classify `CtTypeMember`s efficiently.
 
@@ -37,13 +37,13 @@ Sorting is still “runtime-heavy”:
 - We compute ordering rule values (alpha key, visibility rank, signature key, etc.) repeatedly.
 - We introduced extra wrapper DTOs to hold those values, but they are not integrated into the compiled pipeline.
 
-### Problem statement
+#### Problem statement
 We want sorting to be as “compiled” and deterministic as grouping:
 - No repeated comparator construction per group.
 - No repeated computation of ordering rule values per member.
 - Cleaner separation of concerns: *classification prepares data*; *sorting consumes prepared data*.
 
-### Proposed solution
+#### Proposed solution
 **Move sorting compilation to the same stage as selector compilation.**
 
 1) **Extend `MemberDescriptor`** to hold all computed values needed for sorting:
@@ -63,7 +63,7 @@ We want sorting to be as “compiled” and deterministic as grouping:
 - The ordering step sorts descriptors using the already compiled comparator.
 - Finally, the renderer uses the stored reference to the original member to reconstruct text.
 
-### Design details
+#### Design details
 
 #### A. Descriptor-first pipeline
 Instead of passing raw `CtTypeMember` around, we create descriptors once:
@@ -97,18 +97,18 @@ As a follow-up (not part of this item), consider:
 
 This is **explicitly deferred** until the non-generic version proves beneficial.
 
-### Expected benefits
+#### Expected benefits
 - Performance: one-time descriptor construction + one-time per-group comparator compilation.
 - Cleaner architecture: sorting logic becomes “compiled config” rather than ad-hoc runtime plumbing.
 - Consistency: grouping and sorting follow the same “compile once, run many” model.
 - Better testability: comparator behavior can be unit-tested using synthetic descriptors.
 
-### Non-goals
+#### Non-goals
 - Do not refactor the entire dependency-graph subsystem as part of this item.
 - Do not generalize away from Spoon in the first implementation of this idea.
 - Do not change output semantics (only reduce repeated work and improve structure).
 
-### Implementation outline (when we revisit this)
+#### Implementation outline (when we revisit this)
 - [ ] Identify current “ordering rule values wrapper” DTO(s) and list the computed values required.
 - [ ] Extend `MemberDescriptor` to include those values + a reference to the original member.
 - [ ] Update the descriptor factory to compute keys once (single pass).
@@ -122,13 +122,13 @@ This is **explicitly deferred** until the non-generic version proves beneficial.
 
 ---
 
-## 2. Add a type-based selector to rule lines (field type / method return type)
+### 2. Add a type-based selector to rule lines (field type / method return type)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred to the next product version)
 - [ ] For the first working version, match special fields (e.g., logger fields) **by name only**
 
-### Background
+#### Background
 The current selector model supports:
 - kind / access / modifiers
 - name matchers (EXACT / REGEX)
@@ -139,18 +139,18 @@ This is enough for many “layout” rules, but it cannot express common real-wo
 - “all methods returning `Optional<T>` / `Stream<T>` / `CompletableFuture<T>`”
 - “fields of type `Pattern` / `ObjectMapper` / `Clock`”, etc.
 
-### Problem statement
+#### Problem statement
 Without a type selector, some default grouping rules are forced to rely on naming conventions, which:
 - is less precise (false positives / negatives),
 - is inconsistent across projects,
 - makes configuration harder to reason about.
 
-### Decision for the first working version
+#### Decision for the first working version
 To avoid scope creep and ensure we ship a working end-to-end tool:
 - **Do not implement type-based matching in this version.**
 - In Default Rule, match `serialVersionUID` and logger fields **by name** (EXACT / REGEX) within the “static final fields” subgroup.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Introduce a new selector atom for rule lines: **type matcher**.
 
 - Match styles: EXACT / REGEX (same as name/annotation matchers).
@@ -162,7 +162,7 @@ Introduce a new selector atom for rule lines: **type matcher**.
   - TYPE declarations → qualified name (optional)
   - CONSTRUCTOR / initializer blocks → no match (type matcher never matches)
 
-### Design details (next version)
+#### Design details (next version)
 
 #### A. Type normalization
 To keep matching stable:
@@ -175,16 +175,16 @@ The DSL should document:
 - `type.exact: "org.slf4j.Logger"` / `type.exact: "Logger"`
 - `type.regex: ".*Logger"` etc.
 
-### Expected benefits
+#### Expected benefits
 - Much more expressive configuration for real projects.
 - Cleaner defaults (logger fields detected by type, not naming convention).
 - Fewer “special-case” groups that rely on heuristics.
 
-### Non-goals
+#### Non-goals
 - Do not introduce full semantic typing (imports resolution, type inference) in selectors.
 - Do not change current selector semantics for name/annotation.
 
-### Implementation outline (when we revisit this)
+#### Implementation outline (when we revisit this)
 - [ ] Extend the unified rule-line model to carry a type matcher (optional).
 - [ ] Implement compilation of the matcher into a predicate on `CtTypeMember`.
 - [ ] Introduce a type name extraction utility (field type / method return type).
@@ -196,13 +196,13 @@ The DSL should document:
 
 ---
 
-## 3. Handle enum constants ordering explicitly (future work)
+### 3. Handle enum constants ordering explicitly (future work)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred to the next product version)
 - [ ] Current behavior: enum constants remain **as-is** (original source order)
 
-### Background
+#### Background
 Enum constants are not regular fields and have strict placement rules in Java source:
 they appear at the top of an enum body, before other members.
 
@@ -211,13 +211,13 @@ In practice, this means:
 - we do not attempt to re-order enum constants,
 - they are preserved in their original order.
 
-### Problem statement
+#### Problem statement
 Projects often want a deterministic enum constant order, or at least a documented policy.
 Without an explicit rule:
 - enum constants may remain inconsistent across files,
 - users cannot express “keep as-is” vs “sort constants” as a configurable choice.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add explicit enum-constant handling with a configurable strategy.
 
 Two initial strategies to support:
@@ -229,15 +229,15 @@ Two initial strategies to support:
 Placement rule (still mandatory):
 - enum constants must be printed before other enum members.
 
-### Expected benefits
+#### Expected benefits
 - Deterministic ordering for enums when desired.
 - Clear, documented behavior instead of an implicit “we ignore them”.
 
-### Non-goals
+#### Non-goals
 - Do not attempt to reorder enum constants based on initializer complexity or “length”.
 - Do not introduce semantic grouping of enum constants in the first iteration.
 
-### Implementation outline (when we revisit this)
+#### Implementation outline (when we revisit this)
 - [ ] Model enum constants as a dedicated member kind in classification.
 - [ ] Ensure enum constants are emitted before other enum members in rendering.
 - [ ] Implement `PRESERVE`, `ALPHA_ASC`, `ALPHA_DESC` strategies.
@@ -249,13 +249,13 @@ Placement rule (still mandatory):
 
 ---
 
-## 4. Inter-procedural initializer dependencies (field default expression -> method calls)
+### 4. Inter-procedural initializer dependencies (field default expression -> method calls)
 
-### Status
+#### Status
 - [ ] Not implemented (verified against current dependency providers)
 - [ ] Deferred to a future version because it is complex and can significantly increase analysis cost
 
-### Why this is needed
+#### Why this is needed
 Current declaration dependency detection handles direct field references found in initializer-like AST roots
 (field initializer, init blocks, enum constant initializer, etc.).
 
@@ -266,14 +266,14 @@ A missing case:
 
 If we ignore this case, we may reorder members in a way that is unsafe for initialization semantics.
 
-### Verified current behavior (why this item stays TODO)
+#### Verified current behavior (why this item stays TODO)
 - Dependency providers currently collect dependencies from direct field access scanning in initializer roots.
 - No provider in the graph builder performs inter-procedural traversal of method bodies from initializer call sites.
 - No call-graph / recursion-aware traversal is present in dependency provider chain.
 
 Conclusion: indirect dependencies through called methods are not modeled yet.
 
-### Proposed solution (future)
+#### Proposed solution (future)
 Add a new declaration dependency provider for initializer call chains:
 
 1) For initializer-like dependent members, find method invocations in the initializer AST.
@@ -282,7 +282,7 @@ Add a new declaration dependency provider for initializer call chains:
 4) Recursively follow nested same-type method calls to build transitive dependencies.
 5) Add `DECLARATION_DEPENDENCY` edges from referenced provider fields to the original dependent member.
 
-### Safety / complexity requirements
+#### Safety / complexity requirements
 - Recursion and cycles:
   - maintain a visited call stack per traversal to avoid infinite recursion;
   - strongly connected call components should not crash analysis.
@@ -294,12 +294,12 @@ Add a new declaration dependency provider for initializer call chains:
 - Scope control:
   - first iteration can be limited to same-type, non-overridden method resolution.
 
-### Non-goals (first iteration)
+#### Non-goals (first iteration)
 - Full inter-class call graph.
 - Precise runtime dispatch modeling across inheritance hierarchies.
 - Side-effect inference beyond field read/write dependencies required for declaration safety.
 
-### Implementation outline (when we revisit this)
+#### Implementation outline (when we revisit this)
 - [ ] Add `InitializerMethodCallDependencyProvider` to dependency providers chain.
 - [ ] Implement same-type call resolution utility for Spoon method invocations.
 - [ ] Implement recursion-safe transitive method traversal and field-read extraction.
@@ -312,13 +312,13 @@ Add a new declaration dependency provider for initializer call chains:
   - [ ] interaction with existing direct initializer dependencies
 
 
-## 5. Explicit-declaring-type instance forward-reference corner-case (parked failing E2E)
+### 5. Explicit-declaring-type instance forward-reference corner-case (parked failing E2E)
 
-### Status
+#### Status
 - [ ] Not implemented (known failing scenario discovered in E2E)
 - [ ] Temporarily parked from active `*.java` fixtures until dependency analysis is fixed
 
-### Case summary (what exactly happens)
+#### Case summary (what exactly happens)
 Scenario class (`ExplicitTypeInstanceReferrerForwardReference...`) uses this pattern:
 - static field `zzz` is initialized via `new Sample().aaa`;
 - instance field `aaa` reads `Sample.bravo + 1`;
@@ -328,7 +328,7 @@ The value observed at runtime depends on declaration order and class-init timing
 - in the input variant, `zzz` is evaluated before `bravo` initializer runs, so `aaa` observes default static value and `zzz == 1`;
 - in the reordered variant, `aaa` is moved above `zzz`, which changes initialization sequence assumptions and breaks expected semantics.
 
-### Why current implementation fails
+#### Why current implementation fails
 Current dependency handling covers direct declaration dependencies and several local initializer cases, but does not yet fully protect this mixed pattern:
 - explicit declaring-type field access from instance initializer;
 - cross interaction between instance construction and static initialization ordering;
@@ -336,19 +336,19 @@ Current dependency handling covers direct declaration dependencies and several l
 
 As a result, sorter can produce an order that is syntactically valid but semantically different at runtime.
 
-### What to implement (plan)
+#### What to implement (plan)
 1. Re-enable this scenario as an active `.java` E2E fixture and confirm it fails reproducibly in `RESTRUCTURE + CHECK` flow.
 2. Extend dependency extraction for field initializers to model explicit declaring-type static reads inside instance initializers used by static field initialization chains.
 3. Add conservative ordering constraints so members participating in such chains are not moved across unsafe boundaries.
 4. Re-run full E2E + compile + runtime assertions; then keep scenario active as regression guard.
 
-### Corner-case family to cover next
+#### Corner-case family to cover next
 - Same pattern with primitive default values (`0`, `false`, `\u0000`) and `null`.
 - Longer chains (`static -> new instance -> instance field -> static field -> helper method`).
 - Mixed `this.` and `TypeName.` references in one initializer graph.
 - Cycles with SCC bundling to ensure no unstable reorder loops.
 
-### Very short note on temporary parking mechanism
+#### Very short note on temporary parking mechanism
 Current fixture is parked via escaped extension only as a temporary unblock step.
 Parked fixture files (excluded from automatic E2E sweep):
 - `core/src/test/resources/test-cases/core/e2e/restructure/10-field-initializer-explicit-type-forward-chain/input/ExplicitTypeInstanceReferrerForwardReferenceEscapedKnownIssueSample.~java`
@@ -371,33 +371,33 @@ Related parked lazy-context fixture (separate backlog track):
 
 ---
 
-## 6. Adaptive static-import optimizer (future version)
+### 6. Adaptive static-import optimizer (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Why this is needed
+#### Why this is needed
 Large type-qualified calls and constants can reduce readability when repeated often,
 while excessive static imports can make source harder to scan.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Introduce an import optimizer that:
 - detects frequent static candidates (constants and static methods),
 - adds/removes static imports automatically,
 - keeps usage explicit for infrequent candidates,
 - enforces a configurable upper threshold for static import count per file.
 
-### Candidate scoring (initial direction)
+#### Candidate scoring (initial direction)
 - frequency of usage in file;
 - qualified-name length savings (prefer long owner class names);
 - optional allow/deny patterns by package/type/member.
 
-### Safety requirements
+#### Safety requirements
 - never exceed configured static-import budget;
 - preserve deterministic output between runs;
 - avoid collisions/ambiguity when multiple static members share names.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Add config model for static-import budget and scoring strategy.
 - [ ] Build per-file usage index for static members.
 - [ ] Add deterministic add/remove planner for static imports.
@@ -405,24 +405,24 @@ Introduce an import optimizer that:
 
 ---
 
-## 7. Annotation ordering policies (future version)
+### 7. Annotation ordering policies (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 When declarations have many annotations, order quickly becomes inconsistent and noisy in diffs.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add configurable annotation ordering modes:
 - `ALPHA` (alphabetical by normalized annotation name),
 - `LENGTH_ASC` / `LENGTH_DESC`,
 - combined policy (primary by length, secondary alphabetical tie-breaker).
 
-### Scope
+#### Scope
 - types, methods, constructors, fields, parameters, record components.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Add annotation-order strategy to config DSL.
 - [ ] Normalize names (simple vs qualified) before comparison.
 - [ ] Preserve relative order for exact ties to keep output stable.
@@ -430,20 +430,20 @@ Add configurable annotation ordering modes:
 
 ---
 
-## 8. Collapse single-value annotation array braces (future version)
+### 8. Collapse single-value annotation array braces (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 For annotation attributes declared as arrays, Java allows omitting braces when only one value is passed.
 Keeping braces in single-value cases adds visual noise and creates avoidable diff churn.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add an automatic rewrite that transforms single-element annotation array arguments into a concise form
 without redundant braces when syntax and semantics stay equivalent.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Detect annotation array arguments with exactly one element.
 - [ ] Rewrite to brace-less single-value form where Java grammar permits it.
 - [ ] Skip cases where formatting/printing would become ambiguous.
@@ -451,73 +451,73 @@ without redundant braces when syntax and semantics stay equivalent.
 
 ---
 
-## 9. Constants and enum ordering expansion (future version)
+### 9. Constants and enum ordering expansion (future version)
 
-### Status
+#### Status
 - [ ] Partially captured in existing backlog; expanded here for completeness
 
-### Existing related item
+#### Existing related item
 - Enum constants ordering is already tracked in **Section 3** and should not be duplicated.
 
-### Additional future scope
+#### Additional future scope
 - explicit ordering policies for regular constants groups beyond current defaults;
 - shared configurable policy layer so constants/enum ordering rules stay consistent.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Reuse Section 3 enum implementation as the baseline.
 - [ ] Add constants-group ordering options with stable tie-breakers.
 - [ ] Add consistency tests (constants vs enum constants).
 
 ---
 
-## 10. Record-member ordering policies (future version)
+### 10. Record-member ordering policies (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 Record components/fields can become inconsistently ordered across files and modules,
 but this area should be configurable separately from enum/constants ordering.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add dedicated ordering strategies for record members:
 - alphabetical ordering;
 - declaration-preserving mode;
 - optional multi-key ordering with deterministic tie-breakers.
 
-### Safety requirements
+#### Safety requirements
 - preserve Java record semantics and generated member contracts;
 - keep deterministic output across repeated runs;
 - avoid rewriting that changes runtime behavior or binary compatibility unexpectedly.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Add record-member ordering strategy options to config.
 - [ ] Implement stable comparator with clear tie-break hierarchy.
 - [ ] Add focused fixtures for records with multiple components.
 
 ---
 
-## 11. Static-candidate conversion analyzer (instance -> static) (future version)
+### 11. Static-candidate conversion analyzer (instance -> static) (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 Some members are instance methods/fields but do not depend on instance state (or depend on very little),
 so they can be promoted to static for clarity and explicit dependencies.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add dependency-graph analysis to detect members that can safely become static:
 - detect methods with no `this`/instance-field dependency;
 - detect fields that are instance-declared but semantically static candidates;
 - optionally support controlled refactor mode for near-static methods by extracting required instance data into parameters.
 
-### Safety requirements
+#### Safety requirements
 - preserve behavior (including override/inheritance constraints);
 - skip members where static conversion breaks API or framework contracts;
 - provide conservative mode by default.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Build instance-dependency classifier on top of member dependency graph.
 - [ ] Add refactoring guardrails (override checks, reflective usage risk flags).
 - [ ] Add optional rewrite mode for parameterized utility extraction.
@@ -525,28 +525,28 @@ Add dependency-graph analysis to detect members that can safely become static:
 
 ---
 
-## 12. Visibility minimization pass (future version)
+### 12. Visibility minimization pass (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 Projects often keep broader visibility than necessary (`public`/`protected`) for classes,
 constructors, methods, and fields that are only used in narrower scopes.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Introduce a configurable pass that lowers visibility to the minimal safe level:
 - classes / nested classes,
 - constructors,
 - methods,
 - fields.
 
-### Safety requirements
+#### Safety requirements
 - do not break external API/public contracts when project is a library;
 - honor framework entry points and reflection-based usage allowlists;
 - produce an explicit report of every reduced-visibility change.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Add symbol-usage analysis across module boundaries.
 - [ ] Add configurable API boundary definitions.
 - [ ] Implement safe downgrade planner with dry-run mode.
@@ -554,16 +554,16 @@ Introduce a configurable pass that lowers visibility to the minimal safe level:
 
 ---
 
-## 13. Nullability interfaces / annotations enforcer (future version)
+### 13. Nullability interfaces / annotations enforcer (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 Teams need consistent nullability annotation coverage,
 but manual enforcement is repetitive and drifts over time.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add a nullability policy analyzer/fixer with configurable minimum scope:
 - `public` only, or
 - `public + package-private`, etc.
@@ -571,38 +571,38 @@ Add a nullability policy analyzer/fixer with configurable minimum scope:
 The analyzer validates and auto-fixes missing/incorrect nullability annotations for fields, methods,
 and method parameters according to configured scope.
 
-### Safety requirements
+#### Safety requirements
 - honor existing repository conventions and exclusions;
 - avoid changing `Object` override signatures/behavior;
 - support warning-only mode before auto-fix mode.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Add configurable nullability scope policy to DSL.
 - [ ] Implement nullability inference/validation + fix planner.
 
 ---
 
-## 14. Lombok policy enforcer and optimizer (future version)
+### 14. Lombok policy enforcer and optimizer (future version)
 
-### Status
+#### Status
 - [ ] Not implemented (explicitly deferred)
 
-### Problem statement
+#### Problem statement
 When Lombok is available, projects often keep a mix of manual boilerplate and partial Lombok usage,
 which increases maintenance cost and style drift.
 
-### Proposed solution (next version)
+#### Proposed solution (next version)
 Add a dedicated Lombok analyzer/fixer:
 - detect Lombok availability and supported annotations per module;
 - replace eligible boilerplate with Lombok annotations;
 - remove redundant manual code and redundant Lombok annotations.
 
-### Safety requirements
+#### Safety requirements
 - preserve behavior and generated API contracts;
 - honor project-level exclusions and style constraints;
 - support warning-only mode before auto-fix mode.
 
-### Implementation outline (when revisited)
+#### Implementation outline (when revisited)
 - [ ] Detect Lombok availability and supported annotations per module.
 - [ ] Build rule set for safe boilerplate-to-Lombok migrations.
 - [ ] Add semantic-preservation tests for migrated classes.
@@ -611,38 +611,38 @@ Add a dedicated Lombok analyzer/fixer:
 
 ## Technical debt / stabilization backlog
 
-## 1. Blank-final nearest-provider edge cases still not covered by active E2E
+### 1. Blank-final nearest-provider edge cases still not covered by active E2E
 
-### Status
+#### Status
 - [ ] Not fully implemented in active E2E coverage
 
-### Remaining gap
+#### Remaining gap
 - true multi-candidate-writer nearest-guaranteed-provider selection across multiple initialization members;
 - valid Java cannot express this shape without violating final-assignment rules, so active compile/run E2E fixtures cannot model it directly.
 
-### Backlog direction
+#### Backlog direction
 - keep this as a dedicated dependency-analysis improvement track;
 - design a safe representation strategy for this family (without weakening valid-Java guarantees).
 
 ---
 
-## 2. Spoon comment attachment gaps for non-type and comment-only units
+### 2. Spoon comment attachment gaps for non-type and comment-only units
 
-### Status
+#### Status
 - [ ] Open investigation / upstream tracking not yet completed
 
-### Verified current behavior
+#### Verified current behavior
 - For some `package-info.java` and `module-info.java` sources, Spoon does not reliably expose leading file-scope
   opt-out comments through attached `CtComment` nodes.
 - For comment-only sources, Spoon can produce `TYPE_DECLARATION` unit type with no declared types and no
   recoverable file-scope comments from AST traversal.
 
-### Temporary workaround in code
+#### Temporary workaround in code
 - `JHarmonizerOptOutResolver` keeps an AST-first strategy.
 - For known unreliable unit shapes, file-level opt-out directives are parsed from raw source comments using
   a lexer-like fallback.
 
-### Follow-up actions
+#### Follow-up actions
 - [ ] Create/confirm upstream Spoon issue(s) with minimal reproducible samples for:
   - [ ] package declarations with leading file comments;
   - [ ] module declarations with leading file comments;

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,22 +8,19 @@ when the pipeline is proven end-to-end.
 
 ---
 
-## 0. Must-have: allow opting out of harmonization per file/type
+## Backlog buckets
 
-Add a suppression mechanism to skip JHarmonizer processing for selected Java sources (or specific top-level types):
-- Skip sorting (member reordering)
-- Skip formatting (Palantir Java Format)
-- Skip “check” validations
+To keep planning explicit, this backlog is split into two categories:
 
-Rationale:
-Sometimes the formatter/printer behaves incorrectly for a specific class, or the file is intentionally maintained manually. The user must be able to mark such sources so the tool does not touch them on every run.
+1) **Technical debt / stabilization backlog**  
+   Items that improve correctness, safety, architecture, or maintainability of existing behavior.
 
-Acceptance idea:
-- Introduce a well-defined marker (e.g., a special comment or a dedicated suppress annotation with a stable token/code).
-- When the marker is present, the file/type is excluded from all harmonization steps (restructure + check + formatting).
-- The marker must be easy to search for across the codebase and safe to keep in VCS.
+2) **Planned future features (new product functionality)**  
+   Items that extend user-visible capabilities in upcoming versions.
 
 ---
+
+## Planned future features (new product functionality)
 
 ## 1. Compile group sorting once and precompute ordering rule values in `MemberDescriptor`
 
@@ -374,7 +371,247 @@ Related parked lazy-context fixture (separate backlog track):
 
 ---
 
-## 6. Blank-final nearest-provider edge cases still not covered by active E2E
+## 6. Adaptive static-import optimizer (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Why this is needed
+Large type-qualified calls and constants can reduce readability when repeated often,
+while excessive static imports can make source harder to scan.
+
+### Proposed solution (next version)
+Introduce an import optimizer that:
+- detects frequent static candidates (constants and static methods),
+- adds/removes static imports automatically,
+- keeps usage explicit for infrequent candidates,
+- enforces a configurable upper threshold for static import count per file.
+
+### Candidate scoring (initial direction)
+- frequency of usage in file;
+- qualified-name length savings (prefer long owner class names);
+- optional allow/deny patterns by package/type/member.
+
+### Safety requirements
+- never exceed configured static-import budget;
+- preserve deterministic output between runs;
+- avoid collisions/ambiguity when multiple static members share names.
+
+### Implementation outline (when revisited)
+- [ ] Add config model for static-import budget and scoring strategy.
+- [ ] Build per-file usage index for static members.
+- [ ] Add deterministic add/remove planner for static imports.
+- [ ] Add collision resolution rules and regression tests.
+
+---
+
+## 7. Annotation ordering policies (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+When declarations have many annotations, order quickly becomes inconsistent and noisy in diffs.
+
+### Proposed solution (next version)
+Add configurable annotation ordering modes:
+- `ALPHA` (alphabetical by normalized annotation name),
+- `LENGTH_ASC` / `LENGTH_DESC`,
+- combined policy (primary by length, secondary alphabetical tie-breaker).
+
+### Scope
+- types, methods, constructors, fields, parameters, record components.
+
+### Implementation outline (when revisited)
+- [ ] Add annotation-order strategy to config DSL.
+- [ ] Normalize names (simple vs qualified) before comparison.
+- [ ] Preserve relative order for exact ties to keep output stable.
+- [ ] Add fixture coverage for all supported declaration kinds.
+
+---
+
+## 8. Collapse single-value annotation array braces (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+For annotation attributes declared as arrays, Java allows omitting braces when only one value is passed.
+Keeping braces in single-value cases adds visual noise and creates avoidable diff churn.
+
+### Proposed solution (next version)
+Add an automatic rewrite that transforms single-element annotation array arguments into a concise form
+without redundant braces when syntax and semantics stay equivalent.
+
+### Implementation outline (when revisited)
+- [ ] Detect annotation array arguments with exactly one element.
+- [ ] Rewrite to brace-less single-value form where Java grammar permits it.
+- [ ] Skip cases where formatting/printing would become ambiguous.
+- [ ] Add round-trip fixtures to verify semantic equivalence and stable output.
+
+---
+
+## 9. Constants and enum ordering expansion (future version)
+
+### Status
+- [ ] Partially captured in existing backlog; expanded here for completeness
+
+### Existing related item
+- Enum constants ordering is already tracked in **Section 3** and should not be duplicated.
+
+### Additional future scope
+- explicit ordering policies for regular constants groups beyond current defaults;
+- shared configurable policy layer so constants/enum ordering rules stay consistent.
+
+### Implementation outline (when revisited)
+- [ ] Reuse Section 3 enum implementation as the baseline.
+- [ ] Add constants-group ordering options with stable tie-breakers.
+- [ ] Add consistency tests (constants vs enum constants).
+
+---
+
+## 10. Record-member ordering policies (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+Record components/fields can become inconsistently ordered across files and modules,
+but this area should be configurable separately from enum/constants ordering.
+
+### Proposed solution (next version)
+Add dedicated ordering strategies for record members:
+- alphabetical ordering;
+- declaration-preserving mode;
+- optional multi-key ordering with deterministic tie-breakers.
+
+### Safety requirements
+- preserve Java record semantics and generated member contracts;
+- keep deterministic output across repeated runs;
+- avoid rewriting that changes runtime behavior or binary compatibility unexpectedly.
+
+### Implementation outline (when revisited)
+- [ ] Add record-member ordering strategy options to config.
+- [ ] Implement stable comparator with clear tie-break hierarchy.
+- [ ] Add focused fixtures for records with multiple components.
+
+---
+
+## 11. Static-candidate conversion analyzer (instance -> static) (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+Some members are instance methods/fields but do not depend on instance state (or depend on very little),
+so they can be promoted to static for clarity and explicit dependencies.
+
+### Proposed solution (next version)
+Add dependency-graph analysis to detect members that can safely become static:
+- detect methods with no `this`/instance-field dependency;
+- detect fields that are instance-declared but semantically static candidates;
+- optionally support controlled refactor mode for near-static methods by extracting required instance data into parameters.
+
+### Safety requirements
+- preserve behavior (including override/inheritance constraints);
+- skip members where static conversion breaks API or framework contracts;
+- provide conservative mode by default.
+
+### Implementation outline (when revisited)
+- [ ] Build instance-dependency classifier on top of member dependency graph.
+- [ ] Add refactoring guardrails (override checks, reflective usage risk flags).
+- [ ] Add optional rewrite mode for parameterized utility extraction.
+- [ ] Add compile + behavior regression fixtures.
+
+---
+
+## 12. Visibility minimization pass (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+Projects often keep broader visibility than necessary (`public`/`protected`) for classes,
+constructors, methods, and fields that are only used in narrower scopes.
+
+### Proposed solution (next version)
+Introduce a configurable pass that lowers visibility to the minimal safe level:
+- classes / nested classes,
+- constructors,
+- methods,
+- fields.
+
+### Safety requirements
+- do not break external API/public contracts when project is a library;
+- honor framework entry points and reflection-based usage allowlists;
+- produce an explicit report of every reduced-visibility change.
+
+### Implementation outline (when revisited)
+- [ ] Add symbol-usage analysis across module boundaries.
+- [ ] Add configurable API boundary definitions.
+- [ ] Implement safe downgrade planner with dry-run mode.
+- [ ] Add regression tests for framework-specific entry points.
+
+---
+
+## 13. Nullability interfaces / annotations enforcer (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+Teams need consistent nullability annotation coverage,
+but manual enforcement is repetitive and drifts over time.
+
+### Proposed solution (next version)
+Add a nullability policy analyzer/fixer with configurable minimum scope:
+- `public` only, or
+- `public + package-private`, etc.
+
+The analyzer validates and auto-fixes missing/incorrect nullability annotations for fields, methods,
+and method parameters according to configured scope.
+
+### Safety requirements
+- honor existing repository conventions and exclusions;
+- avoid changing `Object` override signatures/behavior;
+- support warning-only mode before auto-fix mode.
+
+### Implementation outline (when revisited)
+- [ ] Add configurable nullability scope policy to DSL.
+- [ ] Implement nullability inference/validation + fix planner.
+
+---
+
+## 14. Lombok policy enforcer and optimizer (future version)
+
+### Status
+- [ ] Not implemented (explicitly deferred)
+
+### Problem statement
+When Lombok is available, projects often keep a mix of manual boilerplate and partial Lombok usage,
+which increases maintenance cost and style drift.
+
+### Proposed solution (next version)
+Add a dedicated Lombok analyzer/fixer:
+- detect Lombok availability and supported annotations per module;
+- replace eligible boilerplate with Lombok annotations;
+- remove redundant manual code and redundant Lombok annotations.
+
+### Safety requirements
+- preserve behavior and generated API contracts;
+- honor project-level exclusions and style constraints;
+- support warning-only mode before auto-fix mode.
+
+### Implementation outline (when revisited)
+- [ ] Detect Lombok availability and supported annotations per module.
+- [ ] Build rule set for safe boilerplate-to-Lombok migrations.
+- [ ] Add semantic-preservation tests for migrated classes.
+
+---
+
+## Technical debt / stabilization backlog
+
+## 1. Blank-final nearest-provider edge cases still not covered by active E2E
 
 ### Status
 - [ ] Not fully implemented in active E2E coverage
@@ -389,7 +626,7 @@ Related parked lazy-context fixture (separate backlog track):
 
 ---
 
-## 7. Spoon comment attachment gaps for non-type and comment-only units
+## 2. Spoon comment attachment gaps for non-type and comment-only units
 
 ### Status
 - [ ] Open investigation / upstream tracking not yet completed
@@ -411,3 +648,5 @@ Related parked lazy-context fixture (separate backlog track):
   - [ ] module declarations with leading file comments;
   - [ ] comment-only compilation units.
 - [ ] Re-evaluate and remove/limit raw-source fallback after upstream fix is available and verified.
+
+---


### PR DESCRIPTION
### Motivation
- Reorganize and clarify the project backlog to separate stabilization/technical debt items from user-facing future features.  
- Capture additional design proposals and implementation outlines so planned work is explicit and discoverable.  
- Make a few existing notes (parking of flaky fixtures, Spoon comment workarounds) easier to find and track alongside new proposals.

### Description
- Rewrote `docs/TODO.md` to introduce backlog buckets (`Technical debt / stabilization backlog` and `Planned future features`) and renumber/relocate existing items.  
- Replaced the previous top-level opt-out note with an explicit backlog structure and preserved the `JHarmonizerOptOutResolver` workaround description under comment-attachment gaps.  
- Added and expanded multiple future-feature proposals including an adaptive static-import optimizer, annotation ordering policies, collapse single-value annotation array braces, constants/enum ordering expansion, record-member ordering policies, static-candidate conversion analyzer, visibility minimization pass, nullability enforcer, and Lombok policy enforcer and optimizer.  
- Kept and clarified existing technical-debt items such as sorting compilation into `MemberDescriptor`, blank-final nearest-provider edge cases, parked fixtures, and Spoon comment attachment gaps.

### Testing
- No automated code tests were run as this PR only modifies documentation in `docs/TODO.md`.  
- No behavioral changes to source code were introduced, so CI test suites were not required for this change.  
- Markdown/doc linter checks (if enabled in CI) are expected to validate formatting during normal CI runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c828f199f88325b3ecbcbd46a1e564)