### PR TITLE
Introduce Lombok builders for config and stats models and migrate call sites to builders

### DIFF
--- a/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
+++ b/cli/src/main/java/io/github/lemon_ant/jharmonizer/cli/command/BaseCommand.java
@@ -170,13 +170,10 @@ abstract class BaseCommand implements Callable<Integer> {
                 ? JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromFile(configFilePath)
                 : null;
         FlexibleUnifiedConfig cliOverrideConfig = (disableBackups || disableStatisticsOutput)
-                ? new FlexibleUnifiedConfig(
-                        null,
-                        null,
-                        disableBackups ? false : null,
-                        disableStatisticsOutput ? false : null,
-                        null,
-                        null)
+                ? FlexibleUnifiedConfig.builder()
+                        .backupsEnabled(disableBackups ? false : null)
+                        .printProcessingStatistics(disableStatisticsOutput ? false : null)
+                        .build()
                 : null;
         FlexibleUnifiedConfig effectiveConfig = mergeFlexibleConfigs(externalConfig, cliOverrideConfig);
         return new SrcProcessor(effectiveConfig);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/CompiledConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/CompiledConfig.java
@@ -7,6 +7,8 @@ import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedFormatting;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedHeaderLine;
 import java.util.List;
 import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 
@@ -50,7 +52,8 @@ public class CompiledConfig {
      * @param printProcessingStatistics the print processing statistics flag
      * @param headerLine the header line
      */
-    CompiledConfig(
+    @Builder(access = AccessLevel.PACKAGE)
+    private CompiledConfig(
             @NonNull List<CompiledMemberGroup> rootMemberGroups,
             @NonNull CompiledTopLevelTypesOrdering topLevelTypesOrdering,
             @NonNull UnifiedFormatting formatting,

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/Unified2CompiledModelCompiler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/Unified2CompiledModelCompiler.java
@@ -28,12 +28,13 @@ public class Unified2CompiledModelCompiler {
         CompiledTopLevelTypesOrdering topLevelTypesOrdering =
                 TopLevelTypesOrderingCompiler.compileTopLevelTypesOrdering(unifiedConfig.getTopLevelTypesOrdering());
 
-        return new CompiledConfig(
-                memberGroups,
-                topLevelTypesOrdering,
-                unifiedConfig.getFormatting(),
-                unifiedConfig.isBackupsEnabled(),
-                unifiedConfig.isPrintProcessingStatistics(),
-                unifiedConfig.getHeaderLine());
+        return CompiledConfig.builder()
+                .rootMemberGroups(memberGroups)
+                .topLevelTypesOrdering(topLevelTypesOrdering)
+                .formatting(unifiedConfig.getFormatting())
+                .backupsEnabled(unifiedConfig.isBackupsEnabled())
+                .printProcessingStatistics(unifiedConfig.isPrintProcessingStatistics())
+                .headerLine(unifiedConfig.getHeaderLine())
+                .build();
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizerFlexible2FlexibleUnifiedConverter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizerFlexible2FlexibleUnifiedConverter.java
@@ -30,13 +30,14 @@ public class JHarmonizerFlexible2FlexibleUnifiedConverter {
                 vendorConfig.getPrintProcessingStatistics().orElse(null);
         UnifiedHeaderLine headerLine = readHeaderLine(vendorConfig);
         List<UnifiedMemberGroup> rootMemberGroups = readRootMemberGroups(vendorConfig);
-        return new FlexibleUnifiedConfig(
-                topLevelTypesOrdering,
-                formatting,
-                backupsEnabled,
-                printProcessingStatistics,
-                headerLine,
-                rootMemberGroups);
+        return FlexibleUnifiedConfig.builder()
+                .topLevelTypesOrdering(topLevelTypesOrdering)
+                .formatting(formatting)
+                .backupsEnabled(backupsEnabled)
+                .printProcessingStatistics(printProcessingStatistics)
+                .headerLine(headerLine)
+                .rootMemberGroups(rootMemberGroups)
+                .build();
     }
 
     @Nullable

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/FlexibleUnifiedConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/FlexibleUnifiedConfig.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Singular;
@@ -63,7 +64,8 @@ public class FlexibleUnifiedConfig {
      * @param headerLine the header line
      * @param rootMemberGroups the root member groups
      */
-    public FlexibleUnifiedConfig(
+    @Builder
+    private FlexibleUnifiedConfig(
             @Nullable UnifiedTopLevelTypesOrdering topLevelTypesOrdering,
             @Nullable UnifiedFormatting formatting,
             @Nullable Boolean backupsEnabled,

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfig.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfig.java
@@ -58,7 +58,7 @@ public class UnifiedConfig {
      * @param rootMemberGroups the root member groups
      */
     @Builder
-    public UnifiedConfig(
+    private UnifiedConfig(
             @NonNull UnifiedTopLevelTypesOrdering topLevelTypesOrdering,
             @NonNull UnifiedFormatting formatting,
             @NonNull Boolean backupsEnabled,

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMerger.java
@@ -73,7 +73,14 @@ public class UnifiedConfigMerger {
                         .orElse(overlayRootGroups))
                 .orElse(baseline.getRootMemberGroups().orElse(null));
 
-        return new FlexibleUnifiedConfig(top, formatting, backupsEnabled, printProcessingStatistics, header, root);
+        return FlexibleUnifiedConfig.builder()
+                .topLevelTypesOrdering(top)
+                .formatting(formatting)
+                .backupsEnabled(backupsEnabled)
+                .printProcessingStatistics(printProcessingStatistics)
+                .headerLine(header)
+                .rootMemberGroups(root)
+                .build();
     }
 
     @NonNull

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/SrcProcessingStats.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/SrcProcessingStats.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.stream.Collector;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Value;
@@ -59,7 +61,8 @@ public class SrcProcessingStats {
         @NonNull
         List<@NonNull Path> filesWithUnexpectedErrors;
 
-        AggregatedProcessingStatistic(
+        @Builder(access = AccessLevel.PACKAGE)
+        private AggregatedProcessingStatistic(
                 long fileCount,
                 long totalSize,
                 long totalProcessingTimeNanos,
@@ -201,16 +204,17 @@ public class SrcProcessingStats {
          */
         @NonNull
         AggregatedProcessingStatistic toAggregatedStats() {
-            return new AggregatedProcessingStatistic(
-                    count.sum(),
-                    totalSize.sum(),
-                    totalTime.sum(),
-                    totalParsingTime.sum(),
-                    totalSortingTime.sum(),
-                    totalFormattingTime.sum(),
-                    minSize.get(),
-                    maxSize.get(),
-                    Collections.unmodifiableList(unexpectedErrorPaths));
+            return AggregatedProcessingStatistic.builder()
+                    .fileCount(count.sum())
+                    .totalSize(totalSize.sum())
+                    .totalProcessingTimeNanos(totalTime.sum())
+                    .totalParsingTimeNanos(totalParsingTime.sum())
+                    .totalSortingTimeNanos(totalSortingTime.sum())
+                    .totalFormattingTimeNanos(totalFormattingTime.sum())
+                    .smallestFile(minSize.get())
+                    .largestFile(maxSize.get())
+                    .filesWithUnexpectedErrors(Collections.unmodifiableList(unexpectedErrorPaths))
+                    .build();
         }
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
@@ -343,12 +343,12 @@ class OptOutSrcProcessorIntegrationTest {
                         UnifiedTypeKind.ANNOTATION))))
                 .orderingRules(List.of(UnifiedOrderingRule.ALPHA))
                 .build();
-        return new FlexibleUnifiedConfig(
-                topLevelTypesOrdering,
-                new UnifiedFormatting(true, UnifiedFormatterStyle.PALANTIR),
-                false,
-                null,
-                new UnifiedHeaderLine('-', 0),
-                List.of(rootMemberGroup));
+        return FlexibleUnifiedConfig.builder()
+                .topLevelTypesOrdering(topLevelTypesOrdering)
+                .formatting(new UnifiedFormatting(true, UnifiedFormatterStyle.PALANTIR))
+                .backupsEnabled(false)
+                .headerLine(new UnifiedHeaderLine('-', 0))
+                .rootMemberGroups(List.of(rootMemberGroup))
+                .build();
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
@@ -277,7 +277,8 @@ class SrcProcessorTest {
         String unformattedSrcCode = "package demo; public class BackupEnabled {private int x;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupEnabled.java", unformattedSrcCode);
         String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null, null));
+        SrcProcessor srcProcessor = new SrcProcessor(
+                FlexibleUnifiedConfig.builder().backupsEnabled(true).build());
 
         // When
         srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
@@ -296,7 +297,8 @@ class SrcProcessorTest {
         String firstSrcCode = "package demo; public class BackupTwice {private int x;}";
         String secondSrcCode = "package demo; public class BackupTwice {private int y;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupTwice.java", firstSrcCode);
-        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, true, null, null, null));
+        SrcProcessor srcProcessor = new SrcProcessor(
+                FlexibleUnifiedConfig.builder().backupsEnabled(true).build());
 
         // When
         srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
@@ -316,7 +318,8 @@ class SrcProcessorTest {
         String unformattedSrcCode = "package demo; public class BackupDisabled {private int x;}";
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupDisabled.java", unformattedSrcCode);
         String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
-        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, false, null, null, null));
+        SrcProcessor srcProcessor = new SrcProcessor(
+                FlexibleUnifiedConfig.builder().backupsEnabled(false).build());
 
         // When
         srcProcessor.processSources(temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
@@ -335,8 +338,8 @@ class SrcProcessorTest {
         Path javaFilePath = writeJavaFile(temporaryDirectory, "BackupOverrideDisabled.java", unformattedSrcCode);
         String originalSrcCode = Files.readString(javaFilePath, StandardCharsets.UTF_8);
         FlexibleUnifiedConfig effectiveConfig = UnifiedConfigMerger.merge(
-                new FlexibleUnifiedConfig(null, null, true, null, null, null),
-                new FlexibleUnifiedConfig(null, null, false, null, null, null));
+                FlexibleUnifiedConfig.builder().backupsEnabled(true).build(),
+                FlexibleUnifiedConfig.builder().backupsEnabled(false).build());
         SrcProcessor srcProcessor = new SrcProcessor(effectiveConfig);
 
         // When

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
@@ -26,7 +26,7 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineFirstGroup = createGroup("Default Rule");
         UnifiedMemberGroup baselineSecondGroup = createGroup("Units");
         UnifiedConfig baselineConfig = createConfig(List.of(baselineFirstGroup, baselineSecondGroup));
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, null, null, null, null);
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder().build();
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -47,13 +47,10 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup newUtilityGroup = createGroup("Utility");
         UnifiedMemberGroup replacementDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup newAuditGroup = createGroup("Audit");
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
-                null,
-                null,
-                null,
-                null,
-                null,
-                List.of(replacementFallbackGroup, newUtilityGroup, replacementDefaultGroup, newAuditGroup));
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(
+                        List.of(replacementFallbackGroup, newUtilityGroup, replacementDefaultGroup, newAuditGroup))
+                .build();
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -76,8 +73,9 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineFallbackGroup = createGroup("Fallback");
         UnifiedConfig baselineConfig = createConfig(List.of(baselineNestedGroup, baselineFallbackGroup));
         UnifiedMemberGroup overlayNestedGroup = createGroup("Default Rule", List.of(createGroup("Overlay Methods")));
-        FlexibleUnifiedConfig overlayConfig =
-                new FlexibleUnifiedConfig(null, null, null, null, null, List.of(overlayNestedGroup));
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(overlayNestedGroup))
+                .build();
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -94,8 +92,9 @@ class UnifiedConfigMergerTest {
         // Given
         UnifiedMemberGroup baselineDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup unnamedOverlayGroup = createGroup(null);
-        FlexibleUnifiedConfig overlayConfig =
-                new FlexibleUnifiedConfig(null, null, null, null, null, List.of(unnamedOverlayGroup));
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(unnamedOverlayGroup))
+                .build();
 
         // When
         UnifiedConfig mergedConfig =
@@ -113,8 +112,9 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineTrailingNamedGroup = createGroup("Trailing");
         UnifiedMemberGroup overlayReplacementNamedGroup = createGroup("Default Rule");
         UnifiedMemberGroup overlayNewUnnamedGroup = createGroup(null);
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, null, List.of(overlayReplacementNamedGroup, overlayNewUnnamedGroup));
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(overlayReplacementNamedGroup, overlayNewUnnamedGroup))
+                .build();
 
         // When
         UnifiedConfig mergedConfig = UnifiedConfigMerger.merge(
@@ -135,7 +135,8 @@ class UnifiedConfigMergerTest {
         // Given
         UnifiedMemberGroup firstBaselineGroup = createGroup("Default Rule");
         UnifiedMemberGroup duplicateBaselineGroup = createGroup("Default Rule", List.of(createGroup("Duplicate")));
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, null, null, null, List.of());
+        FlexibleUnifiedConfig overlayConfig =
+                FlexibleUnifiedConfig.builder().rootMemberGroups(List.of()).build();
 
         // When / Then
         assertThatThrownBy(() -> UnifiedConfigMerger.merge(
@@ -147,9 +148,15 @@ class UnifiedConfigMergerTest {
     @Test
     void merge_flexibleOverlayProvided_overridesBackupsAndKeepsBaselineFields() {
         // Given
-        FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
-                TOP_LEVEL_TYPES_ORDERING, FORMATTING, true, null, HEADER_LINE, List.of(createGroup("Default Rule")));
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(null, null, false, null, null, null);
+        FlexibleUnifiedConfig baselineConfig = FlexibleUnifiedConfig.builder()
+                .topLevelTypesOrdering(TOP_LEVEL_TYPES_ORDERING)
+                .formatting(FORMATTING)
+                .backupsEnabled(true)
+                .headerLine(HEADER_LINE)
+                .rootMemberGroups(List.of(createGroup("Default Rule")))
+                .build();
+        FlexibleUnifiedConfig overlayConfig =
+                FlexibleUnifiedConfig.builder().backupsEnabled(false).build();
 
         // When
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -167,12 +174,14 @@ class UnifiedConfigMergerTest {
         // Given
         UnifiedMemberGroup baselineDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup baselineUnitsGroup = createGroup("Units");
-        FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, null, List.of(baselineDefaultGroup, baselineUnitsGroup));
+        FlexibleUnifiedConfig baselineConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(baselineDefaultGroup, baselineUnitsGroup))
+                .build();
         UnifiedMemberGroup replacementDefaultGroup = createGroup("Default Rule");
         UnifiedMemberGroup newAuditGroup = createGroup("Audit");
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, null, List.of(replacementDefaultGroup, newAuditGroup));
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(replacementDefaultGroup, newAuditGroup))
+                .build();
 
         // When
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
@@ -188,17 +197,14 @@ class UnifiedConfigMergerTest {
         UnifiedMemberGroup baselineNamedGroup = createGroup("Default Rule");
         UnifiedMemberGroup baselineUnnamedGroup = createGroup(null);
         UnifiedMemberGroup baselineTrailingNamedGroup = createGroup("Trailing");
-        FlexibleUnifiedConfig baselineConfig = new FlexibleUnifiedConfig(
-                null,
-                null,
-                null,
-                null,
-                null,
-                List.of(baselineNamedGroup, baselineUnnamedGroup, baselineTrailingNamedGroup));
+        FlexibleUnifiedConfig baselineConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(baselineNamedGroup, baselineUnnamedGroup, baselineTrailingNamedGroup))
+                .build();
         UnifiedMemberGroup overlayReplacementNamedGroup = createGroup("Default Rule");
         UnifiedMemberGroup overlayNewNamedGroup = createGroup("Audit");
-        FlexibleUnifiedConfig overlayConfig = new FlexibleUnifiedConfig(
-                null, null, null, null, null, List.of(overlayReplacementNamedGroup, overlayNewNamedGroup));
+        FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder()
+                .rootMemberGroups(List.of(overlayReplacementNamedGroup, overlayNewNamedGroup))
+                .build();
 
         // When
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
@@ -14,16 +14,15 @@ class ProcessingStatisticsPrintServiceTest {
         // Given
         Path brokenPath = Path.of("zeta", "Broken.java");
         Path failurePath = Path.of("alpha", "Failure.java");
-        AggregatedProcessingStatistic stats = new AggregatedProcessingStatistic(
-                2,
-                6_500,
-                2_300_000_000L,
-                1_100_000_000L,
-                700_000_000L,
-                500_000_000L,
-                null,
-                null,
-                List.of(brokenPath, failurePath));
+        AggregatedProcessingStatistic stats = AggregatedProcessingStatistic.builder()
+                .fileCount(2)
+                .totalSize(6_500)
+                .totalProcessingTimeNanos(2_300_000_000L)
+                .totalParsingTimeNanos(1_100_000_000L)
+                .totalSortingTimeNanos(700_000_000L)
+                .totalFormattingTimeNanos(500_000_000L)
+                .filesWithUnexpectedErrors(List.of(brokenPath, failurePath))
+                .build();
 
         // When
         String report = ProcessingStatisticsPrintService.render(stats);
@@ -45,8 +44,15 @@ class ProcessingStatisticsPrintServiceTest {
     @Test
     void render_withoutUnexpectedErrors_printsNoneBullet() {
         // Given
-        AggregatedProcessingStatistic stats =
-                new AggregatedProcessingStatistic(0, 0, 0, 0, 0, 0, null, null, List.of());
+        AggregatedProcessingStatistic stats = AggregatedProcessingStatistic.builder()
+                .fileCount(0)
+                .totalSize(0)
+                .totalProcessingTimeNanos(0)
+                .totalParsingTimeNanos(0)
+                .totalSortingTimeNanos(0)
+                .totalFormattingTimeNanos(0)
+                .filesWithUnexpectedErrors(List.of())
+                .build();
 
         // When
         String report = ProcessingStatisticsPrintService.render(stats);
@@ -65,8 +71,15 @@ class ProcessingStatisticsPrintServiceTest {
                 "nested",
                 "feature",
                 "InternalToolForVeryLongStatisticsOutputVerification.java");
-        AggregatedProcessingStatistic stats = new AggregatedProcessingStatistic(
-                1, 123_456, 1_234_567_890L, 456_000_000L, 400_000_000L, 300_000_000L, null, null, List.of(longPath));
+        AggregatedProcessingStatistic stats = AggregatedProcessingStatistic.builder()
+                .fileCount(1)
+                .totalSize(123_456)
+                .totalProcessingTimeNanos(1_234_567_890L)
+                .totalParsingTimeNanos(456_000_000L)
+                .totalSortingTimeNanos(400_000_000L)
+                .totalFormattingTimeNanos(300_000_000L)
+                .filesWithUnexpectedErrors(List.of(longPath))
+                .build();
 
         // When
         String report = ProcessingStatisticsPrintService.render(stats);


### PR DESCRIPTION
### Motivation
- Replace many multi-parameter constructors with Lombok `@Builder` to make construction of immutable config and stats models safer and clearer.
- Reduce risk of parameter-order bugs and make it easier to create partial/overlay instances for merging logic.
- Update call sites and tests to use the new builder APIs.

### Description
- Added `@Builder` (with some package access) and made original constructors private for `FlexibleUnifiedConfig`, `UnifiedConfig`, and `CompiledConfig`, and added a builder for `SrcProcessingStats.AggregatedProcessingStatistic`.
- Rewrote callers to use builders, including `BaseCommand.createSrcProcessor(...)`, `Unified2CompiledModelCompiler.compile(...)`, `JHarmonizerFlexible2FlexibleUnifiedConverter.convert2FlexibleUnified(...)`, and `UnifiedConfigMerger.merge(...)`.
- Updated the stats aggregation to construct `AggregatedProcessingStatistic` via its builder in `StatsContainer.toAggregatedStats()`.
- Updated imports and added `lombok.AccessLevel` / `lombok.Builder` annotations where needed and adjusted visibility for constructors to enforce builder usage.
- Updated unit and integration tests to use the new builder factories (`FlexibleUnifiedConfig.builder()`, `AggregatedProcessingStatistic.builder()`, etc.).

### Testing
- Ran the project's unit test suite via `mvn test`, with updated tests compiling against the new builder APIs and passing.
- Verified core tests exercising configuration merging and stats rendering, including `UnifiedConfigMergerTest`, `ProcessingStatisticsPrintServiceTest`, and `SrcProcessorTest`, all succeeded.
- Ran the integration test `OptOutSrcProcessorIntegrationTest` which was updated to use builders and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc1dc05ca08325b47203397f260bfe)