### PR TITLE
Add ProcessingStatisticsPrintService and use it to render aggregated processing stats

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
@@ -13,6 +13,7 @@ import io.github.lemon_ant.jharmonizer.core.flow.RestructureFlow;
 import io.github.lemon_ant.jharmonizer.core.flow.SafeFlow;
 import io.github.lemon_ant.jharmonizer.core.formatter.Formatter;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.PathDisplayFormatUtil;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.ProcessingStatisticsPrintService;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats;
 import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
 import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
@@ -103,7 +104,7 @@ public final class SrcProcessor {
                         flowProcessingResult.getFlowProcessingStatus().name())))
                 .collect(SrcProcessingStats.statsCollector());
 
-        log.info(aggregatedProcessingStatistic.toString());
+        log.info(ProcessingStatisticsPrintService.render(aggregatedProcessingStatistic));
         return aggregatedProcessingStatistic;
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
@@ -1,0 +1,91 @@
+package io.github.lemon_ant.jharmonizer.core.processing_stat;
+
+import static io.github.lemon_ant.jharmonizer.core.processing_stat.HumanReadableFormatsUtils.formatBytes;
+import static io.github.lemon_ant.jharmonizer.core.processing_stat.HumanReadableFormatsUtils.formatHmsMillisFromNanos;
+import static io.github.lemon_ant.jharmonizer.core.processing_stat.HumanReadableFormatsUtils.formatSecondsMicrosecondsFromNanos;
+import static io.github.lemon_ant.jharmonizer.core.processing_stat.PathDisplayFormatUtil.abbreviatePathForDisplay;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Renders processing statistics into a structured log-friendly report.
+ */
+@UtilityClass
+public class ProcessingStatisticsPrintService {
+
+    private static final int METRIC_WIDTH = 32;
+    private static final int VALUE_WIDTH = 49;
+    private static final String HEADER = "JHarmonizer harmonization summary";
+
+    /**
+     * Builds a pseudo-table report with a dedicated section for unexpected internal errors.
+     *
+     * @param stats aggregated statistics to print
+     * @return formatted multiline report suitable for logs
+     */
+    @NonNull
+    public String render(@NonNull AggregatedProcessingStatistic stats) {
+        List<Path> sortedUnexpectedErrors = stats.getFilesWithUnexpectedErrors().stream()
+                .sorted(Comparator.comparing(Path::toString))
+                .toList();
+        List<String> reportLines = new ArrayList<>();
+
+        reportLines.add("");
+        reportLines.add(renderSeparator('='));
+        reportLines.add(" " + HEADER);
+        reportLines.add(renderSeparator('='));
+        reportLines.add(renderRow("Files processed", String.format("%,d", stats.getFileCount())));
+        reportLines.add(renderRow("Total size", formatBytes(stats.getTotalSize())));
+        reportLines.add(renderRow("Average size", formatBytes(stats.calculateAverageSize())));
+        reportLines.add(renderRow("Min size", formatSizeWithPath(stats.getSmallestFile())));
+        reportLines.add(renderRow("Max size", formatSizeWithPath(stats.getLargestFile())));
+        reportLines.add(
+                renderRow("Total processing time", formatHmsMillisFromNanos(stats.getTotalProcessingTimeNanos())));
+        reportLines.add(renderRow(
+                "Average processing time",
+                formatSecondsMicrosecondsFromNanos(stats.calculateAverageProcessingTime()) + " s/file"));
+        reportLines.add(
+                renderRow("Files with unexpected internal errors", String.valueOf(sortedUnexpectedErrors.size())));
+        reportLines.add(renderSeparator('-'));
+        reportLines.add("Unexpected internal error files:");
+
+        if (sortedUnexpectedErrors.isEmpty()) {
+            reportLines.add("  - none");
+        } else {
+            for (Path path : sortedUnexpectedErrors) {
+                reportLines.add("  - " + abbreviatePathForDisplay(path, AggregatedProcessingStatistic.MAX_PATH_LENGTH));
+            }
+        }
+
+        reportLines.add(renderSeparator('='));
+        return String.join(System.lineSeparator(), reportLines);
+    }
+
+    @NonNull
+    private String formatSizeWithPath(@Nullable FileProcessingStatistic fileProcessingStatistic) {
+        if (fileProcessingStatistic == null) {
+            return formatBytes(0L);
+        }
+        return formatBytes(fileProcessingStatistic.getSize()) + " ("
+                + abbreviatePathForDisplay(
+                        fileProcessingStatistic.getPath(), AggregatedProcessingStatistic.MAX_PATH_LENGTH)
+                + ")";
+    }
+
+    @NonNull
+    private String renderRow(@NonNull String metric, @NonNull String value) {
+        return String.format("| %-" + METRIC_WIDTH + "s | %-" + VALUE_WIDTH + "s |", metric, value);
+    }
+
+    @NonNull
+    private String renderSeparator(char separatorChar) {
+        return String.valueOf(separatorChar).repeat(METRIC_WIDTH + VALUE_WIDTH + 7);
+    }
+}

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
@@ -20,7 +20,7 @@ import lombok.experimental.UtilityClass;
 @UtilityClass
 public class ProcessingStatisticsPrintService {
 
-    private static final int METRIC_WIDTH = 32;
+    private static final int METRIC_WIDTH = 40;
     private static final int VALUE_WIDTH = 49;
     private static final String HEADER = "JHarmonizer harmonization summary";
 
@@ -31,7 +31,7 @@ public class ProcessingStatisticsPrintService {
      * @return formatted multiline report suitable for logs
      */
     @NonNull
-    public String render(@NonNull AggregatedProcessingStatistic stats) {
+    public static String render(@NonNull AggregatedProcessingStatistic stats) {
         List<Path> sortedUnexpectedErrors = stats.getFilesWithUnexpectedErrors().stream()
                 .sorted(Comparator.comparing(Path::toString))
                 .toList();
@@ -69,7 +69,7 @@ public class ProcessingStatisticsPrintService {
     }
 
     @NonNull
-    private String formatSizeWithPath(@Nullable FileProcessingStatistic fileProcessingStatistic) {
+    private static String formatSizeWithPath(@Nullable FileProcessingStatistic fileProcessingStatistic) {
         if (fileProcessingStatistic == null) {
             return formatBytes(0L);
         }
@@ -80,12 +80,25 @@ public class ProcessingStatisticsPrintService {
     }
 
     @NonNull
-    private String renderRow(@NonNull String metric, @NonNull String value) {
-        return String.format("| %-" + METRIC_WIDTH + "s | %-" + VALUE_WIDTH + "s |", metric, value);
+    private static String renderRow(@NonNull String metric, @NonNull String value) {
+        String metricCell = fitCell(metric, METRIC_WIDTH);
+        String valueCell = fitCell(value, VALUE_WIDTH);
+        return String.format("| %-" + METRIC_WIDTH + "s | %-" + VALUE_WIDTH + "s |", metricCell, valueCell);
     }
 
     @NonNull
-    private String renderSeparator(char separatorChar) {
+    private static String renderSeparator(char separatorChar) {
         return String.valueOf(separatorChar).repeat(METRIC_WIDTH + VALUE_WIDTH + 7);
+    }
+
+    @NonNull
+    private static String fitCell(@NonNull String value, int maxWidth) {
+        if (value.length() <= maxWidth) {
+            return value;
+        }
+        if (maxWidth <= 3) {
+            return value.substring(0, maxWidth);
+        }
+        return value.substring(0, maxWidth - 3) + "...";
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
@@ -65,7 +65,7 @@ public class ProcessingStatisticsPrintService {
                 reportLines.add("- " + abbreviatePathForDisplay(path, DETAIL_PATH_MAX_LENGTH));
             }
         }
-        return String.join(System.lineSeparator(), reportLines);
+        return String.join(System.lineSeparator(), reportLines) + System.lineSeparator();
     }
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
@@ -21,7 +21,8 @@ import lombok.experimental.UtilityClass;
 public class ProcessingStatisticsPrintService {
 
     private static final int METRIC_WIDTH = 40;
-    private static final int VALUE_WIDTH = 49;
+    private static final int VALUE_WIDTH = 24;
+    private static final int DETAIL_PATH_MAX_LENGTH = 120;
     private static final String HEADER = "JHarmonizer harmonization summary";
 
     /**
@@ -44,8 +45,8 @@ public class ProcessingStatisticsPrintService {
         reportLines.add(renderRow("Files processed", String.format("%,d", stats.getFileCount())));
         reportLines.add(renderRow("Total size", formatBytes(stats.getTotalSize())));
         reportLines.add(renderRow("Average size", formatBytes(stats.calculateAverageSize())));
-        reportLines.add(renderRow("Min size", formatSizeWithPath(stats.getSmallestFile())));
-        reportLines.add(renderRow("Max size", formatSizeWithPath(stats.getLargestFile())));
+        reportLines.add(renderRow("Min size", formatSize(stats.getSmallestFile())));
+        reportLines.add(renderRow("Max size", formatSize(stats.getLargestFile())));
         reportLines.add(
                 renderRow("Total processing time", formatHmsMillisFromNanos(stats.getTotalProcessingTimeNanos())));
         reportLines.add(renderRow(
@@ -54,29 +55,41 @@ public class ProcessingStatisticsPrintService {
         reportLines.add(
                 renderRow("Files with unexpected internal errors", String.valueOf(sortedUnexpectedErrors.size())));
         reportLines.add(renderSeparator('-'));
-        reportLines.add("Unexpected internal error files:");
+        addSizeBoundaryPaths(reportLines, stats);
 
         if (sortedUnexpectedErrors.isEmpty()) {
-            reportLines.add("  - none");
+            reportLines.add("Unexpected internal error files: none");
         } else {
+            reportLines.add("Unexpected internal error files:");
             for (Path path : sortedUnexpectedErrors) {
-                reportLines.add("  - " + abbreviatePathForDisplay(path, AggregatedProcessingStatistic.MAX_PATH_LENGTH));
+                reportLines.add("- " + abbreviatePathForDisplay(path, DETAIL_PATH_MAX_LENGTH));
             }
         }
-
-        reportLines.add(renderSeparator('='));
         return String.join(System.lineSeparator(), reportLines);
     }
 
     @NonNull
-    private static String formatSizeWithPath(@Nullable FileProcessingStatistic fileProcessingStatistic) {
+    private static String formatSize(@Nullable FileProcessingStatistic fileProcessingStatistic) {
         if (fileProcessingStatistic == null) {
             return formatBytes(0L);
         }
-        return formatBytes(fileProcessingStatistic.getSize()) + " ("
-                + abbreviatePathForDisplay(
-                        fileProcessingStatistic.getPath(), AggregatedProcessingStatistic.MAX_PATH_LENGTH)
-                + ")";
+        return formatBytes(fileProcessingStatistic.getSize());
+    }
+
+    private static void addSizeBoundaryPaths(
+            @NonNull List<String> reportLines, @NonNull AggregatedProcessingStatistic stats) {
+        if (stats.getSmallestFile() == null && stats.getLargestFile() == null) {
+            return;
+        }
+        reportLines.add("Size boundary files:");
+        if (stats.getSmallestFile() != null) {
+            reportLines.add("- Min size file: "
+                    + abbreviatePathForDisplay(stats.getSmallestFile().getPath(), DETAIL_PATH_MAX_LENGTH));
+        }
+        if (stats.getLargestFile() != null) {
+            reportLines.add("- Max size file: "
+                    + abbreviatePathForDisplay(stats.getLargestFile().getPath(), DETAIL_PATH_MAX_LENGTH));
+        }
     }
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/SrcProcessingStats.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/SrcProcessingStats.java
@@ -1,10 +1,5 @@
 package io.github.lemon_ant.jharmonizer.core.processing_stat;
 
-import static io.github.lemon_ant.jharmonizer.core.processing_stat.HumanReadableFormatsUtils.formatBytes;
-import static io.github.lemon_ant.jharmonizer.core.processing_stat.HumanReadableFormatsUtils.formatHmsMillisFromNanos;
-import static io.github.lemon_ant.jharmonizer.core.processing_stat.HumanReadableFormatsUtils.formatSecondsMicrosecondsFromNanos;
-import static io.github.lemon_ant.jharmonizer.core.processing_stat.PathDisplayFormatUtil.abbreviatePathForDisplay;
-
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowProcessingResult;
 import io.github.lemon_ant.jharmonizer.core.flow.FlowProcessingStatus;
@@ -12,11 +7,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Value;
@@ -78,37 +71,6 @@ public class SrcProcessingStats {
             this.filesWithUnexpectedErrors = Collections.unmodifiableList(filesWithUnexpectedErrors);
         }
 
-        @Override
-        public String toString() {
-            return String.format(
-                    "Harmonization result:%nFiles processed: %,d%n" + "Total size: %s%n" + "Average size: %s%n"
-                            + "Min size: %s %s%n"
-                            + "Max size: %s %s%n"
-                            + "Total processing time: %s%n"
-                            + "Average processing time: %s s/file%n"
-                            + "Files with unexpected internal errors: %s",
-                    fileCount,
-                    formatBytes(totalSize),
-                    formatBytes(calculateAverageSize()),
-                    formatBytes(Optional.ofNullable(smallestFile)
-                            .map(FileProcessingStatistic::getSize)
-                            .orElse(0L)),
-                    Optional.ofNullable(smallestFile)
-                            .map(FileProcessingStatistic::getPath)
-                            .map(path -> " (" + abbreviatePathForDisplay(path, MAX_PATH_LENGTH) + ")")
-                            .orElse(""),
-                    formatBytes(Optional.ofNullable(largestFile)
-                            .map(FileProcessingStatistic::getSize)
-                            .orElse(0L)),
-                    Optional.ofNullable(largestFile)
-                            .map(FileProcessingStatistic::getPath)
-                            .map(path -> " (" + abbreviatePathForDisplay(path, MAX_PATH_LENGTH) + ")")
-                            .orElse(""),
-                    formatHmsMillisFromNanos(totalProcessingTimeNanos),
-                    formatSecondsMicrosecondsFromNanos(calculateAverageProcessingTime()),
-                    formatUnexpectedErrorFilesForDisplay());
-        }
-
         // Average time spent on processing a file
         /**
          * Performs the calculate average processing time.
@@ -125,17 +87,6 @@ public class SrcProcessingStats {
          */
         long calculateAverageSize() {
             return fileCount > 0 ? totalSize / fileCount : 0;
-        }
-
-        @NonNull
-        private String formatUnexpectedErrorFilesForDisplay() {
-            if (filesWithUnexpectedErrors.isEmpty()) {
-                return "none";
-            }
-            return filesWithUnexpectedErrors.stream()
-                    .map(path -> abbreviatePathForDisplay(path, MAX_PATH_LENGTH))
-                    .sorted()
-                    .collect(Collectors.joining(", ", "[", "]"));
         }
     }
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
@@ -1,0 +1,48 @@
+package io.github.lemon_ant.jharmonizer.core.processing_stat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.AggregatedProcessingStatistic;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProcessingStatisticsPrintServiceTest {
+
+    @Test
+    void render_containsPseudoTableAndMultilineUnexpectedErrorList() {
+        // Given
+        AggregatedProcessingStatistic stats = new AggregatedProcessingStatistic(
+                2,
+                6_500,
+                2_300_000_000L,
+                null,
+                null,
+                List.of(Path.of("zeta/Broken.java"), Path.of("alpha/Failure.java")));
+
+        // When
+        String report = ProcessingStatisticsPrintService.render(stats);
+
+        // Then
+        assertThat(report)
+                .startsWith(System.lineSeparator())
+                .contains("JHarmonizer harmonization summary")
+                .contains("| Files processed")
+                .contains("| Files with unexpected internal errors")
+                .contains("Unexpected internal error files:")
+                .contains("  - alpha/Failure.java")
+                .contains("  - zeta/Broken.java");
+    }
+
+    @Test
+    void render_withoutUnexpectedErrors_printsNoneBullet() {
+        // Given
+        AggregatedProcessingStatistic stats = new AggregatedProcessingStatistic(0, 0, 0, null, null, List.of());
+
+        // When
+        String report = ProcessingStatisticsPrintService.render(stats);
+
+        // Then
+        assertThat(report).contains("Unexpected internal error files:").contains("  - none");
+    }
+}

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
@@ -12,13 +12,10 @@ class ProcessingStatisticsPrintServiceTest {
     @Test
     void render_containsPseudoTableAndMultilineUnexpectedErrorList() {
         // Given
+        Path brokenPath = Path.of("zeta", "Broken.java");
+        Path failurePath = Path.of("alpha", "Failure.java");
         AggregatedProcessingStatistic stats = new AggregatedProcessingStatistic(
-                2,
-                6_500,
-                2_300_000_000L,
-                null,
-                null,
-                List.of(Path.of("zeta/Broken.java"), Path.of("alpha/Failure.java")));
+                2, 6_500, 2_300_000_000L, null, null, List.of(brokenPath, failurePath));
 
         // When
         String report = ProcessingStatisticsPrintService.render(stats);
@@ -30,8 +27,12 @@ class ProcessingStatisticsPrintServiceTest {
                 .contains("| Files processed")
                 .contains("| Files with unexpected internal errors")
                 .contains("Unexpected internal error files:")
-                .contains("  - alpha/Failure.java")
-                .contains("  - zeta/Broken.java");
+                .contains("  - "
+                        + PathDisplayFormatUtil.abbreviatePathForDisplay(
+                                failurePath, AggregatedProcessingStatistic.MAX_PATH_LENGTH))
+                .contains("  - "
+                        + PathDisplayFormatUtil.abbreviatePathForDisplay(
+                                brokenPath, AggregatedProcessingStatistic.MAX_PATH_LENGTH));
     }
 
     @Test
@@ -44,5 +45,24 @@ class ProcessingStatisticsPrintServiceTest {
 
         // Then
         assertThat(report).contains("Unexpected internal error files:").contains("  - none");
+    }
+
+    @Test
+    void render_longValues_keepsPseudoTableHeaderAligned() {
+        // Given
+        Path longPath = Path.of(
+                "very-long-module-name",
+                "deeply",
+                "nested",
+                "feature",
+                "InternalToolForVeryLongStatisticsOutputVerification.java");
+        AggregatedProcessingStatistic stats =
+                new AggregatedProcessingStatistic(1, 123_456, 1_234_567_890L, null, null, List.of(longPath));
+
+        // When
+        String report = ProcessingStatisticsPrintService.render(stats);
+
+        // Then
+        assertThat(report).contains("| Files with unexpected internal errors");
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
@@ -27,12 +27,8 @@ class ProcessingStatisticsPrintServiceTest {
                 .contains("| Files processed")
                 .contains("| Files with unexpected internal errors")
                 .contains("Unexpected internal error files:")
-                .contains("  - "
-                        + PathDisplayFormatUtil.abbreviatePathForDisplay(
-                                failurePath, AggregatedProcessingStatistic.MAX_PATH_LENGTH))
-                .contains("  - "
-                        + PathDisplayFormatUtil.abbreviatePathForDisplay(
-                                brokenPath, AggregatedProcessingStatistic.MAX_PATH_LENGTH));
+                .contains("- " + PathDisplayFormatUtil.abbreviatePathForDisplay(failurePath, 120))
+                .contains("- " + PathDisplayFormatUtil.abbreviatePathForDisplay(brokenPath, 120));
     }
 
     @Test
@@ -44,7 +40,8 @@ class ProcessingStatisticsPrintServiceTest {
         String report = ProcessingStatisticsPrintService.render(stats);
 
         // Then
-        assertThat(report).contains("Unexpected internal error files:").contains("  - none");
+        assertThat(report).contains("Unexpected internal error files: none");
+        assertThat(report).doesNotContain("Unexpected internal error files:\n");
     }
 
     @Test
@@ -63,6 +60,9 @@ class ProcessingStatisticsPrintServiceTest {
         String report = ProcessingStatisticsPrintService.render(stats);
 
         // Then
-        assertThat(report).contains("| Files with unexpected internal errors");
+        assertThat(report)
+                .contains("| Files with unexpected internal errors")
+                .contains("| Min size")
+                .doesNotEndWith("=");
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc `toString()` summary with a dedicated renderer to produce a structured, log-friendly harmonization summary. 
- Centralize formatting logic for processing statistics for easier maintenance and improved readability in logs. 

### Description
- Added `ProcessingStatisticsPrintService` which renders `AggregatedProcessingStatistic` into a pseudo-table report and a multiline list of unexpected error files. 
- Replaced the previous `toString()` usage in `SrcProcessor.processSources` with `ProcessingStatisticsPrintService.render(...)`. 
- Removed the old `toString()`-based rendering and related formatting helpers from `SrcProcessingStats.AggregatedProcessingStatistic`, keeping it focused on raw metrics. 
- Added unit tests `ProcessingStatisticsPrintServiceTest` that assert the report contains the pseudo-table, metrics, and proper handling of unexpected error lists. 

### Testing
- Ran the unit test suite with `mvn test` and the new tests in `ProcessingStatisticsPrintServiceTest` executed. 
- All tests, including the new rendering assertions, passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cba760ea348325be9ac864684ecf55)