### PR TITLE
Preserve members outside enum constant class bodies by filtering explicit type members

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NonNull;
@@ -115,6 +116,7 @@ final class SpoonTypePrinter {
     @NonNull
     private static List<CtTypeMember> findExplicitTypeMembers(CtType<?> type) {
         return type.getTypeMembers().stream()
+                .filter(typeMember -> Objects.equals(typeMember.getDeclaringType(), type))
                 // Spoon creates implicit constructors which don't exist in the source code
                 .filter(typeMember -> typeMember.getPosition().isValidPosition())
                 /* TODO(RECORDS_DISABLED): Remove this guard when record headers/components are printed correctly.

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -116,6 +116,10 @@ final class SpoonTypePrinter {
     @NonNull
     private static List<CtTypeMember> findExplicitTypeMembers(CtType<?> type) {
         return type.getTypeMembers().stream()
+                // Spoon quirk: getTypeMembers() of a type may also include members whose declaring type
+                // is a nested/anonymous class (e.g., the anonymous classes of enum constants). We only want
+                // members that are declared directly in `type`, otherwise those nested members would be
+                // printed as if they were top-level members of `type`.
                 .filter(typeMember -> Objects.equals(typeMember.getDeclaringType(), type))
                 // Spoon creates implicit constructors which don't exist in the source code
                 .filter(typeMember -> typeMember.getPosition().isValidPosition())

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinterTest.java
@@ -36,4 +36,52 @@ class SpoonCustomSrcPrinterTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("already been finalized");
     }
+
+    @Test
+    void serializeCompilationUnit_enumConstantsWithClassBodies_keepMembersOutsideConstantBody() {
+        // Given
+        String srcCode = """
+                enum Metric {
+                    FIRST {
+                        @Override
+                        long value() {
+                            return 1L;
+                        }
+                    },
+                    SECOND {
+                        @Override
+                        long value() {
+                            return 2L;
+                        }
+                    };
+
+                    private final long cached = 7L;
+
+                    abstract long value();
+
+                    long total() {
+                        return value() + cached;
+                    }
+                }
+                """;
+        SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Metric.java")));
+        SpoonCustomSrcPrinter printer = new SpoonCustomSrcPrinter(
+                spoonAstModel.getCompilationUnit().getFactory().getEnvironment(),
+                srcCode,
+                spoonAstModel.getOptOuts().getSortingSkippedTypes());
+
+        // When
+        SerializedSrcWithSkippedTypeRanges serializedSrcWithSkippedTypeRanges =
+                printer.serializeCompilationUnit(spoonAstModel.getCompilationUnit());
+
+        // Then
+        String serializedSrc = serializedSrcWithSkippedTypeRanges.getSerializedSrcCode();
+        assertThat(serializedSrc).contains("};");
+        assertThat(serializedSrc).contains("private final long cached = 7L;");
+        assertThatCodeParses(serializedSrc);
+    }
+
+    private static void assertThatCodeParses(String srcCode) {
+        SpoonParser.parseJavaSrcFile(createSrcFile(srcCode, Path.of("Metric.java")));
+    }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonCustomSrcPrinterTest.java
@@ -78,6 +78,8 @@ class SpoonCustomSrcPrinterTest {
         String serializedSrc = serializedSrcWithSkippedTypeRanges.getSerializedSrcCode();
         assertThat(serializedSrc).contains("};");
         assertThat(serializedSrc).contains("private final long cached = 7L;");
+        assertThat(serializedSrc.indexOf("};"))
+                .isLessThan(serializedSrc.indexOf("private final long cached = 7L;"));
         assertThatCodeParses(serializedSrc);
     }
 

--- a/core/src/test/resources/test-cases/core/e2e/regression/04-enum-anonymous-argument-body-boundary/expected/EnumAnonymousArgumentBodyBoundaryRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/04-enum-anonymous-argument-body-boundary/expected/EnumAnonymousArgumentBodyBoundaryRegressionSample.java
@@ -1,0 +1,60 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+import java.util.function.LongUnaryOperator;
+
+public enum EnumAnonymousArgumentBodyBoundaryRegressionSample {
+    FIRST(
+            value -> value + 1,
+            new Reducer() {
+                @Override
+                public long reduce(long value) {
+                    if (value > 10) {
+                        return value - 10;
+                    }
+
+                    if (value > 0) {
+                        return value + 10;
+                    }
+
+                    return value;
+                }
+            },
+            true),
+
+    SECOND(
+            value -> value * 2,
+            new Reducer() {
+                @Override
+                public long reduce(long value) {
+                    return value;
+                }
+            },
+            false);
+
+    private final LongUnaryOperator mapper;
+    private final Reducer reducer;
+    private final boolean visible;
+
+    public static void main(String[] args) {
+        if (FIRST.compute(1) != 12) {
+            throw new IllegalStateException("Unexpected FIRST value");
+        }
+        if (SECOND.compute(3) != 6) {
+            throw new IllegalStateException("Unexpected SECOND value");
+        }
+    }
+
+    EnumAnonymousArgumentBodyBoundaryRegressionSample(LongUnaryOperator mapper, Reducer reducer, boolean visible) {
+        this.mapper = mapper;
+        this.reducer = reducer;
+        this.visible = visible;
+    }
+
+    private long compute(long value) {
+        return reducer.reduce(mapper.applyAsLong(value));
+    }
+
+    private interface Reducer {
+        long reduce(long value);
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/regression/04-enum-anonymous-argument-body-boundary/input/EnumAnonymousArgumentBodyBoundaryRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/04-enum-anonymous-argument-body-boundary/input/EnumAnonymousArgumentBodyBoundaryRegressionSample.java
@@ -1,0 +1,64 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+import java.util.function.LongUnaryOperator;
+
+public enum EnumAnonymousArgumentBodyBoundaryRegressionSample {
+    FIRST(
+            value -> value + 1,
+            new Reducer() {
+                @Override
+                public long reduce(long value) {
+                    if (value > 10) {
+                        return value - 10;
+                    }
+
+                    if (value > 0) {
+                        return value + 10;
+                    }
+
+                    return value;
+                }
+            },
+            true
+    ),
+
+    SECOND(
+            value -> value * 2,
+            new Reducer() {
+                @Override
+                public long reduce(long value) {
+                    return value;
+                }
+            },
+            false
+    );
+
+    public static void main(String[] args) {
+        if (FIRST.compute(1) != 12) {
+            throw new IllegalStateException("Unexpected FIRST value");
+        }
+        if (SECOND.compute(3) != 6) {
+            throw new IllegalStateException("Unexpected SECOND value");
+        }
+    }
+
+    private final LongUnaryOperator mapper;
+
+    private final Reducer reducer;
+
+    private final boolean visible;
+
+    EnumAnonymousArgumentBodyBoundaryRegressionSample(LongUnaryOperator mapper, Reducer reducer, boolean visible) {
+        this.mapper = mapper;
+        this.reducer = reducer;
+        this.visible = visible;
+    }
+
+    private long compute(long value) {
+        return reducer.reduce(mapper.applyAsLong(value));
+    }
+
+    private interface Reducer {
+        long reduce(long value);
+    }
+}


### PR DESCRIPTION
### Motivation
- Anonymous class bodies used in enum constants could cause members declared on the surrounding enum to be misattributed or lost during printing, producing invalid output that fails to parse.
- The type-member discovery currently included implicit or non-declared members created by Spoon, which led to incorrect printing around enum constant boundaries.
- Add a regression test and input/expected resources to cover the enum anonymous-argument/body boundary scenario.

### Description
- Tighten `findExplicitTypeMembers` in `SpoonTypePrinter` to filter members to those whose `getDeclaringType()` equals the inspected type by adding a `Objects.equals(...)` check and import.
- Add a unit test `serializeCompilationUnit_enumConstantsWithClassBodies_keepMembersOutsideConstantBody` to `SpoonCustomSrcPrinterTest` that verifies members outside enum constant class bodies are preserved and that the serialized source still parses.
- Add new e2e regression test resources under `test-cases/core/e2e/regression/04-enum-anonymous-argument-body-boundary` including `input` and `expected` sample files demonstrating the enum-constant anonymous-class boundary.

### Testing
- Ran the updated unit test `SpoonCustomSrcPrinterTest`, including the new enum constant test, and it passed.
- Executed the added e2e regression case for `04-enum-anonymous-argument-body-boundary` and it passed with the produced output matching the expected sample.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca79a84cf083258d795a4ddfa438b6)