### PR TITLE
Fix member boundary detection in SpoonTypePrinter and add enum anonymous-body regression test

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -138,7 +138,6 @@ final class SpoonTypePrinter {
             List<CtTypeMember> explicitTypeMembers,
             boolean first,
             boolean previousElementNeedSeparatorAfter) {
-
         // TODO Check Orphaned comments
 
         boolean needsSeparatorBeforeCurrentMember = needsSeparatorBefore(member, first);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -138,6 +138,7 @@ final class SpoonTypePrinter {
             List<CtTypeMember> explicitTypeMembers,
             boolean first,
             boolean previousElementNeedSeparatorAfter) {
+
         // TODO Check Orphaned comments
 
         boolean needsSeparatorBeforeCurrentMember = needsSeparatorBefore(member, first);
@@ -163,7 +164,7 @@ final class SpoonTypePrinter {
 
         int nextElementStart = explicitTypeMembers.stream()
                 .mapToInt(typeMember -> typeMember.getPosition().getSourceStart())
-                .filter(start -> start > member.getPosition().getSourceEnd())
+                .filter(start -> start > member.getPosition().getSourceStart())
                 .min()
                 .orElse(member.getPosition().getSourceEnd() + 1);
         printOriginalFragment(member.getPosition().getSourceStart(), nextElementStart - 1);

--- a/core/src/test/resources/test-cases/core/e2e/regression/03-enum-anonymous-body-member-boundary/expected/EnumAnonymousBodyMemberBoundaryRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/03-enum-anonymous-body-member-boundary/expected/EnumAnonymousBodyMemberBoundaryRegressionSample.java
@@ -1,0 +1,42 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public enum EnumAnonymousBodyMemberBoundaryRegressionSample {
+    BETA {
+        @Override
+        String describe(int value) {
+            if (value > 10) {
+                return "big";
+            }
+
+            if (value > 0) {
+                return "small";
+            }
+
+            return "zero";
+        }
+    },
+
+    ALPHA {
+        @Override
+        String describe(int value) {
+            return Integer.toString(value);
+        }
+    };
+
+    private final String marker = scenarioName();
+
+    public static void main(String[] args) {
+        if (!"small".equals(BETA.describe(1))) {
+            throw new IllegalStateException("Unexpected BETA description");
+        }
+        if (!"0".equals(ALPHA.describe(0))) {
+            throw new IllegalStateException("Unexpected ALPHA description");
+        }
+    }
+
+    abstract String describe(int value);
+
+    private static String scenarioName() {
+        return EnumAnonymousBodyMemberBoundaryRegressionSample.class.getSimpleName();
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/regression/03-enum-anonymous-body-member-boundary/input/EnumAnonymousBodyMemberBoundaryRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/03-enum-anonymous-body-member-boundary/input/EnumAnonymousBodyMemberBoundaryRegressionSample.java
@@ -1,0 +1,42 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public enum EnumAnonymousBodyMemberBoundaryRegressionSample {
+    BETA {
+        @Override
+        String describe(int value) {
+            if (value > 10) {
+                return "big";
+            }
+
+            if (value > 0) {
+                return "small";
+            }
+
+            return "zero";
+        }
+    },
+
+    ALPHA {
+        @Override
+        String describe(int value) {
+            return Integer.toString(value);
+        }
+    };
+
+    public static void main(String[] args) {
+        if (!"small".equals(BETA.describe(1))) {
+            throw new IllegalStateException("Unexpected BETA description");
+        }
+        if (!"0".equals(ALPHA.describe(0))) {
+            throw new IllegalStateException("Unexpected ALPHA description");
+        }
+    }
+
+    abstract String describe(int value);
+
+    private static String scenarioName() {
+        return EnumAnonymousBodyMemberBoundaryRegressionSample.class.getSimpleName();
+    }
+
+    private final String marker = scenarioName();
+}


### PR DESCRIPTION
### Motivation
- Correct computation of the next element start in the type member printing logic to avoid printing incorrect original fragments for members (notably enum anonymous bodies). 
- Add a regression test that captures the enum anonymous-body / member-boundary scenario to prevent regressions.

### Description
- Change the next-element search filter in `SpoonTypePrinter` to compare starts against `member.getPosition().getSourceStart()` instead of `member.getPosition().getSourceEnd()` so the next element boundary is computed correctly.
- Add an end-to-end regression test case under `core/src/test/resources/test-cases/core/e2e/regression/03-enum-anonymous-body-member-boundary/` with both `input` and `expected` Java files exercising enum anonymous body boundaries and a final `marker` field placement.
- Small formatting adjustment in `printTypeMember` to keep the method layout consistent.

### Testing
- Ran the project test suite including the core e2e regression tests with the new `03-enum-anonymous-body-member-boundary` case and the tests completed successfully.
- Verified the modified behavior by running `mvn test` locally and confirmed the new regression passes and existing tests remain green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca60ba6edc8325b9e0609ed15f4384)