### PR TITLE
Update CLI IT assertions for harmonization summary banner

### DIFF
--- a/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
+++ b/cli/src/test/java/io/github/lemon_ant/jharmonizer/cli/e2e/JHarmonizerCliPackagedJarIT.java
@@ -120,7 +120,7 @@ class JHarmonizerCliPackagedJarIT {
         assertThat(result.getExitCode()).as(result.toString()).isZero();
         assertThat(result.combinedOutput())
                 .as(result.toString())
-                .contains("Harmonization result:")
+                .contains("JHarmonizer harmonization summary")
                 .doesNotContain("SLF4J(W)");
         assertFileChanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.APP_JAVA);
         assertFileChanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.FEATURE_SERVICE_JAVA);
@@ -208,7 +208,7 @@ class JHarmonizerCliPackagedJarIT {
         assertThat(result.getExitCode()).as(result.toString()).isZero();
         assertThat(result.combinedOutput())
                 .as(result.toString())
-                .contains("Harmonization result:")
+                .contains("JHarmonizer harmonization summary")
                 .contains("App.java")
                 .containsAnyOf("REORDERED", "FORMATTED");
         assertFileUnchanged(ORIGINAL_PROJECT_DIRECTORY, projectDirectory, Constants.APP_JAVA);


### PR DESCRIPTION
### Motivation
- Integration tests expected the old banner text `"Harmonization result:"` but the CLI now emits the header `"JHarmonizer harmonization summary"`, which caused two IT failures. 

### Description
- Replaced the stale expectation `"Harmonization result:"` with `"JHarmonizer harmonization summary"` in `cli/src/test/java/.../JHarmonizerCliPackagedJarIT.java` for the `restructureCommand_baseDirOmitted_useCurrentWorkingDirectory` and `checkCommand_nonHarmonizedFilesPresent_returnSuccessWithoutModifyingFiles` tests. 
- No production code was changed; this is an assertion-only update to bring tests in line with current CLI output.

### Testing
- Ran `mvn -pl cli -Dtest=JHarmonizerCliPackagedJarIT test`, which failed because the `cli` module could not resolve the `jharmonizer-core:1.0-SNAPSHOT` dependency when built in isolation. 
- Ran `mvn -pl cli -am -Dtest=JHarmonizerCliPackagedJarIT test`, which failed before reaching the CLI ITs due to Surefire reporting no matching tests in the `core` module for the specified pattern. 
- Ran `mvn -pl cli -am -DskipTests install`, which failed due to existing PMD violations in the `core` module that are unrelated to this test-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1eaf00d08325a7b9cb93c7a34f25)