### PR TITLE
Use `isEmpty()` assertions for absent rootMemberGroups and remove unused import in tests

### DIFF
--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizerFlexible2FlexibleUnifiedConverterTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/JHarmonizerFlexible2FlexibleUnifiedConverterTest.java
@@ -4,13 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.lemon_ant.jharmonizer.core.config.input.jharmonizer.model.JHarmonizerFlexibleConfig;
 import io.github.lemon_ant.jharmonizer.core.config.unified.FlexibleUnifiedConfig;
-import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class JHarmonizerFlexible2FlexibleUnifiedConverterTest {
 
     @Test
-    void convert2FlexibleUnified_memberGroupsMissing_keepsRootMemberGroupsEmpty() {
+    void convert2FlexibleUnified_memberGroupsMissing_keepsRootMemberGroupsAbsent() {
         // Given
         JHarmonizerFlexibleConfig vendorConfig = new JHarmonizerFlexibleConfig(null, null, null, null, null, null);
 
@@ -19,6 +18,6 @@ class JHarmonizerFlexible2FlexibleUnifiedConverterTest {
                 JHarmonizerFlexible2FlexibleUnifiedConverter.convert2FlexibleUnified(vendorConfig);
 
         // Then
-        assertThat(unifiedConfig.getRootMemberGroups()).contains(List.of());
+        assertThat(unifiedConfig.getRootMemberGroups()).isEmpty();
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
@@ -235,7 +235,7 @@ class UnifiedConfigMergerTest {
     }
 
     @Test
-    void merge_flexibleRootGroupsMissingOnBothSides_keepsRootMemberGroupsEmpty() {
+    void merge_flexibleRootGroupsMissingOnBothSides_keepsRootMemberGroupsAbsent() {
         // Given
         FlexibleUnifiedConfig baselineConfig = FlexibleUnifiedConfig.builder().build();
         FlexibleUnifiedConfig overlayConfig = FlexibleUnifiedConfig.builder().build();
@@ -244,7 +244,7 @@ class UnifiedConfigMergerTest {
         FlexibleUnifiedConfig mergedConfig = UnifiedConfigMerger.merge(baselineConfig, overlayConfig);
 
         // Then
-        assertThat(mergedConfig.getRootMemberGroups()).contains(List.of());
+        assertThat(mergedConfig.getRootMemberGroups()).isEmpty();
     }
 
     @NonNull


### PR DESCRIPTION
### Motivation
- Tests should assert that missing `rootMemberGroups` are absent (empty) using a direct `isEmpty()` assertion rather than checking for an empty `List.of()` match, and unused imports should be removed.

### Description
- Renamed tests to reflect that missing root member groups are "absent" and updated assertions from `contains(List.of())` to `isEmpty()` in `JHarmonizerFlexible2FlexibleUnifiedConverterTest` and `UnifiedConfigMergerTest`.
- Removed the now-unused `java.util.List` import from `JHarmonizerFlexible2FlexibleUnifiedConverterTest`.

### Testing
- Ran the updated unit tests `JHarmonizerFlexible2FlexibleUnifiedConverterTest` and `UnifiedConfigMergerTest`, and they passed. 
- Ran the project unit test suite and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd00fc69f883259212eb33ce3dffaf)