### PR TITLE
Catch runtime exceptions during partial evaluation and add method-reference fixture test

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtExpression;
@@ -20,10 +22,11 @@ import spoon.reflect.declaration.CtField;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.visitor.filter.TypeFilter;
-import spoon.support.SpoonClassNotFoundException;
 
 @UtilityClass
 class DeclaringTypeFieldReferenceUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(DeclaringTypeFieldReferenceUtils.class);
 
     /**
      * Performs the require declaring type.
@@ -95,10 +98,15 @@ class DeclaringTypeFieldReferenceUtils {
      * @return partially evaluated expression, or empty when Spoon cannot resolve required classes
      */
     @NonNull
+    @SuppressWarnings("PMD.AvoidCatchingGenericException")
     static Optional<CtExpression<?>> findPartiallyEvaluatedExpression(@NonNull CtExpression<?> expression) {
         try {
             return Optional.of(expression.partiallyEvaluate());
-        } catch (SpoonClassNotFoundException ignored) {
+        } catch (RuntimeException exception) {
+            logger.warn(
+                    "Failed to partially evaluate field initializer expression at {}. Falling back to raw expression.",
+                    expression.getPosition(),
+                    exception);
             return Optional.empty();
         }
     }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
@@ -6,8 +6,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import spoon.reflect.code.CtAssignment;
 import spoon.reflect.code.CtExecutableReferenceExpression;
 import spoon.reflect.code.CtExpression;
@@ -24,9 +23,8 @@ import spoon.reflect.declaration.CtTypeMember;
 import spoon.reflect.visitor.filter.TypeFilter;
 
 @UtilityClass
+@Slf4j
 class DeclaringTypeFieldReferenceUtils {
-
-    private static final Logger logger = LoggerFactory.getLogger(DeclaringTypeFieldReferenceUtils.class);
 
     /**
      * Performs the require declaring type.
@@ -103,14 +101,14 @@ class DeclaringTypeFieldReferenceUtils {
         try {
             return Optional.of(expression.partiallyEvaluate());
         } catch (RuntimeException exception) {
-            logger.warn(
+            log.warn(
                     "Failed to partially evaluate field initializer expression at {} ({}: {}). "
                             + "Falling back to raw expression.",
                     expression.getPosition(),
                     exception.getClass().getSimpleName(),
                     exception.getMessage());
-            if (logger.isDebugEnabled()) {
-                logger.debug("Partial-evaluation failure stack trace.", exception);
+            if (log.isDebugEnabled()) {
+                log.debug("Partial-evaluation failure stack trace.", exception);
             }
             return Optional.empty();
         }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
@@ -92,10 +92,10 @@ class DeclaringTypeFieldReferenceUtils {
     }
 
     /**
-     * Attempts to partially evaluate an expression without failing on missing runtime classes.
+     * Attempts to partially evaluate an expression.
      *
      * @param expression the expression to evaluate
-     * @return partially evaluated expression, or empty when Spoon cannot resolve required classes
+     * @return partially evaluated expression, or empty when Spoon/runtime failures prevent safe folding
      */
     @NonNull
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
@@ -104,9 +104,14 @@ class DeclaringTypeFieldReferenceUtils {
             return Optional.of(expression.partiallyEvaluate());
         } catch (RuntimeException exception) {
             logger.warn(
-                    "Failed to partially evaluate field initializer expression at {}. Falling back to raw expression.",
+                    "Failed to partially evaluate field initializer expression at {} ({}: {}). "
+                            + "Falling back to raw expression.",
                     expression.getPosition(),
-                    exception);
+                    exception.getClass().getSimpleName(),
+                    exception.getMessage());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Partial-evaluation failure stack trace.", exception);
+            }
             return Optional.empty();
         }
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/MemberDependencyGraphBuilderTest.java
@@ -237,6 +237,22 @@ class MemberDependencyGraphBuilderTest {
     }
 
     @Test
+    void buildDependencyGraph_explicitThisForwardReferenceWithMethodReference_preservesSrcDeclarationOrder() {
+        // Given
+        MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
+                Constants.FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_MEMBERS);
+
+        // When
+        Set<CtTypeMember> directProviders = memberDependencyGraph.findDirectProviders(
+                Constants.EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_BRAVO_FIELD_MEMBER,
+                EnumSet.of(MemberDependencyEdgeKind.DECLARATION_DEPENDENCY));
+
+        // Then
+        assertThat(directProviders)
+                .containsExactly(Constants.EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_ALPHA_FIELD_MEMBER);
+    }
+
+    @Test
     void buildDependencyGraph_explicitDeclaringTypeForwardReference_preservesSrcDeclarationOrder() {
         // Given
         MemberDependencyGraph memberDependencyGraph = MemberDependencyGraphBuilder.buildDependencyGraph(
@@ -676,6 +692,25 @@ class MemberDependencyGraphBuilderTest {
         private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_MINUS_ZERO_DEFAULT_VALUE_BRAVO_FIELD_MEMBER =
                 SpoonTestCaseUtils.requireTypeMemberBySimpleName(
                         FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_MINUS_ZERO_DEFAULT_VALUE_MEMBERS, "bravo");
+
+        private static final URL FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_FIXTURE_URL =
+                TestCaseResourceUtils.requireClasspathResourceUrl(
+                        "/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture.java");
+        private static final CtType<?>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_FIXTURE_MAIN_TYPE =
+                        SpoonTestCaseUtils.parseMainTypeFromJavaFixtureResource(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_FIXTURE_URL);
+        private static final Map<CtTypeMember, CompiledMemberGroup>
+                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_MEMBERS =
+                        buildTypeMember2NaturalGroup(
+                                FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_FIXTURE_MAIN_TYPE,
+                                MEMBER_GROUP_WITHOUT_ACCESSOR_BUNDLING);
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_ALPHA_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_MEMBERS, "alpha");
+        private static final CtTypeMember EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_BRAVO_FIELD_MEMBER =
+                SpoonTestCaseUtils.requireTypeMemberBySimpleName(
+                        FIELD_INITIALIZER_EXPLICIT_THIS_FORWARD_REFERENCE_METHOD_REFERENCE_MEMBERS, "bravo");
 
         private static final URL FIELD_INITIALIZER_EXPLICIT_DECLARING_TYPE_FORWARD_REFERENCE_FIXTURE_URL =
                 TestCaseResourceUtils.requireClasspathResourceUrl(

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture.java
@@ -1,4 +1,6 @@
-class FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture {
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
+
+public class FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture {
 
     private final int alpha = this.bravo;
 

--- a/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture.java
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/dependency-graph/valid/explicit-this-forward-reference/FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture.java
@@ -1,0 +1,8 @@
+class FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture {
+
+    private final int alpha = this.bravo;
+
+    private final int bravo = java.util.Optional.<java.util.function.Supplier<Integer>>of(() -> 0)
+            .map(java.util.function.Supplier::get)
+            .orElse(0);
+}

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -675,3 +675,34 @@ Add a dedicated Lombok analyzer/fixer:
 - [ ] Re-evaluate and remove/limit raw-source fallback after upstream fix is available and verified.
 
 ---
+
+### 3. Spoon partial evaluator NPE on method-reference expressions in no-classpath mode
+
+#### Status
+- [ ] Open investigation / upstream issue not yet created
+
+#### Verified current behavior
+- In no-classpath parsing, Spoon may throw `NullPointerException` from partial evaluation while inspecting
+  field-initializer expressions containing method references.
+- Reproduced with expression shape similar to:
+  `Map.of(WHOLE_CONFIG_KEY, WholeConfigDifferentiator::getByteBufferDifferentiator)`.
+
+#### Representative stack trace (captured)
+```text
+java.lang.NullPointerException: Cannot invoke "spoon.reflect.reference.CtTypeReference.getTypeDeclaration()"
+because the return value of "spoon.reflect.reference.CtFieldReference.getDeclaringType()" is null
+    at spoon.support.reflect.eval.VisitorPartialEvaluator.visitFieldAccess(VisitorPartialEvaluator.java:428)
+    at spoon.support.reflect.eval.VisitorPartialEvaluator.visitCtFieldRead(VisitorPartialEvaluator.java:397)
+    at spoon.support.reflect.eval.VisitorPartialEvaluator.visitCtInvocation(VisitorPartialEvaluator.java:529)
+```
+
+#### Temporary workaround in code
+- `DeclaringTypeFieldReferenceUtils.findPartiallyEvaluatedExpression(...)` treats partial-evaluation runtime
+  failures as non-foldable expressions, logs warning context, and returns `Optional.empty()`.
+
+#### Follow-up actions
+- [ ] Create upstream Spoon issue with a minimal reproducible sample based on method-reference field initializer.
+- [ ] Attach the captured stack trace and no-classpath context to the upstream report.
+- [ ] Revisit local fallback scope after upstream fix becomes available.
+
+---


### PR DESCRIPTION
### Motivation

- Partially evaluating field initializer expressions can fail when Spoon cannot resolve runtime classes or when other runtime errors occur, causing dependency analysis to abort. 
- A specific case with a field initializer that uses a method reference needed a test to ensure forward-reference declaration ordering is preserved when partial evaluation falls back to raw expressions.

### Description

- Added an SLF4J `Logger` to `DeclaringTypeFieldReferenceUtils` and changed `findPartiallyEvaluatedExpression` to catch `RuntimeException`, log a warning with the expression position and exception, and return `Optional.empty()` to fall back to the raw expression. 
- Removed the reliance on `SpoonClassNotFoundException` and added a `@SuppressWarnings("PMD.AvoidCatchingGenericException")` on the method. 
- Added a new unit test `buildDependencyGraph_explicitThisForwardReferenceWithMethodReference_preservesSrcDeclarationOrder` to `MemberDependencyGraphBuilderTest` and included the corresponding test fixture file `FieldInitializerExplicitThisForwardReferenceMethodReferenceFixture.java` and related constants.

### Testing

- Ran the unit tests including `MemberDependencyGraphBuilderTest` (which contains the new `buildDependencyGraph_explicitThisForwardReferenceWithMethodReference_preservesSrcDeclarationOrder` test) via `mvn test`. 
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9699e7b1c8325a01fa6a511840cd2)