### PR TITLE
Skip partial evaluation for anonymous-class initializers and add regression test

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtils.java
@@ -14,6 +14,7 @@ import spoon.reflect.code.CtFieldAccess;
 import spoon.reflect.code.CtFieldRead;
 import spoon.reflect.code.CtFieldWrite;
 import spoon.reflect.code.CtLambda;
+import spoon.reflect.code.CtNewClass;
 import spoon.reflect.code.CtOperatorAssignment;
 import spoon.reflect.cu.SourcePosition;
 import spoon.reflect.declaration.CtElement;
@@ -98,15 +99,21 @@ class DeclaringTypeFieldReferenceUtils {
     @NonNull
     @SuppressWarnings("PMD.AvoidCatchingGenericException")
     static Optional<CtExpression<?>> findPartiallyEvaluatedExpression(@NonNull CtExpression<?> expression) {
+        if (!expression.getElements(new TypeFilter<>(CtNewClass.class)).isEmpty()) {
+            return Optional.empty();
+        }
+
         try {
             return Optional.of(expression.partiallyEvaluate());
         } catch (RuntimeException exception) {
-            log.warn(
-                    "Failed to partially evaluate field initializer expression at {} ({}: {}). "
-                            + "Falling back to raw expression.",
-                    expression.getPosition(),
-                    exception.getClass().getSimpleName(),
-                    exception.getMessage());
+            if (log.isWarnEnabled()) {
+                log.warn(
+                        "Failed to partially evaluate field initializer expression at {} ({}: {}). "
+                                + "Falling back to raw expression.",
+                        expression.getPosition(),
+                        exception.getClass().getSimpleName(),
+                        exception.getMessage());
+            }
             if (log.isDebugEnabled()) {
                 log.debug("Partial-evaluation failure stack trace.", exception);
             }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtilsTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/dependency_graph/DeclaringTypeFieldReferenceUtilsTest.java
@@ -1,0 +1,35 @@
+package io.github.lemon_ant.jharmonizer.core.sorter.spoon.dependency_graph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtNewClass;
+import spoon.reflect.visitor.filter.TypeFilter;
+
+class DeclaringTypeFieldReferenceUtilsTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void findPartiallyEvaluatedExpression_anonymousClassInitializer_returnsEmptyOptionalWithoutPartialEvaluation() {
+        // Given
+        CtExpression<?> expression = mock(CtExpression.class);
+        CtNewClass<?> anonymousClassExpression = mock(CtNewClass.class);
+        when(expression.getElements(any(TypeFilter.class))).thenReturn(List.of(anonymousClassExpression));
+
+        // When
+        Optional<CtExpression<?>> partiallyEvaluatedExpression =
+                DeclaringTypeFieldReferenceUtils.findPartiallyEvaluatedExpression(expression);
+
+        // Then
+        assertThat(partiallyEvaluatedExpression).isEmpty();
+        verify(expression, never()).partiallyEvaluate();
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/regression/02-anonymous-class-initializer/expected/AnonymousClassInitializerRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/02-anonymous-class-initializer/expected/AnonymousClassInitializerRegressionSample.java
@@ -1,0 +1,49 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class AnonymousClassInitializerRegressionSample {
+    private static final String expectedValue = "selected";
+    private static final Selector selector = Selector.of().or("", "selected");
+
+    public static void main(String[] args) {
+        String selectedValue = selector.value();
+        if (!expectedValue.equals(selectedValue)) {
+            throw new IllegalStateException("Unexpected selected value: " + selectedValue);
+        }
+    }
+
+    private interface Selector {
+        static Selector of() {
+            return new Selector() {
+                @Override
+                public Selector or(String... candidates) {
+                    for (String candidate : candidates) {
+                        if (candidate != null && !candidate.isEmpty()) {
+                            return new Selector() {
+                                @Override
+                                public Selector or(String... ignoredCandidates) {
+                                    return this;
+                                }
+
+                                @Override
+                                public String value() {
+                                    return candidate;
+                                }
+                            };
+                        }
+                    }
+
+                    return this;
+                }
+
+                @Override
+                public String value() {
+                    return "";
+                }
+            };
+        }
+
+        Selector or(String... candidates);
+
+        String value();
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/regression/02-anonymous-class-initializer/input/AnonymousClassInitializerRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/02-anonymous-class-initializer/input/AnonymousClassInitializerRegressionSample.java
@@ -1,0 +1,49 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public class AnonymousClassInitializerRegressionSample {
+    private static final Selector selector = Selector.of().or("", "selected");
+    private static final String expectedValue = "selected";
+
+    public static void main(String[] args) {
+        String selectedValue = selector.value();
+        if (!expectedValue.equals(selectedValue)) {
+            throw new IllegalStateException("Unexpected selected value: " + selectedValue);
+        }
+    }
+
+    private interface Selector {
+        Selector or(String... candidates);
+
+        String value();
+
+        static Selector of() {
+            return new Selector() {
+                @Override
+                public Selector or(String... candidates) {
+                    for (String candidate : candidates) {
+                        if (candidate != null && !candidate.isEmpty()) {
+                            return new Selector() {
+                                @Override
+                                public Selector or(String... ignoredCandidates) {
+                                    return this;
+                                }
+
+                                @Override
+                                public String value() {
+                                    return candidate;
+                                }
+                            };
+                        }
+                    }
+
+                    return this;
+                }
+
+                @Override
+                public String value() {
+                    return "";
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent unsafe or incorrect partial-evaluation of expressions that contain anonymous class instantiations (`CtNewClass`) which can cause runtime/Spoon failures or incorrect folding.
- Avoid attempting `partiallyEvaluate()` when an anonymous-class is present to preserve original AST semantics for field initializers.
- Reduce logging overhead by guarding the warning log formatting behind an enabled-level check.

### Description

- Added a guard in `DeclaringTypeFieldReferenceUtils.findPartiallyEvaluatedExpression` to return `Optional.empty()` when the expression contains a `CtNewClass` element.  
- Imported `CtNewClass` and preserved the existing exception handling fallback for other partial-evaluation failures.  
- Wrapped the `log.warn(...)` call in an `if (log.isWarnEnabled())` check to avoid unnecessary log message construction.  
- Added a unit test `DeclaringTypeFieldReferenceUtilsTest` that verifies expressions containing `CtNewClass` are not partially evaluated, and added an e2e regression test case for the anonymous-class initializer under `test-cases/core/e2e/regression/02-anonymous-class-initializer` (both `input` and `expected`).

### Testing

- Added and executed the unit test `DeclaringTypeFieldReferenceUtilsTest`, which passed.  
- Executed the core test suite including the e2e regression case `02-anonymous-class-initializer`, which validated the behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98ff8fa9c83258b9d4ceb6c336ddf)