### PR TITLE
Add debug message at sorting stage start

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/Sorter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/Sorter.java
@@ -30,6 +30,7 @@ public final class Sorter {
      */
     @NonNull
     public SortingResult sort(@NonNull SpoonAstModel spoonAstModel) {
+        log.debug("Sorting {}", spoonAstModel.getPath());
         StopWatch.TimedResult<SpoonAstModel> sortingResult = StopWatch.measure(() -> {
             spoonSorter.sortCompilationUnitRecursively(
                     spoonAstModel.getCompilationUnit(),


### PR DESCRIPTION
### Motivation
- Парсинг и сериализация уже логируются, но начало этапа сортировки не видно в логах, поэтому нужно добавить явное debug-сообщение перед выполнением сортировки.

### Description
- Добавлен `log.debug("Sorting {}", spoonAstModel.getPath())` в метод `Sorter.sort(...)` (файл `core/src/main/java/io/github/lemon_ant/jharmonizer/core/sorter/Sorter.java`) чтобы явно фиксировать старт sorting-фазы.

### Testing
- Запущена команда `mvn -pl core -DskipITs test`, которая в этом окружении завершилась ошибкой резолва внешней зависимости (HTTP 502 при загрузке `org.jspecify:jspecify:1.0.0`), поэтому модульные тесты не могли завершиться из‑за внешней ошибки, а не из‑за изменений в коде.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd18286a1c83258f9d8af0344a8e56)