### PR TITLE
Replace magic ellipsis with constants and suppress PMD DataClass warning

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerFlexibleConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerFlexibleConfig.java
@@ -16,6 +16,7 @@ import lombok.Value;
  * Flexible overlay for JHarmonizerConfig. All fields are optional.
  */
 @Value
+@SuppressWarnings("PMD.DataClass")
 @Getter(AccessLevel.NONE)
 public class JHarmonizerFlexibleConfig {
 
@@ -122,4 +123,5 @@ public class JHarmonizerFlexibleConfig {
     public Optional<JHarmonizerTopLevelTypesOrdering> getTopLevelTypesOrdering() {
         return ofNullable(topLevelTypesOrdering);
     }
+
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintService.java
@@ -22,6 +22,8 @@ public class ProcessingStatisticsPrintService {
 
     private static final int METRIC_WIDTH = 40;
     private static final int VALUE_WIDTH = 24;
+    private static final String ELLIPSIS = "...";
+    private static final int ELLIPSIS_LENGTH = ELLIPSIS.length();
     private static final int DETAIL_PATH_MAX_LENGTH = 120;
     private static final String HEADER = "JHarmonizer harmonization summary";
 
@@ -125,9 +127,9 @@ public class ProcessingStatisticsPrintService {
         if (value.length() <= maxWidth) {
             return value;
         }
-        if (maxWidth <= 3) {
+        if (maxWidth <= ELLIPSIS_LENGTH) {
             return value.substring(0, maxWidth);
         }
-        return value.substring(0, maxWidth - 3) + "...";
+        return value.substring(0, maxWidth - ELLIPSIS_LENGTH) + ELLIPSIS;
     }
 }


### PR DESCRIPTION
### Motivation
- Remove a hard-coded magic number/string used for truncation and centralize the ellipsis representation for clarity and maintainability.
- Suppress a PMD `DataClass` warning on an intentional data holder class to quiet static analysis noise.

### Description
- Added `ELLIPSIS` and `ELLIPSIS_LENGTH` constants to `ProcessingStatisticsPrintService` and updated `fitCell` to use them instead of the literal `3` and `"..."`.
- Added `@SuppressWarnings("PMD.DataClass")` to `JHarmonizerFlexibleConfig` to acknowledge its intended data-class role.

### Testing
- Ran unit tests with `mvn test` and project verification/static analysis with `mvn verify`, and the automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc12214e508325ab83fe8ff5eb086f)