### PR TITLE
build: bump SpotBugs Maven plugin to 4.9.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <pmd.version>7.23.0</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
-        <spotbugs-maven-plugin.version>4.9.8.2</spotbugs-maven-plugin.version>
+        <spotbugs-maven-plugin.version>4.9.8.3</spotbugs-maven-plugin.version>
         <spotbugs.version>4.9.8</spotbugs.version>
         <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
     </properties>


### PR DESCRIPTION
### Motivation
- Keep build tooling up-to-date by updating Maven plugins to their latest stable releases and verify related transitive constraints (Palantir formatter/Jackson BOM). 

### Description
- Bumped `spotbugs-maven-plugin.version` in the parent `pom.xml` from `4.9.8.2` to `4.9.8.3`.

### Testing
- Ran `mvn -DskipTests versions:display-property-updates versions:display-dependency-updates versions:display-plugin-updates` and validated available updates; the change was applied. 
- Ran `mvn -DskipTests verify -Dskip-quality-gates` which completed successfully. 
- Queried Maven Central metadata for `com.palantir.javaformat:palantir-java-format`, `com.github.spotbugs:spotbugs-maven-plugin`, and `com.github.spotbugs:spotbugs` to confirm current releases (Palantir remains `2.90.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccf50f01dc83258ac2f31c13ec3c20)