### PR TITLE
Add debug completion summary when stats disabled and record source size in bytes

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/SrcProcessor.java
@@ -38,6 +38,8 @@ public final class SrcProcessor {
 
     private static final String SINGLE_FILE_LOG_PREFIX = "JHarmonizer";
     private static final int MAX_TOTAL_PATH_LENGTH = 100;
+    private static final String SUMMARY_STATUS_COMPLETED = "COMPLETED";
+    private static final String SUMMARY_STATUS_COMPLETED_WITH_ERRORS = "COMPLETED_WITH_ERRORS";
 
     private final CompiledConfig config;
     private final Formatter formatter;
@@ -109,9 +111,26 @@ public final class SrcProcessor {
         if (config.isPrintProcessingStatistics()) {
             log.info(ProcessingStatisticsPrintService.render(aggregatedProcessingStatistic));
         } else {
+            logDebugProcessingCompletionSummary(aggregatedProcessingStatistic, flowType);
             logFilesWithUnexpectedErrors(aggregatedProcessingStatistic);
         }
         return aggregatedProcessingStatistic;
+    }
+
+    private static void logDebugProcessingCompletionSummary(
+            @NonNull AggregatedProcessingStatistic aggregatedStatistic, @NonNull FlowType flowType) {
+        String processingStatus =
+                aggregatedStatistic.getFilesWithUnexpectedErrors().isEmpty()
+                        ? SUMMARY_STATUS_COMPLETED
+                        : SUMMARY_STATUS_COMPLETED_WITH_ERRORS;
+        log.debug(
+                "Processing completed (full statistics report disabled). flowType={}, status={}, processedFiles={}, totalSizeBytes={}, totalProcessingTimeNanos={}, unexpectedErrors={}",
+                flowType,
+                processingStatus,
+                aggregatedStatistic.getFileCount(),
+                aggregatedStatistic.getTotalSize(),
+                aggregatedStatistic.getTotalProcessingTimeNanos(),
+                aggregatedStatistic.getFilesWithUnexpectedErrors().size());
     }
 
     private static void logFilesWithUnexpectedErrors(@NonNull AggregatedProcessingStatistic aggregatedStatistic) {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/SafeFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/SafeFlow.java
@@ -50,7 +50,7 @@ public final class SafeFlow implements IFlow {
                     .path(srcFile.getPath())
                     .relocations(List.of())
                     .diff("")
-                    .parsingStatistic(new ParsingStatistic(srcFile.getSrcCode().length(), 0, 0, 0, 0))
+                    .parsingStatistic(new ParsingStatistic(srcFile.getSrcCode().length(), 0, 0, 0, 0, 0))
                     .sortingStatistic(new SortingStatistic(0))
                     .serializationStatistic(new SerializationStatistic(0, 0))
                     .formattingStatistic(new FormattingStatistic(0, 0))

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/SafeFlow.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/flow/SafeFlow.java
@@ -5,6 +5,7 @@ import io.github.lemon_ant.jharmonizer.core.formatter.FormattingStatistic;
 import io.github.lemon_ant.jharmonizer.core.sorter.SortingStatistic;
 import io.github.lemon_ant.jharmonizer.core.translator.ParsingStatistic;
 import io.github.lemon_ant.jharmonizer.core.translator.SerializationStatistic;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NonNull;
@@ -50,7 +51,13 @@ public final class SafeFlow implements IFlow {
                     .path(srcFile.getPath())
                     .relocations(List.of())
                     .diff("")
-                    .parsingStatistic(new ParsingStatistic(srcFile.getSrcCode().length(), 0, 0, 0, 0, 0))
+                    .parsingStatistic(new ParsingStatistic(
+                            srcFile.getSrcCode().length(),
+                            srcFile.getSrcCode().getBytes(StandardCharsets.UTF_8).length,
+                            0,
+                            0,
+                            0,
+                            0))
                     .sortingStatistic(new SortingStatistic(0))
                     .serializationStatistic(new SerializationStatistic(0, 0))
                     .formattingStatistic(new FormattingStatistic(0, 0))

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/FileProcessingStatistic.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/FileProcessingStatistic.java
@@ -9,7 +9,7 @@ import lombok.Value;
 
 /**
  * Per-file processing statistics derived from a {@link FlowProcessingResult}.
- * Aggregates wall-clock processing time across all phases and records the original file size.
+ * Aggregates wall-clock processing time across all phases and records original file size in bytes.
  */
 @Value
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -34,6 +34,6 @@ public class FileProcessingStatistic {
         return new FileProcessingStatistic(
                 flowProcessingResult.getPath(),
                 processingTime,
-                flowProcessingResult.getParsingStatistic().getOriginalSrcCodeLength());
+                flowProcessingResult.getParsingStatistic().getOriginalSrcCodeSizeInBytes());
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/HumanReadableFormatsUtils.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/processing_stat/HumanReadableFormatsUtils.java
@@ -22,7 +22,6 @@ final class HumanReadableFormatsUtils {
     private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.ROOT);
 
     private static final DecimalFormat DECIMAL_0 = new DecimalFormat("#,##0", DECIMAL_FORMAT_SYMBOLS);
-
     private static final DecimalFormat DECIMAL_1 = new DecimalFormat("#,##0.0", DECIMAL_FORMAT_SYMBOLS);
 
     /**
@@ -36,7 +35,6 @@ final class HumanReadableFormatsUtils {
         if (bytes < 0) {
             throw new IllegalArgumentException("Byte size must be non-negative, but was: " + bytes);
         }
-
         if (bytes < KIB) {
             return DECIMAL_0.format(bytes) + " B";
         }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingResult.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingResult.java
@@ -7,7 +7,7 @@ import lombok.Value;
 
 /**
  * Result of parsing one Java source file into a Spoon AST model.
- * Bundles the parsed model with its associated timing and size statistics.
+ * Bundles the parsed model with its associated timing and source-length statistics.
  */
 @Value
 public class ParsingResult {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingResult.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingResult.java
@@ -7,7 +7,8 @@ import lombok.Value;
 
 /**
  * Result of parsing one Java source file into a Spoon AST model.
- * Bundles the parsed model with its associated timing and source-length statistics.
+ * Bundles the parsed model with its associated timing and source statistics
+ * (source-length and UTF-8 byte size).
  */
 @Value
 public class ParsingResult {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingStatistic.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingStatistic.java
@@ -3,11 +3,12 @@ package io.github.lemon_ant.jharmonizer.core.translator;
 import lombok.Value;
 
 /**
- * Timing and size statistics collected during a single source-file parsing pass.
+ * Timing and source statistics collected during a single source-file parsing pass.
  */
 @Value
 public class ParsingStatistic {
     long originalSrcCodeLength;
+    long originalSrcCodeSizeInBytes;
     int parsedMembersCount;
     int parsedRootTypesCount;
     int parsedTypesTotalCount;

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingStatistic.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/ParsingStatistic.java
@@ -3,7 +3,8 @@ package io.github.lemon_ant.jharmonizer.core.translator;
 import lombok.Value;
 
 /**
- * Timing and source statistics collected during a single source-file parsing pass.
+ * Timing and source statistics collected during a single source-file parsing pass,
+ * including source-length and UTF-8 byte size.
  */
 @Value
 public class ParsingStatistic {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializationResult.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializationResult.java
@@ -5,7 +5,7 @@ import lombok.Value;
 
 /**
  * Result of serializing a sorted Spoon AST back to Java source code.
- * Bundles the serialized source payload with the associated timing and size statistics.
+ * Bundles the serialized source payload with the associated timing and source-length statistics.
  */
 @Value
 public class SerializationResult {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializationStatistic.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SerializationStatistic.java
@@ -4,7 +4,7 @@ import java.util.Objects;
 import lombok.Value;
 
 /**
- * Timing and size statistics collected during a single AST-to-source serialization pass.
+ * Timing and source-length statistics collected during a single AST-to-source serialization pass.
  */
 @Value
 public class SerializationStatistic {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SrcAstTranslator.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/SrcAstTranslator.java
@@ -9,6 +9,7 @@ import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonParser;
 import io.github.lemon_ant.jharmonizer.core.utilities.StopWatch;
 import io.github.lemon_ant.jharmonizer.core.utilities.StopWatch.TimedResult;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -80,6 +81,7 @@ public final class SrcAstTranslator {
 
         return new ParsingStatistic(
                 originalSrcCode.length(),
+                originalSrcCode.getBytes(StandardCharsets.UTF_8).length,
                 allTypesMembers.size(),
                 rootTypes.size(),
                 allDeclaredTypes.size(),

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/SrcProcessorTest.java
@@ -3,6 +3,7 @@ package io.github.lemon_ant.jharmonizer.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -347,6 +348,38 @@ class SrcProcessorTest {
                 javaFilePath.resolveSibling(javaFilePath.getFileName().toString() + ".bak");
         assertThat(backupFilePath).doesNotExist();
         assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).isNotEqualTo(originalSrcCode);
+    }
+
+    @Test
+    void processSources_processingStatisticsDisabled_logsDebugCompletionSummary() throws Exception {
+        // Given
+        Path javaFilePath =
+                writeJavaFile(temporaryDirectory, "SummarySample.java", "package demo; public class SummarySample {}");
+        SrcProcessor srcProcessor = new SrcProcessor(new FlexibleUnifiedConfig(null, null, null, false, null, null));
+        Logger logger = (Logger) LoggerFactory.getLogger(SrcProcessor.class);
+        Level initialLevel = logger.getLevel();
+        logger.setLevel(Level.DEBUG);
+        ListAppender<ILoggingEvent> listAppender = attachListAppender();
+
+        // When
+        try {
+            srcProcessor.processSources(
+                    temporaryDirectory, INCLUDE_ALL_JAVA_FILES, EXCLUDE_NO_FILES, FlowType.RESTRUCTURE);
+        } finally {
+            detachListAppender(listAppender);
+            logger.setLevel(initialLevel);
+        }
+        String logs = collectLogMessages(listAppender);
+
+        // Then
+        assertThat(Files.readString(javaFilePath, StandardCharsets.UTF_8)).contains("public class SummarySample");
+        assertThat(logs)
+                .contains("Processing completed (full statistics report disabled)")
+                .contains("flowType=RESTRUCTURE")
+                .contains("status=COMPLETED")
+                .contains("processedFiles=1")
+                .contains("totalSizeBytes=")
+                .contains("unexpectedErrors=0");
     }
 
     @NonNull

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/processing_stat/ProcessingStatisticsPrintServiceTest.java
@@ -33,6 +33,7 @@ class ProcessingStatisticsPrintServiceTest {
                 .startsWith(System.lineSeparator())
                 .contains("JHarmonizer harmonization summary")
                 .contains("| Files processed")
+                .contains("| Total size")
                 .contains("| Parsing time (share)")
                 .contains("| Sorting time (share)")
                 .contains("| Formatting time (share)")


### PR DESCRIPTION
### Motivation
- Provide a concise debug summary when full processing statistics are disabled so runs still expose aggregated status and counts.
- Record original source size in bytes (UTF-8) alongside character length to report accurate total sizes in statistics.

### Description
- Add `logDebugProcessingCompletionSummary` to `SrcProcessor` and call it when `isPrintProcessingStatistics()` is false to emit a compact debug summary containing `flowType`, `status`, `processedFiles`, `totalSizeBytes`, `totalProcessingTimeNanos`, and `unexpectedErrors`.
- Introduce summary status constants `SUMMARY_STATUS_COMPLETED` and `SUMMARY_STATUS_COMPLETED_WITH_ERRORS` in `SrcProcessor` and log `COMPLETED` / `COMPLETED_WITH_ERRORS` accordingly.
- Add `originalSrcCodeSizeInBytes` to `ParsingStatistic`, compute it as `originalSrcCode.getBytes(StandardCharsets.UTF_8).length` in `SrcAstTranslator`, and propagate that value into `FileProcessingStatistic` (use `getOriginalSrcCodeSizeInBytes()` for file size).
- Update `SafeFlow` to build fallback `FlowProcessingResult` with the expanded `ParsingStatistic` constructor signature.
- Adjust tests and messages: update `ProcessingStatisticsPrintServiceTest` expectations to include the "Total size" column and add a unit test `processSources_processingStatisticsDisabled_logsDebugCompletionSummary` in `SrcProcessorTest` that asserts the compact debug summary is logged when full stats are disabled.

### Testing
- Ran unit tests via the Maven test suite; updated and new tests executed successfully.
- New test `processSources_processingStatisticsDisabled_logsDebugCompletionSummary` verifies the debug summary is emitted and passed.
- Updated `ProcessingStatisticsPrintServiceTest.render_containsPseudoTableAndMultilineUnexpectedErrorList` passed with the new "Total size" expectation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc213af1d48325a605a4bb2b19ee46)