### PR TITLE
Add CLI option to disable statistics and thread printProcessingStatistics through config

### DIFF
--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -169,8 +169,15 @@ abstract class BaseCommand implements Callable<Integer> {
         FlexibleUnifiedConfig externalConfig = configFilePath != null
                 ? JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(configFilePath)
                 : null;
-        FlexibleUnifiedConfig cliOverrideConfig = new FlexibleUnifiedConfig(
-                null, null, disableBackups ? false : null, disableStatisticsOutput ? false : null, null, null);
+        FlexibleUnifiedConfig cliOverrideConfig = (disableBackups || disableStatisticsOutput)
+                ? new FlexibleUnifiedConfig(
+                        null,
+                        null,
+                        disableBackups ? false : null,
+                        disableStatisticsOutput ? false : null,
+                        null,
+                        null)
+                : null;
         FlexibleUnifiedConfig effectiveConfig = mergeFlexibleConfigs(externalConfig, cliOverrideConfig);
         return new SrcProcessor(effectiveConfig);
     }

--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -77,6 +77,11 @@ abstract class BaseCommand implements Callable<Integer> {
             description = "Disable backup (.bak) file creation even when config enables backups.")
     private boolean noBackup;
 
+    @Option(
+            names = {"-S", "--no-statistics"},
+            description = "Disable final processing statistics report output.")
+    private boolean noStatistics;
+
     /**
      * Returns the processing flow implemented by the command.
      *
@@ -120,7 +125,8 @@ abstract class BaseCommand implements Callable<Integer> {
                 Set.copyOf(excludeGlobs),
                 verbose,
                 effectiveConfigFilePath,
-                noBackup);
+                noBackup,
+                noStatistics);
         if (commandOptions.isVerbose()) {
             ((Logger) LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME)).setLevel(Level.DEBUG);
         }
@@ -141,7 +147,10 @@ abstract class BaseCommand implements Callable<Integer> {
                 commandOptions.getBaseDir(),
                 describeConfigSrc(commandOptions.getConfigFilePath()));
         try {
-            createSrcProcessor(commandOptions.getConfigFilePath(), commandOptions.isNoBackup())
+            createSrcProcessor(
+                            commandOptions.getConfigFilePath(),
+                            commandOptions.isNoBackup(),
+                            commandOptions.isNoStatistics())
                     .processSources(
                             commandOptions.getBaseDir(),
                             commandOptions.getIncludeGlobs(),
@@ -155,13 +164,14 @@ abstract class BaseCommand implements Callable<Integer> {
     }
 
     @NonNull
-    private static SrcProcessor createSrcProcessor(@Nullable Path configFilePath, boolean disableBackups) {
+    private static SrcProcessor createSrcProcessor(
+            @Nullable Path configFilePath, boolean disableBackups, boolean disableStatisticsOutput) {
         FlexibleUnifiedConfig externalConfig = configFilePath != null
                 ? JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(configFilePath)
                 : null;
-        FlexibleUnifiedConfig backupsOverrideConfig =
-                disableBackups ? new FlexibleUnifiedConfig(null, null, false, null, null) : null;
-        FlexibleUnifiedConfig effectiveConfig = mergeFlexibleConfigs(externalConfig, backupsOverrideConfig);
+        FlexibleUnifiedConfig cliOverrideConfig = new FlexibleUnifiedConfig(
+                null, null, disableBackups ? false : null, disableStatisticsOutput ? false : null, null, null);
+        FlexibleUnifiedConfig effectiveConfig = mergeFlexibleConfigs(externalConfig, cliOverrideConfig);
         return new SrcProcessor(effectiveConfig);
     }
 
@@ -225,5 +235,7 @@ abstract class BaseCommand implements Callable<Integer> {
         Path configFilePath;
 
         boolean noBackup;
+
+        boolean noStatistics;
     }
 }

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommandTest.java
@@ -139,6 +139,32 @@ class BaseCommandTest {
     }
 
     @Test
+    void call_noStatisticsOptionInvoked_disablesStatisticsReportInSrcProcessor() {
+        // Given
+        CommandLine cmd = new CommandLine(new TestCommand());
+        AtomicReference<List<?>> constructorArguments = new AtomicReference<>();
+
+        // When
+        int exitCode;
+        try (MockedConstruction<SrcProcessor> srcProcessorMocks =
+                mockConstruction(SrcProcessor.class, (mock, context) -> {
+                    constructorArguments.set(context.arguments());
+                    when(mock.processSources(any(Path.class), any(), any(), any()))
+                            .thenReturn(mock(AggregatedProcessingStatistic.class));
+                })) {
+            exitCode = cmd.execute("--base-dir", "src", "--no-statistics");
+        }
+
+        // Then
+        assertThat(exitCode).isZero();
+        assertThat(constructorArguments.get()).hasSize(1);
+        Object constructorConfig = constructorArguments.get().getFirst();
+        assertThat(constructorConfig).isInstanceOf(FlexibleUnifiedConfig.class);
+        FlexibleUnifiedConfig flexibleConfig = (FlexibleUnifiedConfig) constructorConfig;
+        assertThat(flexibleConfig.getPrintProcessingStatistics()).contains(false);
+    }
+
+    @Test
     void call_processorThrowsRuntimeException_returnsExitCode1() {
         // When
         int exitCode;

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/command/RestructureCommandTest.java
@@ -81,6 +81,7 @@ class RestructureCommandTest {
                 .contains("-b, --base-dir")
                 .contains("-c, --config")
                 .contains("-B, --no-backup")
+                .contains("-S, --no-statistics")
                 .contains("-i, --include")
                 .contains("-e, --exclude")
                 .contains("Repeat this option or pass multiple patterns as a")

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -98,6 +98,7 @@ class JHarmonizerCliPackagedJarIT {
                 .contains("Usage: jharmonizer " + command)
                 .contains("-b, --base-dir")
                 .contains("-B, --no-backup")
+                .contains("-S, --no-statistics")
                 .contains("-i, --include")
                 .contains("-e, --exclude")
                 .contains("Repeat this option or pass multiple patterns as a")

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
@@ -19,6 +19,8 @@ import io.github.lemon_ant.jharmonizer.core.processing_stat.SrcProcessingStats.A
 import io.github.lemon_ant.jharmonizer.core.sorter.Sorter;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -104,8 +106,23 @@ public final class SrcProcessor {
                         flowProcessingResult.getFlowProcessingStatus().name())))
                 .collect(SrcProcessingStats.statsCollector());
 
-        log.info(ProcessingStatisticsPrintService.render(aggregatedProcessingStatistic));
+        if (config.isPrintProcessingStatistics()) {
+            log.info(ProcessingStatisticsPrintService.render(aggregatedProcessingStatistic));
+        } else {
+            logFilesWithUnexpectedErrors(aggregatedProcessingStatistic);
+        }
         return aggregatedProcessingStatistic;
+    }
+
+    private static void logFilesWithUnexpectedErrors(@NonNull AggregatedProcessingStatistic aggregatedStatistic) {
+        if (aggregatedStatistic.getFilesWithUnexpectedErrors().isEmpty()) {
+            return;
+        }
+        String failedFilesLog = aggregatedStatistic.getFilesWithUnexpectedErrors().stream()
+                .sorted(Comparator.comparing(Path::toString))
+                .map(path -> PathDisplayFormatUtil.abbreviatePathForDisplay(path, MAX_TOTAL_PATH_LENGTH))
+                .collect(Collectors.joining(", "));
+        log.warn("Files were not processed correctly: {}", failedFilesLog);
     }
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
@@ -122,7 +122,7 @@ public final class SrcProcessor {
                 .sorted(Comparator.comparing(Path::toString))
                 .map(path -> PathDisplayFormatUtil.abbreviatePathForDisplay(path, MAX_TOTAL_PATH_LENGTH))
                 .collect(Collectors.joining(", "));
-        log.warn("Files were not processed correctly: {}", failedFilesLog);
+        log.warn("Files encountered unexpected errors and were not processed correctly: {}", failedFilesLog);
     }
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/CompiledConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/CompiledConfig.java
@@ -24,6 +24,8 @@ public class CompiledConfig {
 
     boolean backupsEnabled;
 
+    boolean printProcessingStatistics;
+
     /**
      * Header line descriptor (character + leftPadding).
      */
@@ -45,6 +47,7 @@ public class CompiledConfig {
      * @param topLevelTypesOrdering the top level types ordering
      * @param formatting the formatting
      * @param backupsEnabled the backups enabled
+     * @param printProcessingStatistics the print processing statistics flag
      * @param headerLine the header line
      */
     CompiledConfig(
@@ -52,11 +55,13 @@ public class CompiledConfig {
             @NonNull CompiledTopLevelTypesOrdering topLevelTypesOrdering,
             @NonNull UnifiedFormatting formatting,
             boolean backupsEnabled,
+            boolean printProcessingStatistics,
             @NonNull UnifiedHeaderLine headerLine) {
         this.rootMemberGroups = unmodifiableList(rootMemberGroups);
         this.topLevelTypesOrdering = topLevelTypesOrdering;
         this.formatting = formatting;
         this.backupsEnabled = backupsEnabled;
+        this.printProcessingStatistics = printProcessingStatistics;
         this.headerLine = headerLine;
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/Unified2CompiledModelCompiler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/Unified2CompiledModelCompiler.java
@@ -33,6 +33,7 @@ public class Unified2CompiledModelCompiler {
                 topLevelTypesOrdering,
                 unifiedConfig.getFormatting(),
                 unifiedConfig.isBackupsEnabled(),
+                unifiedConfig.isPrintProcessingStatistics(),
                 unifiedConfig.getHeaderLine());
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizer2UnifiedConverter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizer2UnifiedConverter.java
@@ -37,6 +37,7 @@ public final class JHarmonizer2UnifiedConverter {
         UnifiedFormatterStyle style = vendor.getFormatting().getFormatterStyle().getUnifiedFormatterStyle();
 
         boolean backupsEnabled = vendor.isBackupsEnabled();
+        boolean printProcessingStatistics = vendor.isPrintProcessingStatistics();
 
         // 4) headerLine
         UnifiedHeaderLine header = new UnifiedHeaderLine(
@@ -50,6 +51,7 @@ public final class JHarmonizer2UnifiedConverter {
                 .topLevelTypesOrdering(top)
                 .formatting(new UnifiedFormatting(fixImports, style))
                 .backupsEnabled(backupsEnabled)
+                .printProcessingStatistics(printProcessingStatistics)
                 .headerLine(header)
                 .rootMemberGroups(root)
                 .build();

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizerFlexible2FlexibleUnifiedConverter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizerFlexible2FlexibleUnifiedConverter.java
@@ -25,17 +25,24 @@ public class JHarmonizerFlexible2FlexibleUnifiedConverter {
     public static FlexibleUnifiedConfig convert2FlexibleUnified(@NonNull JHarmonizerFlexibleConfig vendorConfig) {
         UnifiedTopLevelTypesOrdering topLevelTypesOrdering = readTopLevelTypesOrdering(vendorConfig);
         UnifiedFormatting formatting = readFormatting(vendorConfig);
-        Boolean backupsEnabled = vendorConfig.getOptionalBackupsEnabled().orElse(null);
+        Boolean backupsEnabled = vendorConfig.getBackupsEnabled().orElse(null);
+        Boolean printProcessingStatistics =
+                vendorConfig.getPrintProcessingStatistics().orElse(null);
         UnifiedHeaderLine headerLine = readHeaderLine(vendorConfig);
         List<UnifiedMemberGroup> rootMemberGroups = readRootMemberGroups(vendorConfig);
         return new FlexibleUnifiedConfig(
-                topLevelTypesOrdering, formatting, backupsEnabled, headerLine, rootMemberGroups);
+                topLevelTypesOrdering,
+                formatting,
+                backupsEnabled,
+                printProcessingStatistics,
+                headerLine,
+                rootMemberGroups);
     }
 
     @Nullable
     private static UnifiedTopLevelTypesOrdering readTopLevelTypesOrdering(JHarmonizerFlexibleConfig vendorConfig) {
         return vendorConfig
-                .getOptionalTopLevelTypesOrdering()
+                .getTopLevelTypesOrdering()
                 .map(TopLevelTypesOrderingMapper::map)
                 .orElse(null);
     }
@@ -43,7 +50,7 @@ public class JHarmonizerFlexible2FlexibleUnifiedConverter {
     @Nullable
     private static UnifiedFormatting readFormatting(JHarmonizerFlexibleConfig vendorConfig) {
         return vendorConfig
-                .getOptionalFormatting()
+                .getFormatting()
                 .map(JHarmonizerFlexible2FlexibleUnifiedConverter::mapFormatting)
                 .orElse(null);
     }
@@ -51,7 +58,7 @@ public class JHarmonizerFlexible2FlexibleUnifiedConverter {
     @Nullable
     private static UnifiedHeaderLine readHeaderLine(JHarmonizerFlexibleConfig vendorConfig) {
         return vendorConfig
-                .getOptionalHeaderLine()
+                .getHeaderLine()
                 .map(headerLine -> new UnifiedHeaderLine(headerLine.getCharacter(), headerLine.getLeftPadding()))
                 .orElse(null);
     }
@@ -59,7 +66,7 @@ public class JHarmonizerFlexible2FlexibleUnifiedConverter {
     @Nullable
     private static List<UnifiedMemberGroup> readRootMemberGroups(JHarmonizerFlexibleConfig vendorConfig) {
         return vendorConfig
-                .getOptionalMemberGroups()
+                .getMemberGroups()
                 .map(memberGroups ->
                         memberGroups.stream().map(MemberGroupMapper::map).toList())
                 .orElse(null);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerConfig.java
@@ -20,6 +20,8 @@ public class JHarmonizerConfig {
 
     boolean backupsEnabled;
 
+    boolean printProcessingStatistics;
+
     @NonNull
     JHarmonizerHeaderLine headerLine;
 
@@ -35,6 +37,7 @@ public class JHarmonizerConfig {
      * @param topLevelTypesOrdering the top level types ordering
      * @param formatting the formatting
      * @param backupsEnabled the backups enabled
+     * @param printProcessingStatistics the print processing statistics flag
      * @param headerLine the header line
      * @param memberGroups the member groups
      */
@@ -43,12 +46,14 @@ public class JHarmonizerConfig {
                     JHarmonizerTopLevelTypesOrdering topLevelTypesOrdering,
             @NonNull @JsonProperty(value = "formatting", required = true) JHarmonizerFormatting formatting,
             @JsonProperty(value = "backups-enabled", required = true) boolean backupsEnabled,
+            @JsonProperty(value = "print-processing-statistics", required = true) boolean printProcessingStatistics,
             @NonNull @JsonProperty(value = "header-line", required = true) JHarmonizerHeaderLine headerLine,
             @NonNull @JsonProperty(value = "type-members-ordering", required = true)
                     List<@NonNull JHarmonizerMemberGroup> memberGroups) {
         this.topLevelTypesOrdering = topLevelTypesOrdering;
         this.formatting = formatting;
         this.backupsEnabled = backupsEnabled;
+        this.printProcessingStatistics = printProcessingStatistics;
         this.headerLine = headerLine;
         Validate.notEmpty(memberGroups, "type-members-ordering cannot be empty");
         this.memberGroups = Collections.unmodifiableList(memberGroups);
@@ -61,6 +66,7 @@ public class JHarmonizerConfig {
         }
 
         return backupsEnabled == that.backupsEnabled
+                && printProcessingStatistics == that.printProcessingStatistics
                 && formatting.equals(that.formatting)
                 && headerLine.equals(that.headerLine)
                 && memberGroups.equals(that.memberGroups)
@@ -71,6 +77,7 @@ public class JHarmonizerConfig {
     public int hashCode() {
         int result = formatting.hashCode();
         result = 31 * result + Boolean.hashCode(backupsEnabled);
+        result = 31 * result + Boolean.hashCode(printProcessingStatistics);
         result = 31 * result + headerLine.hashCode();
         result = 31 * result + memberGroups.hashCode();
         result = 31 * result + topLevelTypesOrdering.hashCode();

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerFlexibleConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerFlexibleConfig.java
@@ -7,6 +7,8 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -14,6 +16,7 @@ import lombok.Value;
  * Flexible overlay for JHarmonizerConfig. All fields are optional.
  */
 @Value
+@Getter(AccessLevel.NONE)
 public class JHarmonizerFlexibleConfig {
 
     @Nullable
@@ -21,6 +24,9 @@ public class JHarmonizerFlexibleConfig {
 
     @Nullable
     Boolean backupsEnabled;
+
+    @Nullable
+    Boolean printProcessingStatistics;
 
     @Nullable
     JHarmonizerHeaderLine headerLine;
@@ -37,6 +43,7 @@ public class JHarmonizerFlexibleConfig {
      * @param topLevelTypesOrdering the optional top-level types ordering override
      * @param formatting the optional formatting override
      * @param backupsEnabled the optional backups-enabled override
+     * @param printProcessingStatistics the optional print-processing-statistics override
      * @param headerLine the optional header-line override
      * @param memberGroups the optional member group overrides
      */
@@ -44,11 +51,13 @@ public class JHarmonizerFlexibleConfig {
             @Nullable @JsonProperty("top-level-types-ordering") JHarmonizerTopLevelTypesOrdering topLevelTypesOrdering,
             @Nullable @JsonProperty("formatting") JHarmonizerFormatting formatting,
             @Nullable @JsonProperty("backups-enabled") Boolean backupsEnabled,
+            @Nullable @JsonProperty("print-processing-statistics") Boolean printProcessingStatistics,
             @Nullable @JsonProperty("header-line") JHarmonizerHeaderLine headerLine,
             @Nullable @JsonProperty("type-members-ordering") List<@NonNull JHarmonizerMemberGroup> memberGroups) {
         this.topLevelTypesOrdering = topLevelTypesOrdering;
         this.formatting = formatting;
         this.backupsEnabled = backupsEnabled;
+        this.printProcessingStatistics = printProcessingStatistics;
         this.headerLine = headerLine;
         this.memberGroups =
                 ofNullable(memberGroups).map(Collections::unmodifiableList).orElse(null);
@@ -60,7 +69,7 @@ public class JHarmonizerFlexibleConfig {
      * @return the optional formatting override
      */
     @NonNull
-    public Optional<JHarmonizerFormatting> getOptionalFormatting() {
+    public Optional<JHarmonizerFormatting> getFormatting() {
         return ofNullable(formatting);
     }
 
@@ -70,8 +79,18 @@ public class JHarmonizerFlexibleConfig {
      * @return the optional backups-enabled override
      */
     @NonNull
-    public Optional<Boolean> getOptionalBackupsEnabled() {
+    public Optional<Boolean> getBackupsEnabled() {
         return ofNullable(backupsEnabled);
+    }
+
+    /**
+     * Returns the optional print-processing-statistics override.
+     *
+     * @return the optional print-processing-statistics override
+     */
+    @NonNull
+    public Optional<Boolean> getPrintProcessingStatistics() {
+        return ofNullable(printProcessingStatistics);
     }
 
     /**
@@ -80,7 +99,7 @@ public class JHarmonizerFlexibleConfig {
      * @return the optional header-line override
      */
     @NonNull
-    public Optional<JHarmonizerHeaderLine> getOptionalHeaderLine() {
+    public Optional<JHarmonizerHeaderLine> getHeaderLine() {
         return ofNullable(headerLine);
     }
 
@@ -90,7 +109,7 @@ public class JHarmonizerFlexibleConfig {
      * @return the optional member group overrides
      */
     @NonNull
-    public Optional<List<JHarmonizerMemberGroup>> getOptionalMemberGroups() {
+    public Optional<List<JHarmonizerMemberGroup>> getMemberGroups() {
         return ofNullable(memberGroups);
     }
 
@@ -100,7 +119,7 @@ public class JHarmonizerFlexibleConfig {
      * @return the optional top-level types ordering override
      */
     @NonNull
-    public Optional<JHarmonizerTopLevelTypesOrdering> getOptionalTopLevelTypesOrdering() {
+    public Optional<JHarmonizerTopLevelTypesOrdering> getTopLevelTypesOrdering() {
         return ofNullable(topLevelTypesOrdering);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/FlexibleUnifiedConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/FlexibleUnifiedConfig.java
@@ -32,6 +32,9 @@ public class FlexibleUnifiedConfig {
     @Nullable
     Boolean backupsEnabled;
 
+    @Nullable
+    Boolean printProcessingStatistics;
+
     /**
      * Optional override for header line.
      */
@@ -56,6 +59,7 @@ public class FlexibleUnifiedConfig {
      * @param topLevelTypesOrdering the top level types ordering
      * @param formatting the formatting
      * @param backupsEnabled the backups enabled
+     * @param printProcessingStatistics the print processing statistics flag
      * @param headerLine the header line
      * @param rootMemberGroups the root member groups
      */
@@ -63,11 +67,13 @@ public class FlexibleUnifiedConfig {
             @Nullable UnifiedTopLevelTypesOrdering topLevelTypesOrdering,
             @Nullable UnifiedFormatting formatting,
             @Nullable Boolean backupsEnabled,
+            @Nullable Boolean printProcessingStatistics,
             @Nullable UnifiedHeaderLine headerLine,
             @Nullable @Singular List<UnifiedMemberGroup> rootMemberGroups) {
         this.topLevelTypesOrdering = topLevelTypesOrdering;
         this.formatting = formatting;
         this.backupsEnabled = backupsEnabled;
+        this.printProcessingStatistics = printProcessingStatistics;
         this.headerLine = headerLine;
         this.rootMemberGroups =
                 ofNullable(rootMemberGroups).map(Collections::unmodifiableList).orElse(null);
@@ -89,6 +95,15 @@ public class FlexibleUnifiedConfig {
     @NonNull
     public Optional<Boolean> getBackupsEnabled() {
         return ofNullable(backupsEnabled);
+    }
+
+    /**
+     * Returns the print processing statistics flag.
+     * @return the print processing statistics flag
+     */
+    @NonNull
+    public Optional<Boolean> getPrintProcessingStatistics() {
+        return ofNullable(printProcessingStatistics);
     }
 
     /**

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfig.java
@@ -27,6 +27,8 @@ public class UnifiedConfig {
 
     boolean backupsEnabled;
 
+    boolean printProcessingStatistics;
+
     /**
      * Header line descriptor (character + leftPadding).
      */
@@ -51,6 +53,7 @@ public class UnifiedConfig {
      * @param topLevelTypesOrdering the top level types ordering
      * @param formatting the formatting
      * @param backupsEnabled the backups enabled
+     * @param printProcessingStatistics the print processing statistics flag
      * @param headerLine the header line
      * @param rootMemberGroups the root member groups
      */
@@ -59,11 +62,13 @@ public class UnifiedConfig {
             @NonNull UnifiedTopLevelTypesOrdering topLevelTypesOrdering,
             @NonNull UnifiedFormatting formatting,
             @NonNull Boolean backupsEnabled,
+            @NonNull Boolean printProcessingStatistics,
             @NonNull UnifiedHeaderLine headerLine,
             @NonNull @Singular List<UnifiedMemberGroup> rootMemberGroups) {
         this.topLevelTypesOrdering = topLevelTypesOrdering;
         this.formatting = formatting;
         this.backupsEnabled = backupsEnabled;
+        this.printProcessingStatistics = printProcessingStatistics;
         this.headerLine = headerLine;
         Validate.notEmpty(rootMemberGroups, "Root member groups cannot be empty");
         this.rootMemberGroups = Collections.unmodifiableList(rootMemberGroups);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
@@ -31,6 +31,8 @@ public class UnifiedConfigMerger {
         UnifiedFormatting formatting = overlay.getFormatting().orElse(baseline.getFormatting());
         UnifiedHeaderLine header = overlay.getHeaderLine().orElse(baseline.getHeaderLine());
         Boolean backupsEnabled = overlay.getBackupsEnabled().orElse(baseline.isBackupsEnabled());
+        Boolean printProcessingStatistics =
+                overlay.getPrintProcessingStatistics().orElse(baseline.isPrintProcessingStatistics());
         List<UnifiedMemberGroup> root = overlay.getRootMemberGroups()
                 .map(overlayRootGroups -> mergeRootMemberGroups(baseline.getRootMemberGroups(), overlayRootGroups))
                 .orElse(baseline.getRootMemberGroups());
@@ -40,6 +42,7 @@ public class UnifiedConfigMerger {
                 .formatting(formatting)
                 .headerLine(header)
                 .backupsEnabled(backupsEnabled)
+                .printProcessingStatistics(printProcessingStatistics)
                 .rootMemberGroups(root)
                 .build();
     }
@@ -62,13 +65,15 @@ public class UnifiedConfigMerger {
                 overlay.getHeaderLine().orElse(baseline.getHeaderLine().orElse(null));
         Boolean backupsEnabled =
                 overlay.getBackupsEnabled().orElse(baseline.getBackupsEnabled().orElse(null));
+        Boolean printProcessingStatistics = overlay.getPrintProcessingStatistics()
+                .orElse(baseline.getPrintProcessingStatistics().orElse(null));
         List<UnifiedMemberGroup> root = overlay.getRootMemberGroups()
                 .map(overlayRootGroups -> baseline.getRootMemberGroups()
                         .map(baselineRootGroups -> mergeRootMemberGroups(baselineRootGroups, overlayRootGroups))
                         .orElse(overlayRootGroups))
                 .orElse(baseline.getRootMemberGroups().orElse(null));
 
-        return new FlexibleUnifiedConfig(top, formatting, backupsEnabled, header, root);
+        return new FlexibleUnifiedConfig(top, formatting, backupsEnabled, printProcessingStatistics, header, root);
     }
 
     @NonNull

--- a/core/src/main/resources/default-config.yml
+++ b/core/src/main/resources/default-config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR # NONE, AOSP, GOOGLE, PALANTIR
 
 backups-enabled: true
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
@@ -347,6 +347,7 @@ class OptOutSrcProcessorIntegrationTest {
                 topLevelTypesOrdering,
                 new UnifiedFormatting(true, UnifiedFormatterStyle.PALANTIR),
                 false,
+                null,
                 new UnifiedHeaderLine('-', 0),
                 List.of(rootMemberGroup));
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
@@ -274,7 +274,7 @@ class SrcProcessorTest {
         String unformattedSrcCode = "package demo; public class BackupEnabled {private int x;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupEnabled.java", unformattedSrcCode);
         String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null));
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null, null));
 
         // When
         srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
@@ -293,7 +293,7 @@ class SrcProcessorTest {
         String firstSrcCode = "package demo; public class BackupTwice {private int x;}";
         String secondSrcCode = "package demo; public class BackupTwice {private int y;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupTwice.java", firstSrcCode);
-        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null));
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null, null));
 
         // When
         srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
@@ -313,7 +313,7 @@ class SrcProcessorTest {
         String unformattedSrcCode = "package demo; public class BackupDisabled {private int x;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSrcCode);
         String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, false, null, null));
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, false, null, null, null));
 
         // When
         srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
@@ -332,8 +332,8 @@ class SrcProcessorTest {
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupOverrideDisabled.java", unformattedSrcCode);
         String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
         FlexibleUnifiedConfig effectiveConfig = UnifiedConfigMerger.merge(
-                new FlexibleUnifiedConfig(null, null, true, null, null),
-                new FlexibleUnifiedConfig(null, null, false, null, null));
+                new FlexibleUnifiedConfig(null, null, true, null, null, null),
+                new FlexibleUnifiedConfig(null, null, false, null, null, null));
         SrcProcessor srcProcessor = new SrcProcessor(effectiveConfig);
 
         // When

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizer2UnifiedConverterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizer2UnifiedConverterTest.java
@@ -45,6 +45,7 @@ class JHarmonizer2UnifiedConverterTest {
                 topLevel,
                 createFormatting(true, FormatterStyle.PALANTIR),
                 true,
+                true,
                 createHeaderLine('-', 5),
                 List.of(root));
 

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/MemberGroupRuleLineTokenSemanticsTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/MemberGroupRuleLineTokenSemanticsTest.java
@@ -94,6 +94,7 @@ class MemberGroupRuleLineTokenSemanticsTest {
         UnifiedConfig unifiedConfig = UnifiedConfig.builder()
                 .formatting(new UnifiedFormatting(true, UnifiedFormatterStyle.PALANTIR))
                 .backupsEnabled(false)
+                .printProcessingStatistics(true)
                 .headerLine(new UnifiedHeaderLine('-', 0))
                 .topLevelTypesOrdering(createMinimalTopLevelTypesOrdering())
                 .rootMemberGroup(rootGroup)

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
@@ -26,7 +26,7 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineFirstGroup = createGroup("Default Rule");
         UnifiedMemberGroup baselineSecondGroup = createGroup("Units");
         UnifiedConfig baselineConfig = createConfig(List.of(baselineFirstGroup, baselineSecondGroup));
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, null, null, null);
+        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, null, null, null, null);
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -48,6 +48,7 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup replacementDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup newAuditGroup = createGroup("Audit");
         FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
+                null,
                 null,
                 null,
                 null,
@@ -76,7 +77,7 @@ class UnifiedConfigMergerTest {
         UnifiedConfig baselineConfig = createConfig(List.of(baselineNestedGroup, baselineFallbackGroup));
         UnifiedMemberGroup overlayNestedGroup = createGroup("Default Rule", List.of(createGroup("Overlay Methods")));
         FlexibleUnifiedConfig overlayConfig =
-                new FlexibleUnifiedConfig(null, null, null, null, List.of(overlayNestedGroup));
+                new FlexibleUnifiedConfig(null, null, null, null, null, List.of(overlayNestedGroup));
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -94,7 +95,7 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup unnamedOverlayGroup = createGroup(null);
         FlexibleUnifiedConfig overlayConfig =
-                new FlexibleUnifiedConfig(null, null, null, null, List.of(unnamedOverlayGroup));
+                new FlexibleUnifiedConfig(null, null, null, null, null, List.of(unnamedOverlayGroup));
 
         // When
         UnifiedConfig mergedConfig =
@@ -113,7 +114,7 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup overlayReplacementNamedGroup = createGroup("Default Rule");
         UnifiedMemberGroup overlayNewUnnamedGroup = createGroup(null);
         FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, List.of(overlayReplacementNamedGroup, overlayNewUnnamedGroup));
+                null, null, null, null, null, List.of(overlayReplacementNamedGroup, overlayNewUnnamedGroup));
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(
@@ -134,7 +135,7 @@ class UnifiedConfigMergerTest {
         // Given
         UnifiedMemberGroup firstBaselineGroup = createGroup("Default Rule");
         UnifiedMemberGroup duplicateBaselineGroup = createGroup("Default Rule", List.of(createGroup("Duplicate")));
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, null, null, List.of());
+        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, null, null, null, List.of());
 
         // When / Then
         assertThatThrownBy(() -> UnifiedConfigMerger.merge(
@@ -147,8 +148,8 @@ class UnifiedConfigMergerTest {
     void merge_flexibleOverlayProvided_overridesBackupsAndKeepsBaselineFields() {
         // Given
         FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
-                TOP_LEVEL_TYPES_ORDERING, FORMATTING, true, HEADER_LINE, List.of(createGroup("Default Rule")));
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, false, null, null);
+                TOP_LEVEL_TYPES_ORDERING, FORMATTING, true, null, HEADER_LINE, List.of(createGroup("Default Rule")));
+        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, false, null, null, null);
 
         // When
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -166,12 +167,12 @@ class UnifiedConfigMergerTest {
         // Given
         UnifiedMemberGroup baselineDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup baselineUnitsGroup = createGroup("Units");
-        FlexibleUnifiedConfig baselineConfig =
-                new FlexibleUnifiedConfig(null, null, null, null, List.of(baselineDefaultGroup, baselineUnitsGroup));
+        FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
+                null, null, null, null, null, List.of(baselineDefaultGroup, baselineUnitsGroup));
         UnifiedMemberGroup replacementDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup newAuditGroup = createGroup("Audit");
-        FlexibleUnifiedConfig overlayConfig =
-                new FlexibleUnifiedConfig(null, null, null, null, List.of(replacementDefaultGroup, newAuditGroup));
+        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
+                null, null, null, null, null, List.of(replacementDefaultGroup, newAuditGroup));
 
         // When
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -188,11 +189,16 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineUnnamedGroup = createGroup(null);
         UnifiedMemberGroup baselineTrailingNamedGroup = createGroup("Trailing");
         FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, List.of(baselineNamedGroup, baselineUnnamedGroup, baselineTrailingNamedGroup));
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(baselineNamedGroup, baselineUnnamedGroup, baselineTrailingNamedGroup));
         UnifiedMemberGroup overlayReplacementNamedGroup = createGroup("Default Rule");
         UnifiedMemberGroup overlayNewNamedGroup = createGroup("Audit");
         FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, List.of(overlayReplacementNamedGroup, overlayNewNamedGroup));
+                null, null, null, null, null, List.of(overlayReplacementNamedGroup, overlayNewNamedGroup));
 
         // When
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -212,6 +218,7 @@ class UnifiedConfigMergerTest {
                 .topLevelTypesOrdering(TOP_LEVEL_TYPES_ORDERING)
                 .formatting(FORMATTING)
                 .backupsEnabled(true)
+                .printProcessingStatistics(true)
                 .headerLine(HEADER_LINE)
                 .rootMemberGroups(rootMemberGroups)
                 .build();

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonSorterTopLevelTypesOrderingTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonSorterTopLevelTypesOrderingTest.java
@@ -135,6 +135,7 @@ class SpoonSorterTopLevelTypesOrderingTest {
                 .topLevelTypesOrdering(topLevelTypesOrdering)
                 .formatting(new UnifiedFormatting(true, UnifiedFormatterStyle.PALANTIR))
                 .backupsEnabled(false)
+                .printProcessingStatistics(true)
                 .headerLine(new UnifiedHeaderLine('-', 0))
                 .rootMemberGroup(rootMemberGroup)
                 .build();

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/invalid-config-missing-member-group-name.yml
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/invalid-config-missing-member-group-name.yml
@@ -7,6 +7,7 @@ formatting:
   fix-imports: true
   formatter-style: PALANTIR
 backups-enabled: true
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/simplest-working-config.yml
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/simplest-working-config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: true
+print-processing-statistics: true
 
 header-line:
   character: "-"

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/top-level-types-ordering-mixed-group-syntax.yml
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/top-level-types-ordering-mixed-group-syntax.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: true
+print-processing-statistics: true
 
 header-line:
   character: "-"

--- a/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/01-baseline-ordering/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/02-static-vs-instance-initializers/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/03-field-initializer-var-ref-chain/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/04-cycle-scc-bundling/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/05-keep-accessors-together/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/06-enum-preserve-and-method-order/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/07-record-method-ordering/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/08-separator-variants/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 0

--- a/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/09-field-initializer-explicit-this-forward-chain/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/10-field-initializer-explicit-type-forward-chain/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/10-field-initializer-explicit-type-forward-chain/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/11-lazy-initializer-contexts/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/12-write-only-initializer-dependency/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/12-write-only-initializer-dependency/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/13-field-initializer-general-compile-time-constant/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/14-blank-final-optimized-provider/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/14-blank-final-optimized-provider/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/15-field-alpha-ordering-multi-level-dependencies/config.yml
@@ -2,6 +2,7 @@ formatting:
   fix-imports: false
   formatter-style: PALANTIR
 backups-enabled: false
+print-processing-statistics: true
 header-line:
   character: "-"
   left-padding: 2

--- a/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/16-default-config-complex-non-class-types/config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR # NONE, AOSP, GOOGLE, PALANTIR
 
 backups-enabled: true
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/resources/test-cases/core/e2e/restructure/17-top-level-types-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/17-top-level-types-ordering/config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: true
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/resources/test-cases/core/e2e/restructure/18-top-level-types-default-groups-ordering/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/18-top-level-types-default-groups-ordering/config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: true
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/resources/test-cases/core/e2e/restructure/19-opt-out-comment-matrix/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/19-opt-out-comment-matrix/config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: false
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/20-non-type-compilation-units/config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: false
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/resources/test-cases/core/e2e/restructure/21-non-type-compilation-units-opt-out-matrix/config.yml
+++ b/core/src/test/resources/test-cases/core/e2e/restructure/21-non-type-compilation-units-opt-out-matrix/config.yml
@@ -3,6 +3,7 @@ formatting:
   formatter-style: PALANTIR
 
 backups-enabled: false
+print-processing-statistics: true
 
 header-line:
   character: '-'

--- a/core/src/test/resources/test-cases/core/sorter/spoon/natural-group-resolution/natural-group-resolution-config.yml
+++ b/core/src/test/resources/test-cases/core/sorter/spoon/natural-group-resolution/natural-group-resolution-config.yml
@@ -9,6 +9,7 @@ formatting:
   formatter-style: palantir
 
 backups-enabled: false
+print-processing-statistics: true
 
 header-line:
   character: '#'


### PR DESCRIPTION
### Motivation

- Provide an opt-out for the final processing statistics report when invoking the CLI and via configuration. 
- Avoid noisy full statistics output while still surfacing files with unexpected processing errors.

### Description

- Added a new CLI flag `-S, --no-statistics` and a `noStatistics` field to `CommandOptions` to allow disabling the final statistics report from the command line. 
- Threaded a new `printProcessingStatistics` flag through the configuration models: YAML model (`JHarmonizerConfig` / `JHarmonizerFlexibleConfig`), unified models (`FlexibleUnifiedConfig`, `UnifiedConfig`), compiler (`Unified2CompiledModelCompiler`), and merger (`UnifiedConfigMerger`).
- Updated the CLI to merge a CLI-derived override `FlexibleUnifiedConfig` that sets `printProcessingStatistics` when appropriate.
- Modified `SrcProcessor` to conditionally render the full processing statistics only when `config.isPrintProcessingStatistics()` is true and to otherwise log only files that failed with unexpected errors via a new `logFilesWithUnexpectedErrors` helper.
- Updated default config resource and numerous test fixtures to include `print-processing-statistics: true` and adapted tests and constructors to the new `FlexibleUnifiedConfig` signature.
- Added a unit test `call_noStatisticsOptionInvoked_disablesStatisticsReportInSrcProcessor` in `BaseCommandTest` to verify the CLI flag behavior.

### Testing

- Ran the project's automated test suite (`mvn test`) including updated unit tests, and all tests completed successfully. 
- Verified the new CLI unit test `call_noStatisticsOptionInvoked_disablesStatisticsReportInSrcProcessor` and other modified tests pass under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe3f1ae748325b36357b8ecdae108)