### PR TITLE
CLI docs: add logging configuration, new CLI options, and TODO for logging-level controls

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -109,7 +109,7 @@ All commands share the same set of options (inherited from `BaseCommand`):
 
 | Option | Short | Required | Description |
 |---|---|---|---|
-| `--base-dir` | `-b` | yes | Root directory to scan for Java source files |
+| `--base-dir` | `-b` | no | Root directory to scan for Java source files (default: current directory) |
 | `--include` | `-i` | no | Glob patterns for files to include; repeat the option or pass a comma-separated list |
 | `--exclude` | `-e` | no | Glob patterns for files to exclude; repeat the option or pass a comma-separated list |
 | `--verbose` | `-v` | no | Enable DEBUG-level logging |

--- a/cli/README.md
+++ b/cli/README.md
@@ -113,6 +113,9 @@ All commands share the same set of options (inherited from `BaseCommand`):
 | `--include` | `-i` | no | Glob patterns for files to include; repeat the option or pass a comma-separated list |
 | `--exclude` | `-e` | no | Glob patterns for files to exclude; repeat the option or pass a comma-separated list |
 | `--verbose` | `-v` | no | Enable DEBUG-level logging |
+| `--config` | `-c` | no | Path to custom YAML configuration file merged over defaults |
+| `--no-backup` | `-B` | no | Disable `.bak` file creation even if enabled in config |
+| `--no-statistics` | `-S` | no | Disable final processing statistics output |
 
 Glob patterns follow the `java.nio.file.PathMatcher` `glob:` syntax,
 e.g. `**/*.java`, `**/generated/**`.
@@ -139,3 +142,70 @@ e.g. `**/*.java`, `**/generated/**`.
 
 Exit code `3` causes the step to fail, signalling that `restructure` needs to be
 run locally before pushing.
+
+## Logging configuration and startup overrides
+
+The CLI uses **SLF4J + Logback**:
+
+- API: `org.slf4j:slf4j-api`
+- Backend: `ch.qos.logback:logback-classic`
+- Default config file in this module: `cli/src/main/resources/logback.xml`
+
+By default, the root logger level is `INFO`.
+
+### 1) CLI switch: `--verbose` / `-v`
+
+For all functional commands (`restructure`, `check-all`, `check-fast`), passing
+`-v` (`--verbose`) raises the **root** log level to `DEBUG` at command start.
+This is the easiest way to get detailed diagnostics from the packaged JAR:
+
+```bash
+java -jar cli/target/jharmonizer-cli.jar check-fast \
+  -b src/main/java \
+  -i "**/*.java" \
+  -v
+```
+
+### 2) JVM startup key: `-Dlogback.configurationFile=...`
+
+Logback supports replacing the bundled logging config at startup using a JVM
+system property. This lets you override levels, appenders, and patterns without
+changing application code.
+
+Example custom config (`/tmp/jharmonizer-logback-debug.xml`):
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT"/>
+  </root>
+</configuration>
+```
+
+Run CLI with override:
+
+```bash
+java -Dlogback.configurationFile=/tmp/jharmonizer-logback-debug.xml \
+  -jar cli/target/jharmonizer-cli.jar check-all \
+  -b src/main/java \
+  -i "**/*.java"
+```
+
+### What is and is not supported now
+
+- ✅ Supported:
+  - `-v` / `--verbose` (built-in CLI option)
+  - `-Dlogback.configurationFile=...` (standard Logback startup override)
+- ⚠️ Not implemented in current bundled config:
+  - Dedicated env vars like `LOG_LEVEL=DEBUG`
+  - Dedicated JVM keys like `-Dapp.log.level=DEBUG`
+
+The latter can be added later by parameterizing `logback.xml` with custom
+properties, but the current file defines a fixed default root level (`INFO`),
+with `-v` as the built-in runtime switch.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -634,6 +634,52 @@ Add a dedicated Lombok analyzer/fixer:
 
 ---
 
+### 16. Flexible logging-level controls for CLI, wrappers, and public API (future version)
+
+#### Status
+- [ ] Not implemented (captured as a future product improvement)
+- [ ] Current behavior:
+  - CLI supports `-v/--verbose` (raises root logging to `DEBUG`)
+  - startup override is possible via backend-specific Logback configuration replacement
+  - there is no unified JHarmonizer-level logging settings surface shared across CLI, wrappers, and API
+
+#### Problem statement
+Logging verbosity control is currently split between CLI flags and backend-specific startup wiring.
+Integrators need a first-class, documented product surface to control logging consistently for:
+- CLI invocations in CI and local tooling,
+- external wrappers (for example Maven/Gradle/IDE integrations),
+- public `SrcProcessor` API embedding.
+
+#### Proposed solution (next version)
+Introduce a normalized logging settings model and expose it consistently across entry points:
+- CLI:
+  - `--log-level=<TRACE|DEBUG|INFO|WARN|ERROR>`
+  - optional subsystem-scoped overrides (for example `--log-level.<subsystem>=<level>`)
+- wrappers/plugins:
+  - equivalent configuration keys mapped to the same normalized settings
+- public API:
+  - explicit logging options in bootstrap/config DTOs for processor creation
+
+#### Expected benefits
+- Consistent behavior regardless of launch path (CLI, wrapper, or direct API).
+- Less dependence on backend-specific configuration files for common verbosity scenarios.
+- Easier support/debug workflows with reproducible logging setup.
+
+#### Non-goals
+- Do not add runtime hot-reload/dynamic log reconfiguration in the first step.
+- Do not hard-couple product-level config to one backend implementation detail.
+
+#### Implementation outline (when revisited)
+- [ ] Define backend-agnostic logging settings model in shared/core config.
+- [ ] Add CLI options for global and subsystem-level logging overrides.
+- [ ] Add wrapper-side mapping to the same normalized model.
+- [ ] Add public `SrcProcessor` bootstrap/config API support.
+- [ ] Implement precedence rules (defaults < file < wrapper/API/CLI override).
+- [ ] Add tests for merging/precedence and deterministic output.
+- [ ] Document end-user recipes for CLI and embedding scenarios.
+
+---
+
 ## Technical debt / stabilization backlog
 
 ### 1. Blank-final nearest-provider edge cases still not covered by active E2E


### PR DESCRIPTION
### Motivation

- Make CLI logging behavior and startup overrides discoverable for integrators and CI users. 
- Surface new runtime options to control config file, backups, and statistics without digging in code. 
- Capture a planned roadmap item to unify logging controls across CLI, wrappers, and public API. 

### Description

- Extend `cli/README.md` with a new "Logging configuration and startup overrides" section that documents SLF4J/Logback usage, the default root level, the `--verbose` (`-v`) switch, and the `-Dlogback.configurationFile=...` JVM override, including examples. 
- Add three CLI options to the options table in the README: `--config` (`-c`), `--no-backup` (`-B`), and `--no-statistics` (`-S`). 
- Document supported and unsupported logging override techniques and recommended usage patterns for packaged JAR and custom Logback config. 
- Add a new TODO entry in `docs/TODO.md` describing a future work item for a normalized, cross-entry-point logging-level control surface for CLI, wrappers, and the public API. 

### Testing

- No automated tests were modified or required for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ccfcb9186083259ba51efe55c171c0)