### PR TITLE
Rename E2E helper to reflect statistics output behavior

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java
@@ -204,17 +204,17 @@ abstract class AbstractSrcProcessorScenarioE2ETest<ValidationStateT> {
     private static SrcProcessor buildSrcProcessor(Path scenarioConfigPath) {
         if (scenarioConfigPath == null) {
             return new SrcProcessor(
-                    disableProcessingStatistics(new FlexibleUnifiedConfig(null, null, null, null, null, null)));
+                    disableProcessingStatisticsOutput(new FlexibleUnifiedConfig(null, null, null, null, null, null)));
         }
 
         FlexibleUnifiedConfig flexibleConfig =
                 JHarmonizerConfigurationManager.parseFlexibleUnifiedConfigFromClasspathResource(
                         E2EFileUtils.toUrl(scenarioConfigPath));
-        return new SrcProcessor(disableProcessingStatistics(flexibleConfig));
+        return new SrcProcessor(disableProcessingStatisticsOutput(flexibleConfig));
     }
 
     @NonNull
-    private static FlexibleUnifiedConfig disableProcessingStatistics(@NonNull FlexibleUnifiedConfig flexibleConfig) {
+    private static FlexibleUnifiedConfig disableProcessingStatisticsOutput(FlexibleUnifiedConfig flexibleConfig) {
         return new FlexibleUnifiedConfig(
                 flexibleConfig.getTopLevelTypesOrdering().orElse(null),
                 flexibleConfig.getFormatting().orElse(null),


### PR DESCRIPTION
### Motivation

- The helper name `disableProcessingStatistics` was misleading because the flag it toggles controls statistics output rather than statistics collection. 
- Align the test helper with repository nullability conventions for private helper parameters.

### Description

- Renamed private helper method `disableProcessingStatistics` to `disableProcessingStatisticsOutput` in `core/src/test/java/io/github/lemon_ant/jharmonizer/core/e2e/AbstractSrcProcessorScenarioE2ETest.java` and updated both call sites in `buildSrcProcessor`. 
- Removed the redundant `@NonNull` annotation from the private helper parameter to match the repository rule that private helper parameters need not be annotated.

### Testing

- Ran `mvn -pl core test -Dtest=AbstractSrcProcessorScenarioE2ETest` and the build completed successfully. 
- The targeted abstract E2E test class produced `Tests run: 0` and the Maven build returned `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc45913cf48325860dd06f17d39917)