### PR TITLE
Replace existing .bak when creating backups and add tests

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandler.java
@@ -1,5 +1,7 @@
 package io.github.lemon_ant.jharmonizer.core.files_handler;
 
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.github.lemon_ant.globpathfinder.GlobPathFinder;
 import io.github.lemon_ant.globpathfinder.PathQuery;
@@ -89,6 +91,7 @@ public class SrcFilesHandler {
     // TODO Hide in the Overwrite method
     /**
      * Renames the source file to its backup variant with a {@code .bak} suffix.
+     * If a backup already exists, it is replaced with the latest pre-overwrite source snapshot.
      *
      * @param sourceFile the source file to back up
      */
@@ -101,7 +104,7 @@ public class SrcFilesHandler {
 
         Path backupPath = srcFile.resolveSibling(srcFile.getFileName().toString() + ".bak");
         try {
-            Files.move(srcFile, backupPath);
+            Files.move(srcFile, backupPath, REPLACE_EXISTING);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandler.java
@@ -93,7 +93,7 @@ public class SrcFilesHandler {
      * Renames the source file to its backup variant with a {@code .bak} suffix.
      * If a backup already exists, it is replaced with the latest pre-overwrite source snapshot.
      *
-     * @param sourceFile the source file to back up
+     * @param srcFile the source file to back up
      */
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public static void renameToBackup(@NonNull Path srcFile) {

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
@@ -9,6 +9,7 @@ import ch.qos.logback.core.read.ListAppender;
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.JHarmonizerConfigurationManager;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedConfigMerger;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFilesHandler;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowType;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.FileProcessingStatistic;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
@@ -256,6 +257,26 @@ class SrcProcessorTest {
         assertThat(backupFilePath).exists();
         assertThat(Files.readString(backupFilePath, StandardCharsets.UTF_8)).isEqualTo(originalSrcCode);
         assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSrcCode);
+    }
+
+    @Test
+    void processSources_secondRunWithBackupsEnabled_replacesExistingBackup() throws Exception {
+        // Given
+        String firstSrcCode = "package demo; public class BackupTwice {private int x;}";
+        String secondSrcCode = "package demo; public class BackupTwice {private int y;}";
+        Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupTwice.java", firstSrcCode);
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null));
+
+        // When
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        SrcFilesHandler.overwrite(javaFilePath, secondSrcCode);
+        srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+
+        // Then
+        Path backupFilePath =
+                javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
+        assertThat(backupFilePath).exists();
+        assertThat(Files.readString(backupFilePath, StandardCharsets.UTF_8)).isEqualTo(secondSrcCode);
     }
 
     @Test

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandlerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/files_handler/SrcFilesHandlerTest.java
@@ -33,6 +33,21 @@ class SrcFilesHandlerTest {
     }
 
     @Test
+    void backup_existingBackup_replacesBackupWithLatestSource() throws IOException {
+        // Given
+        Path srcFile = Files.writeString(tempDir.resolve("Example.java"), "class Latest {}");
+        Path backupFile = Files.writeString(tempDir.resolve("Example.java.bak"), "class OldBackup {}");
+
+        // When
+        SrcFilesHandler.renameToBackup(srcFile);
+
+        // Then
+        assertThat(backupFile).exists();
+        assertThat(Files.readString(backupFile)).isEqualTo("class Latest {}");
+        assertThat(srcFile).doesNotExist();
+    }
+
+    @Test
     void backup_nonExistingFile_throwsIOException() {
         // Given
         Path missingFile = tempDir.resolve("DoesNotExist.java");


### PR DESCRIPTION
### Motivation

- Ensure that creating a backup of a source file replaces any existing backup so the `.bak` file always contains the latest pre-overwrite snapshot.

### Description

- Use `Files.move(srcFile, backupPath, REPLACE_EXISTING)` to replace an existing `.bak` file when renaming a source file to its backup variant and add the `REPLACE_EXISTING` static import.
- Update the method Javadoc to document that an existing backup will be replaced.
- Add `SrcFilesHandlerTest#backup_existingBackup_replacesBackupWithLatestSource` to verify that an existing backup is overwritten with the latest source content.
- Add `SrcProcessorTest#processSources_secondRunWithBackupsEnabled_replacesExistingBackup` to verify end-to-end behavior when processing sources twice with backups enabled.

### Testing

- Ran unit tests in `SrcFilesHandlerTest` including `backup_existingBackup_replacesBackupWithLatestSource`, which succeeded.
- Ran unit tests in `SrcProcessorTest` including `processSources_secondRunWithBackupsEnabled_replacesExistingBackup`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c95d463f2083258ac3bc88c5a81cbb)