### PR TITLE
Disable processing statistics in e2e tests and add `--no-statistics` to CLI test runs

### DIFF
--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -236,7 +236,7 @@ class JHarmonizerCliPackagedJarIT {
         assertThat(result.getExitCode()).as(result.toString()).isZero();
         assertThat(result.combinedOutput())
                 .as(result.toString())
-                .doesNotContain("Harmonization result:")
+                .doesNotContain("JHarmonizer harmonization summary")
                 .contains("App.java")
                 .containsAnyOf("REORDERED", "FORMATTED");
         assertFileUnchanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.APP_JAVA);

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -113,14 +113,20 @@ class JHarmonizerCliPackagedJarIT {
 
         // When
         ExternalCliProcessResult result =
-                ExternalCliProcessRunner.run(EXECUTABLE_JAR, projectDirectory, "restructure", "-i", "**/*.java");
+                ExternalCliProcessRunner.run(
+                        EXECUTABLE_JAR,
+                        projectDirectory,
+                        "restructure",
+                        "--no-statistics",
+                        "--include",
+                        "**/*.java");
 
         // Then
         assertCompleted(result);
         assertThat(result.getExitCode()).as(result.toString()).isZero();
         assertThat(result.combinedOutput())
                 .as(result.toString())
-                .contains("Harmonization result:")
+                .doesNotContain("Harmonization result:")
                 .doesNotContain("SLF4J(W)");
         assertFileChanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.APP_JAVA);
         assertFileChanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.FEATURE_SERVICE_JAVA);
@@ -143,17 +149,18 @@ class JHarmonizerCliPackagedJarIT {
                 EXECUTABLE_JAR,
                 projectDirectory,
                 "restructure",
-                "-b",
+                "--no-statistics",
+                "--base-dir",
                 ".",
-                "-i",
+                "--include",
                 "src/main/java/**/*.java",
-                "-i",
+                "--include",
                 "src/test/java/**/*.java",
-                "-e",
+                "--exclude",
                 "**/internal/**",
-                "-e",
+                "--exclude",
                 "**/excluded/**",
-                "-e",
+                "--exclude",
                 "**/*Test.java");
 
         // Then
@@ -173,14 +180,28 @@ class JHarmonizerCliPackagedJarIT {
         // Given
         Path projectDirectory = copyBasicProject("project-already-harmonized");
         ExternalCliProcessResult initialResult = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, projectDirectory, "restructure", "-b", ".", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                projectDirectory,
+                "restructure",
+                "--no-statistics",
+                "--base-dir",
+                ".",
+                "--include",
+                "**/*.java");
         assertCompleted(initialResult);
         assertThat(initialResult.getExitCode()).as(initialResult.toString()).isZero();
         Path expectedProjectDirectory = copyDirectory(projectDirectory, "project-already-harmonized-expected");
 
         // When
         ExternalCliProcessResult secondResult = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, projectDirectory, "restructure", "-b", ".", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                projectDirectory,
+                "restructure",
+                "--no-statistics",
+                "--base-dir",
+                ".",
+                "--include",
+                "**/*.java");
 
         // Then
         assertCompleted(secondResult);
@@ -201,14 +222,21 @@ class JHarmonizerCliPackagedJarIT {
 
         // When
         ExternalCliProcessResult result = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, projectDirectory, "check-all", "-b", ".", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                projectDirectory,
+                "check-all",
+                "--no-statistics",
+                "--base-dir",
+                ".",
+                "--include",
+                "**/*.java");
 
         // Then
         assertCompleted(result);
         assertThat(result.getExitCode()).as(result.toString()).isZero();
         assertThat(result.combinedOutput())
                 .as(result.toString())
-                .contains("Harmonization result:")
+                .doesNotContain("Harmonization result:")
                 .contains("App.java")
                 .containsAnyOf("REORDERED", "FORMATTED");
         assertFileUnchanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.APP_JAVA);
@@ -229,6 +257,7 @@ class JHarmonizerCliPackagedJarIT {
                 EXECUTABLE_JAR,
                 projectDirectory,
                 "check-all",
+                "--no-statistics",
                 "--base-dir",
                 ".",
                 "--include",
@@ -262,7 +291,14 @@ class JHarmonizerCliPackagedJarIT {
         // Given
         Path projectDirectory = copyBasicProject("project-check-clean");
         ExternalCliProcessResult restructureResult = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, projectDirectory, "restructure", "-b", ".", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                projectDirectory,
+                "restructure",
+                "--no-statistics",
+                "--base-dir",
+                ".",
+                "--include",
+                "**/*.java");
         assertCompleted(restructureResult);
         assertThat(restructureResult.getExitCode())
                 .as(restructureResult.toString())
@@ -271,7 +307,14 @@ class JHarmonizerCliPackagedJarIT {
 
         // When
         ExternalCliProcessResult result = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, projectDirectory, "check-all", "-b", ".", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                projectDirectory,
+                "check-all",
+                "--no-statistics",
+                "--base-dir",
+                ".",
+                "--include",
+                "**/*.java");
 
         // Then
         assertCompleted(result);
@@ -296,7 +339,14 @@ class JHarmonizerCliPackagedJarIT {
 
         // When
         ExternalCliProcessResult result = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, projectDirectory, "check-fast", "-b", ".", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                projectDirectory,
+                "check-fast",
+                "--no-statistics",
+                "--base-dir",
+                ".",
+                "--include",
+                "**/*.java");
 
         // Then
         assertCompleted(result);
@@ -345,7 +395,14 @@ class JHarmonizerCliPackagedJarIT {
 
         // When
         ExternalCliProcessResult result = ExternalCliProcessRunner.run(
-                EXECUTABLE_JAR, workingDirectory, "check-all", "-b", "missing-directory", "-i", "**/*.java");
+                EXECUTABLE_JAR,
+                workingDirectory,
+                "check-all",
+                "--no-statistics",
+                "--base-dir",
+                "missing-directory",
+                "--include",
+                "**/*.java");
 
         // Then
         assertCompleted(result);

--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -126,7 +126,7 @@ class JHarmonizerCliPackagedJarIT {
         assertThat(result.getExitCode()).as(result.toString()).isZero();
         assertThat(result.combinedOutput())
                 .as(result.toString())
-                .doesNotContain("Harmonization result:")
+                .doesNotContain("JHarmonizer harmonization summary")
                 .doesNotContain("SLF4J(W)");
         assertFileChanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.APP_JAVA);
         assertFileChanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.FEATURE_SERVICE_JAVA);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java
@@ -203,13 +203,25 @@ abstract class AbstractSrcProcessorScenarioE2ETest<ValidationStateT> {
     @NonNull
     private static SrcProcessor buildSrcProcessor(Path scenarioConfigPath) {
         if (scenarioConfigPath == null) {
-            return new SrcProcessor();
+            return new SrcProcessor(
+                    disableProcessingStatistics(new FlexibleUnifiedConfig(null, null, null, null, null, null)));
         }
 
         FlexibleUnifiedConfig flexibleConfig =
                 JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromClasspathResource(
                         E2EFileUtils.toUrl(scenarioConfigPath));
-        return new SrcProcessor(flexibleConfig);
+        return new SrcProcessor(disableProcessingStatistics(flexibleConfig));
+    }
+
+    @NonNull
+    private static FlexibleUnifiedConfig disableProcessingStatistics(@NonNull FlexibleUnifiedConfig flexibleConfig) {
+        return new FlexibleUnifiedConfig(
+                flexibleConfig.getTopLevelTypesOrdering().orElse(null),
+                flexibleConfig.getFormatting().orElse(null),
+                flexibleConfig.getBackupsEnabled().orElse(null),
+                false,
+                flexibleConfig.getHeaderLine().orElse(null),
+                flexibleConfig.getRootMemberGroups().orElse(null));
     }
 
     @NonNull


### PR DESCRIPTION
### Motivation

- Make end-to-end tests deterministic and avoid relying on processing-statistics output in stdout by disabling statistics during test runs.
- Align CLI test invocations to use explicit long-form options and a flag to suppress statistics output.

### Description

- Updated CLI integration tests in `JHarmonizerCliPackagedJarIT` to pass `--no-statistics` on all `ExternalCliProcessRunner.run` invocations and to prefer long-form options like `--base-dir`, `--include`, and `--exclude` where applicable. 
- Adjusted assertions that previously expected the presence of a statistics section (for example `Harmonization result:`) to instead assert it is not present when statistics are disabled.
- Modified `AbstractSrcProcessorScenarioE2ETest.buildSrcProcessor` to construct `SrcProcessor` with a `FlexibleUnifiedConfig` where processing statistics are explicitly disabled, and added a private helper `disableProcessingStatistics` to produce such a config.

### Testing

- Ran the CLI integration test class `JHarmonizerCliPackagedJarIT` and the core e2e test `AbstractSrcProcessorScenarioE2ETest` as part of the module test suite; the tests completed and passed.
- Executed the project test suite for the affected modules (unit and integration tests); all affected tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1a033b188325ade76d49a4139f56)