### PR TITLE
Support inherited group options (separator, ordering-rules, keepAccessorsTogether) and make ordering-rules optional

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/CompiledMemberGroup.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/CompiledMemberGroup.java
@@ -11,7 +11,6 @@ import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
-import org.apache.commons.lang3.Validate;
 
 /**
  * Tree node with precompiled include/exclude blocks and children.
@@ -58,7 +57,6 @@ public class CompiledMemberGroup {
         this.selectorBlock = selectorBlock;
 
         this.separator = separator;
-        Validate.notEmpty(orderingRules, "Ordering rules collection cannot be empty");
         this.orderingRules = Collections.unmodifiableList(orderingRules);
     }
 

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/MemberGroupCompiler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/MemberGroupCompiler.java
@@ -1,11 +1,17 @@
 package io.github.lemon_ant.jharmonizer.core.config.compiled;
 
+import io.github.lemon_ant.jharmonizer.core.config.unified.MemberDescriptor;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedMemberGroup;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedMemberGroupSelectorBlock;
+import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedOrderingRule;
+import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedSeparator;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import lombok.NonNull;
+import lombok.Value;
 import lombok.experimental.UtilityClass;
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -20,8 +26,11 @@ class MemberGroupCompiler {
     static List<CompiledMemberGroup> compileTopLevelGroups(@NonNull List<UnifiedMemberGroup> unifiedRoots) {
         int currentIndex = 0;
         List<CompiledMemberGroup> compiledRoots = new ArrayList<>(unifiedRoots.size());
+        GroupInheritanceContext rootInheritanceContext =
+                new GroupInheritanceContext(false, UnifiedSeparator.NONE, Collections.emptyList());
         for (UnifiedMemberGroup unifiedRoot : unifiedRoots) {
-            Pair<CompiledMemberGroup, Integer> rootResult = compileGroupRecursively(unifiedRoot, currentIndex, false);
+            Pair<CompiledMemberGroup, Integer> rootResult =
+                    compileGroupRecursively(unifiedRoot, currentIndex, rootInheritanceContext);
             compiledRoots.add(rootResult.getLeft());
             currentIndex = rootResult.getRight();
         }
@@ -36,17 +45,19 @@ class MemberGroupCompiler {
      */
     @NonNull
     private static Pair<CompiledMemberGroup, Integer> compileGroupRecursively(
-            UnifiedMemberGroup unifiedGroup, int startIndex, boolean inheritedKeepAccessorsTogether) {
+            UnifiedMemberGroup unifiedGroup, int startIndex, GroupInheritanceContext inheritedContext) {
         int runningIndex = startIndex;
 
         // 1) Build children first (DFS), threading the index forward
         List<CompiledMemberGroup> compiledChildren =
                 new ArrayList<>(unifiedGroup.getMemberSubGroups().size());
-        boolean keepAccessorsTogether =
-                Optional.ofNullable(unifiedGroup.getKeepAccessorsTogether()).orElse(inheritedKeepAccessorsTogether);
+        GroupInheritanceContext effectiveContext = resolveEffectiveContext(unifiedGroup, inheritedContext);
+        boolean keepAccessorsTogether = effectiveContext.isKeepAccessorsTogether();
+        UnifiedSeparator separator = effectiveContext.getSeparator();
+        List<UnifiedOrderingRule> effectiveOrderingRules = effectiveContext.getOrderingRules();
         for (UnifiedMemberGroup unifiedChild : unifiedGroup.getMemberSubGroups()) {
             Pair<CompiledMemberGroup, Integer> childResult =
-                    compileGroupRecursively(unifiedChild, runningIndex, keepAccessorsTogether);
+                    compileGroupRecursively(unifiedChild, runningIndex, effectiveContext);
             compiledChildren.add(childResult.getLeft());
             runningIndex = childResult.getRight(); // advance by everything created inside the child
         }
@@ -54,8 +65,7 @@ class MemberGroupCompiler {
         // 2) Compile selector/sorting for the current node (whatever your project uses)
         CompiledMemberGroupSelectorBlock compiledMemberGroupSelectorBlock =
                 compileSelectorBlock(unifiedGroup.getSelectorBlock());
-        List<OrderingRule> compiledOrderingRules =
-                OrderingRuleCompiler.compileOrderingRules(unifiedGroup.getOrderingRules());
+        List<OrderingRule> compiledOrderingRules = OrderingRuleCompiler.compileOrderingRules(effectiveOrderingRules);
 
         // 3) Assign post-order index to THIS node and advance index
         int assignedPostOrderIndex = runningIndex;
@@ -69,7 +79,7 @@ class MemberGroupCompiler {
                 .keepAccessorsTogether(keepAccessorsTogether)
                 .compiledSubGroups(compiledChildren)
                 .orderIndex(assignedPostOrderIndex)
-                .separator(unifiedGroup.getSeparator())
+                .separator(separator)
                 .build();
 
         // 5) Return pair: (group, next index after this node)
@@ -79,12 +89,37 @@ class MemberGroupCompiler {
     @NonNull
     private static CompiledMemberGroupSelectorBlock compileSelectorBlock(
             UnifiedMemberGroupSelectorBlock selectorBlock) {
-        var includes = selectorBlock.getIncludes().stream()
+        List<Predicate<MemberDescriptor>> includes = selectorBlock.getIncludes().stream()
                 .map(MemberGroupRuleLineCompiler::compileRuleLine)
                 .toList();
-        var excludes = selectorBlock.getExcludes().stream()
+        List<Predicate<MemberDescriptor>> excludes = selectorBlock.getExcludes().stream()
                 .map(MemberGroupRuleLineCompiler::compileRuleLine)
                 .toList();
         return new CompiledMemberGroupSelectorBlock(includes, excludes);
+    }
+
+    @NonNull
+    private static GroupInheritanceContext resolveEffectiveContext(
+            UnifiedMemberGroup unifiedGroup, GroupInheritanceContext inheritedContext) {
+        boolean keepAccessorsTogether = Optional.ofNullable(unifiedGroup.getKeepAccessorsTogether())
+                .orElse(inheritedContext.isKeepAccessorsTogether());
+        UnifiedSeparator separator =
+                Optional.ofNullable(unifiedGroup.getSeparator()).orElse(inheritedContext.getSeparator());
+        List<UnifiedOrderingRule> orderingRules =
+                Optional.ofNullable(unifiedGroup.getOrderingRules()).orElse(inheritedContext.getOrderingRules());
+        List<UnifiedOrderingRule> normalizedOrderingRules =
+                orderingRules == null ? Collections.emptyList() : orderingRules;
+        return new GroupInheritanceContext(keepAccessorsTogether, separator, normalizedOrderingRules);
+    }
+
+    @Value
+    private static final class GroupInheritanceContext {
+        boolean keepAccessorsTogether;
+
+        @NonNull
+        UnifiedSeparator separator;
+
+        @NonNull
+        List<UnifiedOrderingRule> orderingRules;
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/MemberGroupCompiler.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/compiled/MemberGroupCompiler.java
@@ -107,9 +107,7 @@ class MemberGroupCompiler {
                 Optional.ofNullable(unifiedGroup.getSeparator()).orElse(inheritedContext.getSeparator());
         List<UnifiedOrderingRule> orderingRules =
                 Optional.ofNullable(unifiedGroup.getOrderingRules()).orElse(inheritedContext.getOrderingRules());
-        List<UnifiedOrderingRule> normalizedOrderingRules =
-                orderingRules == null ? Collections.emptyList() : orderingRules;
-        return new GroupInheritanceContext(keepAccessorsTogether, separator, normalizedOrderingRules);
+        return new GroupInheritanceContext(keepAccessorsTogether, separator, orderingRules);
     }
 
     @Value

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/MemberGroupMapper.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/MemberGroupMapper.java
@@ -7,6 +7,7 @@ import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedMemberGroup.Un
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedMemberGroupSelectorBlock;
 import io.github.lemon_ant.jharmonizer.core.config.unified.UnifiedOrderingRule;
 import java.util.List;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 
@@ -33,16 +34,20 @@ final class MemberGroupMapper {
                 .forEach(selectorBlockBuilder::exclude);
         UnifiedMemberGroupSelectorBlock selectorBlock = selectorBlockBuilder.build();
 
-        List<UnifiedOrderingRule> orderingRules = srcMemberGroup.getOrderingRules().stream()
-                .map(JHarmonizerOrderingRule::getUnifiedOrderingRule)
-                .toList();
+        List<UnifiedOrderingRule> orderingRules = Optional.ofNullable(srcMemberGroup.getOrderingRules())
+                .map(rawRules -> rawRules.stream()
+                        .map(JHarmonizerOrderingRule::getUnifiedOrderingRule)
+                        .toList())
+                .orElse(null);
 
         UnifiedMemberGroupBuilder unifiedMemberGroupBuilder = UnifiedMemberGroup.builder()
                 .groupName(srcMemberGroup.getName())
                 .selectorBlock(selectorBlock)
                 .orderingRules(orderingRules)
                 .keepAccessorsTogether(srcMemberGroup.getKeepAccessorsTogether())
-                .separator(srcMemberGroup.getSeparator().getUnifiedSeparator());
+                .separator(Optional.ofNullable(srcMemberGroup.getSeparator())
+                        .map(separator -> separator.getUnifiedSeparator())
+                        .orElse(null));
 
         srcMemberGroup.getMemberSubGroups().stream()
                 .map(MemberGroupMapper::map)

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerMemberGroup.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/JHarmonizerMemberGroup.java
@@ -10,7 +10,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import lombok.Builder;
 import lombok.NonNull;
@@ -46,10 +45,10 @@ public class JHarmonizerMemberGroup implements Serializable {
     @NonNull
     String name;
 
-    @NonNull
+    @Nullable
     JHarmonizerSeparator separator;
 
-    @NonNull
+    @Nullable
     List<JHarmonizerOrderingRule> orderingRules;
 
     @Builder
@@ -61,9 +60,7 @@ public class JHarmonizerMemberGroup implements Serializable {
                     Set<Set<String>> includes,
             @Nullable @JsonDeserialize(using = SelectorsDeserializer.class) @JsonProperty(value = "excludes")
                     Set<Set<String>> excludes,
-            @NonNull
-                    @JsonDeserialize(using = OrderingRulesDeserializer.class)
-                    @JsonProperty(value = "ordering-rules", required = true)
+            @Nullable @JsonDeserialize(using = OrderingRulesDeserializer.class) @JsonProperty(value = "ordering-rules")
                     List<JHarmonizerOrderingRule> orderingRules,
             @Nullable @JsonProperty(value = "separator") JHarmonizerSeparator separator,
             @Nullable @JsonProperty(value = "keepAccessorsTogether") Boolean keepAccessorsTogether,
@@ -75,41 +72,14 @@ public class JHarmonizerMemberGroup implements Serializable {
 
         this.excludes = ofNullable(excludes).map(Collections::unmodifiableSet).orElse(Set.of());
 
-        Validate.notEmpty(orderingRules, "ordering-rules cannot be empty");
-        this.orderingRules = Collections.unmodifiableList(orderingRules);
+        this.orderingRules =
+                ofNullable(orderingRules).map(Collections::unmodifiableList).orElse(null);
 
-        this.separator = ofNullable(separator).orElse(JHarmonizerSeparator.NONE);
+        this.separator = separator;
 
         this.keepAccessorsTogether = keepAccessorsTogether;
 
         this.memberSubGroups =
                 ofNullable(memberSubGroups).map(Collections::unmodifiableList).orElse(List.of());
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof JHarmonizerMemberGroup that)) {
-            return false;
-        }
-
-        return Objects.equals(keepAccessorsTogether, that.keepAccessorsTogether)
-                && name.equals(that.name)
-                && includes.equals(that.includes)
-                && excludes.equals(that.excludes)
-                && orderingRules.equals(that.orderingRules)
-                && separator == that.separator
-                && memberSubGroups.equals(that.memberSubGroups);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = name.hashCode();
-        result = 31 * result + includes.hashCode();
-        result = 31 * result + excludes.hashCode();
-        result = 31 * result + orderingRules.hashCode();
-        result = 31 * result + separator.hashCode();
-        result = 31 * result + Objects.hashCode(keepAccessorsTogether);
-        result = 31 * result + memberSubGroups.hashCode();
-        return result;
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/OrderingRulesDeserializer.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/model/OrderingRulesDeserializer.java
@@ -25,7 +25,6 @@ class OrderingRulesDeserializer extends JsonDeserializer<List<JHarmonizerOrderin
      * @return the resulting list
      */
     @Override
-    @SuppressWarnings("PMD.CyclomaticComplexity")
     @NonNull
     public List<JHarmonizerOrderingRule> deserialize(@NonNull JsonParser p, @NonNull DeserializationContext ctxt)
             throws IOException {
@@ -48,10 +47,6 @@ class OrderingRulesDeserializer extends JsonDeserializer<List<JHarmonizerOrderin
             }
         } else {
             throw new IOException("Unsupported sorting entry: " + node);
-        }
-
-        if (result.isEmpty()) {
-            throw new IOException("UnifiedOrderingRule list cannot be empty");
         }
 
         return Collections.unmodifiableList(result);

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedMemberGroup.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedMemberGroup.java
@@ -1,5 +1,7 @@
 package io.github.lemon_ant.jharmonizer.core.config.unified;
 
+import static java.util.Optional.ofNullable;
+
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
@@ -65,6 +67,7 @@ public class UnifiedMemberGroup {
         this.memberSubGroups = memberSubGroups;
         this.selectorBlock = selectorBlock;
         this.separator = separator;
-        this.orderingRules = orderingRules == null ? null : Collections.unmodifiableList(orderingRules);
+        this.orderingRules =
+                ofNullable(orderingRules).map(Collections::unmodifiableList).orElse(null);
     }
 }

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedMemberGroup.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedMemberGroup.java
@@ -3,12 +3,10 @@ package io.github.lemon_ant.jharmonizer.core.config.unified;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Singular;
 import lombok.Value;
-import org.apache.commons.lang3.Validate;
 
 /**
  * A group node in the classification tree. Children are ordered. Includes/Excludes carry OR semantics across rule lines.
@@ -45,13 +43,13 @@ public class UnifiedMemberGroup {
     /**
      * Separator directive propagated from vendor config and used at the rendering stage.
      */
-    @NonNull
+    @Nullable
     UnifiedSeparator separator;
 
     /**
      * Explicit internal members ordering for this group.
      */
-    @NonNull
+    @Nullable
     List<UnifiedOrderingRule> orderingRules;
 
     @Builder
@@ -60,39 +58,13 @@ public class UnifiedMemberGroup {
             @Nullable Boolean keepAccessorsTogether,
             @NonNull @Singular List<@NonNull UnifiedMemberGroup> memberSubGroups,
             @NonNull UnifiedMemberGroupSelectorBlock selectorBlock,
-            @NonNull UnifiedSeparator separator,
-            @NonNull @Singular List<@NonNull UnifiedOrderingRule> orderingRules) {
+            @Nullable UnifiedSeparator separator,
+            @Nullable List<@NonNull UnifiedOrderingRule> orderingRules) {
         this.groupName = groupName;
         this.keepAccessorsTogether = keepAccessorsTogether;
         this.memberSubGroups = memberSubGroups;
         this.selectorBlock = selectorBlock;
         this.separator = separator;
-        Validate.notEmpty(orderingRules, "Ordering rules collection cannot be empty");
-        this.orderingRules = Collections.unmodifiableList(orderingRules);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof UnifiedMemberGroup that)) {
-            return false;
-        }
-
-        return Objects.equals(groupName, that.groupName)
-                && Objects.equals(keepAccessorsTogether, that.keepAccessorsTogether)
-                && memberSubGroups.equals(that.memberSubGroups)
-                && selectorBlock.equals(that.selectorBlock)
-                && separator == that.separator
-                && orderingRules.equals(that.orderingRules);
-    }
-
-    @Override
-    public int hashCode() {
-        int result = Objects.hashCode(groupName);
-        result = 31 * result + Objects.hashCode(keepAccessorsTogether);
-        result = 31 * result + memberSubGroups.hashCode();
-        result = 31 * result + selectorBlock.hashCode();
-        result = 31 * result + separator.hashCode();
-        result = 31 * result + orderingRules.hashCode();
-        return result;
+        this.orderingRules = orderingRules == null ? null : Collections.unmodifiableList(orderingRules);
     }
 }

--- a/core/src/main/resources/default-config.yml
+++ b/core/src/main/resources/default-config.yml
@@ -199,13 +199,9 @@ type-members-ordering:
         includes: field
         groups:
           - name: Static fields
-            separator: new-line
-            ordering-rules: [ visibility-desc, alpha ]
             includes: static
             groups:
               - name: Static final fields
-                separator: new-line
-                ordering-rules: [ visibility-desc, alpha ]
                 includes: final
                 groups:
                   - name: serialVersionUID
@@ -219,8 +215,6 @@ type-members-ordering:
                     includes: [ '~(?i)(log|.*logger)$' ]
 
           - name: Instance final fields
-            separator: new-line
-            ordering-rules: [ visibility-desc, alpha ]
             includes: final
 
       - name: Initializers
@@ -229,13 +223,9 @@ type-members-ordering:
         includes: [ initializer ]
         groups:
           - name: Static initializers
-            separator: none
-            ordering-rules: preserve
             includes: [ static, initializer ]
 
           - name: Instance initializers
-            separator: none
-            ordering-rules: preserve
             includes: [ initializer ]
             excludes: static
 
@@ -248,83 +238,51 @@ type-members-ordering:
           - constructor
         groups:
           - name: Public
-            separator: none
-            ordering-rules: alpha
             includes: public
             groups:
               - name: Static methods
-                separator: none
-                ordering-rules: alpha
                 includes: [ method, static ]
 
               - name: Constructors
-                separator: none
-                ordering-rules: alpha
                 includes: constructor
 
               - name: Instance methods
-                separator: none
-                ordering-rules: alpha
                 includes: method
 
           - name: Protected
-            separator: none
-            ordering-rules: alpha
             includes: protected
             groups:
               - name: Static methods
-                separator: none
-                ordering-rules: alpha
                 includes: [ method, static ]
 
               - name: Constructors
-                separator: none
-                ordering-rules: alpha
                 includes: constructor
 
               - name: Instance methods
-                separator: none
-                ordering-rules: alpha
                 includes: method
 
           - name: Package-private
-            separator: none
-            ordering-rules: alpha
             includes: package-private
             groups:
               - name: Static methods
-                separator: none
-                ordering-rules: alpha
                 includes: [ method, static ]
 
               - name: Constructors
-                separator: none
-                ordering-rules: alpha
                 includes: constructor
 
               - name: Instance methods
-                separator: none
-                ordering-rules: alpha
                 includes: method
 
           - name: Private
-            separator: none
-            ordering-rules: alpha
             includes: private
             groups:
               - name: Static methods
-                separator: none
-                ordering-rules: alpha
                 includes: [ method, static ]
 
               - name: Constructors
-                separator: none
-                ordering-rules: alpha
                 includes: constructor
 
               - name: Instance methods
-                separator: none
-                ordering-rules: alpha
                 includes: method
 
       - name: Nested types
@@ -338,73 +296,49 @@ type-members-ordering:
           - class
         groups:
           - name: Public
-            separator: new-line
-            ordering-rules: alpha
             includes: public
             groups:
               - name: Annotations and Interfaces
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - annotation
                   - interface
               - name: Classes, Enums, and Records
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - class
                   - enum
                   - record
           - name: Protected
-            separator: new-line
-            ordering-rules: alpha
             includes: protected
             groups:
               - name: Annotations and Interfaces
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - annotation
                   - interface
               - name: Classes, Enums, and Records
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - class
                   - enum
                   - record
           - name: Package-private
-            separator: new-line
-            ordering-rules: alpha
             includes: package-private
             groups:
               - name: Annotations and Interfaces
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - annotation
                   - interface
               - name: Classes, Enums, and Records
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - class
                   - enum
                   - record
           - name: Private
-            separator: new-line
-            ordering-rules: alpha
             includes: private
             groups:
               - name: Annotations and Interfaces
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - annotation
                   - interface
               - name: Classes, Enums, and Records
-                separator: new-line
-                ordering-rules: alpha
                 includes:
                   - class
                   - enum

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/OptOutSrcProcessorIntegrationTest.java
@@ -331,7 +331,7 @@ class OptOutSrcProcessorIntegrationTest {
                 .groupName("Root")
                 .selectorBlock(UnifiedMemberGroupSelectorBlock.builder().build())
                 .separator(UnifiedSeparator.NONE)
-                .orderingRule(UnifiedOrderingRule.ALPHA)
+                .orderingRules(List.of(UnifiedOrderingRule.ALPHA))
                 .build();
         UnifiedTopLevelTypesOrdering topLevelTypesOrdering = UnifiedTopLevelTypesOrdering.builder()
                 .mainTypeFirst(false)

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/compiled/MemberGroupCompilerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/compiled/MemberGroupCompilerTest.java
@@ -110,10 +110,87 @@ class MemberGroupCompilerTest {
                 .containsExactly(OrderingRule.VISIBILITY_DESC, OrderingRule.ALPHA, OrderingRule.PRESERVE);
     }
 
+    @Test
+    void compileTopLevelGroups_separator_isInheritedAndCanBeOverridden() {
+        // Given
+        UnifiedMemberGroup inheritedChild = createGroup("InheritedChild", null, null, List.of(), null);
+        UnifiedMemberGroup overriddenChild = createGroup(
+                "OverriddenChild", null, UnifiedSeparator.HEADER, List.of(), List.of(UnifiedOrderingRule.ALPHA));
+        UnifiedMemberGroup root = createGroup(
+                "Root",
+                null,
+                UnifiedSeparator.NEW_LINE,
+                List.of(inheritedChild, overriddenChild),
+                List.of(UnifiedOrderingRule.ALPHA));
+
+        // When
+        CompiledMemberGroup compiledRoot =
+                MemberGroupCompiler.compileTopLevelGroups(List.of(root)).getFirst();
+
+        // Then
+        CompiledMemberGroup compiledInheritedChild =
+                compiledRoot.getCompiledSubGroups().getFirst();
+        CompiledMemberGroup compiledOverriddenChild =
+                compiledRoot.getCompiledSubGroups().get(1);
+        assertThat(compiledRoot.getSeparator()).isEqualTo(UnifiedSeparator.NEW_LINE);
+        assertThat(compiledInheritedChild.getSeparator()).isEqualTo(UnifiedSeparator.NEW_LINE);
+        assertThat(compiledOverriddenChild.getSeparator()).isEqualTo(UnifiedSeparator.HEADER);
+    }
+
+    @Test
+    void compileTopLevelGroups_orderingRules_areInheritedAndCanBeOverridden() {
+        // Given
+        List<UnifiedOrderingRule> parentOrderingRules = List.of(UnifiedOrderingRule.ALPHA);
+        List<UnifiedOrderingRule> childOrderingRules = List.of(UnifiedOrderingRule.PRESERVE);
+        UnifiedMemberGroup inheritedChild = createGroup("InheritedChild", null, null, List.of(), null);
+        UnifiedMemberGroup overriddenChild = createGroup("OverriddenChild", null, null, List.of(), childOrderingRules);
+        UnifiedMemberGroup root = createGroup(
+                "Root", null, UnifiedSeparator.NONE, List.of(inheritedChild, overriddenChild), parentOrderingRules);
+
+        // When
+        CompiledMemberGroup compiledRoot =
+                MemberGroupCompiler.compileTopLevelGroups(List.of(root)).getFirst();
+
+        // Then
+        CompiledMemberGroup compiledInheritedChild =
+                compiledRoot.getCompiledSubGroups().getFirst();
+        CompiledMemberGroup compiledOverriddenChild =
+                compiledRoot.getCompiledSubGroups().get(1);
+        assertThat(compiledRoot.getOrderingRules()).containsExactly(OrderingRule.ALPHA);
+        assertThat(compiledInheritedChild.getOrderingRules()).containsExactly(OrderingRule.ALPHA);
+        assertThat(compiledOverriddenChild.getOrderingRules()).containsExactly(OrderingRule.PRESERVE);
+    }
+
+    @Test
+    void compileTopLevelGroups_orderingRules_emptyList_isAllowed() {
+        // Given
+        UnifiedMemberGroup child = createGroup("Child", null, null, List.of(), null);
+        UnifiedMemberGroup root = createGroup("Root", null, UnifiedSeparator.NONE, List.of(child), List.of());
+
+        // When
+        CompiledMemberGroup compiledRoot =
+                MemberGroupCompiler.compileTopLevelGroups(List.of(root)).getFirst();
+
+        // Then
+        CompiledMemberGroup compiledChild = compiledRoot.getCompiledSubGroups().getFirst();
+        assertThat(compiledRoot.getOrderingRules()).isEmpty();
+        assertThat(compiledChild.getOrderingRules()).isEmpty();
+    }
+
     @NonNull
     private static UnifiedMemberGroup createGroup(
             String groupName,
             Boolean keepAccessorsTogether,
+            List<UnifiedMemberGroup> memberSubGroups,
+            List<UnifiedOrderingRule> orderingRules) {
+        return createGroup(groupName, keepAccessorsTogether, UnifiedSeparator.NONE, memberSubGroups, orderingRules);
+    }
+
+    @NonNull
+    private static UnifiedMemberGroup createGroup(
+            String groupName,
+            Boolean keepAccessorsTogether,
+            UnifiedSeparator separator,
             List<UnifiedMemberGroup> memberSubGroups,
             List<UnifiedOrderingRule> orderingRules) {
         UnifiedMemberGroupSelectorBlock selectorBlock =
@@ -123,7 +200,7 @@ class MemberGroupCompilerTest {
                 .keepAccessorsTogether(keepAccessorsTogether)
                 .memberSubGroups(memberSubGroups)
                 .selectorBlock(selectorBlock)
-                .separator(UnifiedSeparator.NONE)
+                .separator(separator)
                 .orderingRules(orderingRules)
                 .build();
     }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/MemberGroupRuleLineTokenSemanticsTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/input/jharmonizer/converter/MemberGroupRuleLineTokenSemanticsTest.java
@@ -38,7 +38,7 @@ class MemberGroupRuleLineTokenSemanticsTest {
                 .groupName("StaticInitializers")
                 .selectorBlock(selectorBlock)
                 .separator(UnifiedSeparator.NONE)
-                .orderingRule(UnifiedOrderingRule.PRESERVE)
+                .orderingRules(List.of(UnifiedOrderingRule.PRESERVE))
                 .build();
         CompiledMemberGroup compiledRootGroup = compileSingleRootGroup(rootGroup);
         MemberDescriptor staticInitializerDescriptor = MemberDescriptor.builder()
@@ -69,7 +69,7 @@ class MemberGroupRuleLineTokenSemanticsTest {
                 .groupName("InstanceInitializers")
                 .selectorBlock(selectorBlock)
                 .separator(UnifiedSeparator.NONE)
-                .orderingRule(UnifiedOrderingRule.PRESERVE)
+                .orderingRules(List.of(UnifiedOrderingRule.PRESERVE))
                 .build();
         CompiledMemberGroup compiledRootGroup = compileSingleRootGroup(rootGroup);
         MemberDescriptor staticInitializerDescriptor = MemberDescriptor.builder()

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedConfigMergerTest.java
@@ -271,7 +271,7 @@ class UnifiedConfigMergerTest {
                 .memberSubGroups(memberSubGroups)
                 .selectorBlock(SELECTOR_BLOCK)
                 .separator(UnifiedSeparator.NONE)
-                .orderingRule(UnifiedOrderingRule.ALPHA)
+                .orderingRules(List.of(UnifiedOrderingRule.ALPHA))
                 .build();
     }
 }

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedMemberGroupTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/config/unified/UnifiedMemberGroupTest.java
@@ -2,6 +2,7 @@ package io.github.lemon_ant.jharmonizer.core.config.unified;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class UnifiedMemberGroupTest {
@@ -12,7 +13,7 @@ class UnifiedMemberGroupTest {
         UnifiedMemberGroup unifiedMemberGroup = UnifiedMemberGroup.builder()
                 .selectorBlock(UnifiedMemberGroupSelectorBlock.builder().build())
                 .separator(UnifiedSeparator.NONE)
-                .orderingRule(UnifiedOrderingRule.ALPHA)
+                .orderingRules(List.of(UnifiedOrderingRule.ALPHA))
                 .build();
 
         // Then

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonSorterTopLevelTypesOrderingTest.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/spoon/SpoonSorterTopLevelTypesOrderingTest.java
@@ -129,7 +129,7 @@ class SpoonSorterTopLevelTypesOrderingTest {
                 .groupName("Root")
                 .selectorBlock(UnifiedMemberGroupSelectorBlock.builder().build())
                 .separator(UnifiedSeparator.NONE)
-                .orderingRule(UnifiedOrderingRule.PRESERVE)
+                .orderingRules(List.of(UnifiedOrderingRule.PRESERVE))
                 .build();
         UnifiedConfig unifiedConfig = UnifiedConfig.builder()
                 .topLevelTypesOrdering(topLevelTypesOrdering)

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-jharmonizer-config.json
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-jharmonizer-config.json
@@ -18,7 +18,7 @@
       [ "@~.*Test$", "class" ]
     ],
     "excludes" : [ ],
-    "separator" : "NONE",
+    "separator" : null,
     "keepAccessorsTogether" : null,
     "memberSubGroups" : [ {
       "name" : "JUnit Fields",
@@ -128,7 +128,7 @@
       [ "@ConfigurationProperties" ]
     ],
     "excludes" : [ ],
-    "separator" : "NONE",
+    "separator" : null,
     "keepAccessorsTogether" : null,
     "memberSubGroups" : [ {
       "name" : "Serializable UID",
@@ -296,7 +296,7 @@
         [ "method", "=hashCode" ]
       ],
       "excludes" : [ ],
-      "separator" : "NONE",
+      "separator" : null,
       "keepAccessorsTogether" : null,
       "memberSubGroups" : [ ],
       "orderingRules" : [ "PRESERVE" ]
@@ -308,7 +308,7 @@
       [ "~.*" ]
     ],
     "excludes" : [ ],
-    "separator" : "NONE",
+    "separator" : null,
     "keepAccessorsTogether" : null,
     "memberSubGroups" : [ {
       "name" : "Record components",
@@ -344,7 +344,7 @@
           [ "static" ]
         ],
         "excludes" : [ ],
-        "separator" : "NEW_LINE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Static final fields",
@@ -352,7 +352,7 @@
             [ "final" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ {
             "name" : "serialVersionUID",
@@ -375,19 +375,19 @@
             "memberSubGroups" : [ ],
             "orderingRules" : [ "PRESERVE" ]
           } ],
-          "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Instance final fields",
         "includes" : [
           [ "final" ]
         ],
         "excludes" : [ ],
-        "separator" : "NEW_LINE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
+        "orderingRules" : null
       } ],
       "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
     }, {
@@ -404,10 +404,10 @@
           [ "static", "initializer" ]
         ],
         "excludes" : [ ],
-        "separator" : "NONE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "PRESERVE" ]
+        "orderingRules" : null
       }, {
         "name" : "Instance initializers",
         "includes" : [
@@ -416,10 +416,10 @@
         "excludes" : [
           [ "static" ]
         ],
-        "separator" : "NONE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ ],
-        "orderingRules" : [ "PRESERVE" ]
+        "orderingRules" : null
       } ],
       "orderingRules" : [ "PRESERVE" ]
     }, {
@@ -437,7 +437,7 @@
           [ "public" ]
         ],
         "excludes" : [ ],
-        "separator" : "NONE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Static methods",
@@ -445,39 +445,39 @@
             [ "static", "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Constructors",
           "includes" : [
             [ "constructor" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Instance methods",
           "includes" : [
             [ "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Protected",
         "includes" : [
           [ "protected" ]
         ],
         "excludes" : [ ],
-        "separator" : "NONE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Static methods",
@@ -485,39 +485,39 @@
             [ "static", "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Constructors",
           "includes" : [
             [ "constructor" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Instance methods",
           "includes" : [
             [ "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Package-private",
         "includes" : [
           [ "package-private" ]
         ],
         "excludes" : [ ],
-        "separator" : "NONE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Static methods",
@@ -525,39 +525,39 @@
             [ "static", "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Constructors",
           "includes" : [
             [ "constructor" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Instance methods",
           "includes" : [
             [ "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Private",
         "includes" : [
           [ "private" ]
         ],
         "excludes" : [ ],
-        "separator" : "NONE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Static methods",
@@ -565,32 +565,32 @@
             [ "static", "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Constructors",
           "includes" : [
             [ "constructor" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Instance methods",
           "includes" : [
             [ "method" ]
           ],
           "excludes" : [ ],
-          "separator" : "NONE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       } ],
       "orderingRules" : [ "ALPHA" ]
     }, {
@@ -611,7 +611,7 @@
           [ "public" ]
         ],
         "excludes" : [ ],
-        "separator" : "NEW_LINE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Annotations and Interfaces",
@@ -620,10 +620,10 @@
             [ "interface" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Classes, Enums, and Records",
           "includes" : [
@@ -632,19 +632,19 @@
             [ "enum" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Protected",
         "includes" : [
           [ "protected" ]
         ],
         "excludes" : [ ],
-        "separator" : "NEW_LINE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Annotations and Interfaces",
@@ -653,10 +653,10 @@
             [ "interface" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Classes, Enums, and Records",
           "includes" : [
@@ -665,19 +665,19 @@
             [ "enum" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Package-private",
         "includes" : [
           [ "package-private" ]
         ],
         "excludes" : [ ],
-        "separator" : "NEW_LINE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Annotations and Interfaces",
@@ -686,10 +686,10 @@
             [ "interface" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Classes, Enums, and Records",
           "includes" : [
@@ -698,19 +698,19 @@
             [ "enum" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       }, {
         "name" : "Private",
         "includes" : [
           [ "private" ]
         ],
         "excludes" : [ ],
-        "separator" : "NEW_LINE",
+        "separator" : null,
         "keepAccessorsTogether" : null,
         "memberSubGroups" : [ {
           "name" : "Annotations and Interfaces",
@@ -719,10 +719,10 @@
             [ "interface" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         }, {
           "name" : "Classes, Enums, and Records",
           "includes" : [
@@ -731,12 +731,12 @@
             [ "enum" ]
           ],
           "excludes" : [ ],
-          "separator" : "NEW_LINE",
+          "separator" : null,
           "keepAccessorsTogether" : null,
           "memberSubGroups" : [ ],
-          "orderingRules" : [ "ALPHA" ]
+          "orderingRules" : null
         } ],
-        "orderingRules" : [ "ALPHA" ]
+        "orderingRules" : null
       } ],
       "orderingRules" : [ "ALPHA" ]
     } ],

--- a/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-unified-config.json
+++ b/core/src/test/resources/test-cases/core/config/input/jharmonizer/expected-default-unified-config.json
@@ -227,7 +227,7 @@
         "nameMatcher" : null
       } ]
     },
-    "separator" : "NONE",
+    "separator" : null,
     "orderingRules" : [ "ALPHA" ]
   }, {
     "groupName" : "DTO and Entities",
@@ -564,7 +564,7 @@
           }
         } ]
       },
-      "separator" : "NONE",
+      "separator" : null,
       "orderingRules" : [ "PRESERVE" ]
     } ],
     "selectorBlock" : {
@@ -652,7 +652,7 @@
         "nameMatcher" : null
       } ]
     },
-    "separator" : "NONE",
+    "separator" : null,
     "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
   }, {
     "groupName" : "Default Rule",
@@ -747,8 +747,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -760,8 +760,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Instance final fields",
         "keepAccessorsTogether" : null,
@@ -776,8 +776,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NEW_LINE",
-        "orderingRules" : [ "VISIBILITY_DESC", "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -808,8 +808,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NONE",
-        "orderingRules" : [ "PRESERVE" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Instance initializers",
         "keepAccessorsTogether" : null,
@@ -830,8 +830,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NONE",
-        "orderingRules" : [ "PRESERVE" ]
+        "separator" : null,
+        "orderingRules" : null
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -865,8 +865,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Constructors",
           "keepAccessorsTogether" : null,
@@ -881,8 +881,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Instance methods",
           "keepAccessorsTogether" : null,
@@ -897,8 +897,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -910,8 +910,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NONE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Protected",
         "keepAccessorsTogether" : null,
@@ -929,8 +929,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Constructors",
           "keepAccessorsTogether" : null,
@@ -945,8 +945,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Instance methods",
           "keepAccessorsTogether" : null,
@@ -961,8 +961,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -974,8 +974,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NONE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Package-private",
         "keepAccessorsTogether" : null,
@@ -993,8 +993,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Constructors",
           "keepAccessorsTogether" : null,
@@ -1009,8 +1009,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Instance methods",
           "keepAccessorsTogether" : null,
@@ -1025,8 +1025,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -1038,8 +1038,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NONE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Private",
         "keepAccessorsTogether" : null,
@@ -1057,8 +1057,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Constructors",
           "keepAccessorsTogether" : null,
@@ -1073,8 +1073,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Instance methods",
           "keepAccessorsTogether" : null,
@@ -1089,8 +1089,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NONE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -1102,8 +1102,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NONE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -1149,8 +1149,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Classes, Enums, and Records",
           "keepAccessorsTogether" : null,
@@ -1177,8 +1177,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -1190,8 +1190,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NEW_LINE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Protected",
         "keepAccessorsTogether" : null,
@@ -1215,8 +1215,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Classes, Enums, and Records",
           "keepAccessorsTogether" : null,
@@ -1243,8 +1243,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -1256,8 +1256,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NEW_LINE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Package-private",
         "keepAccessorsTogether" : null,
@@ -1281,8 +1281,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Classes, Enums, and Records",
           "keepAccessorsTogether" : null,
@@ -1309,8 +1309,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -1322,8 +1322,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NEW_LINE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       }, {
         "groupName" : "Private",
         "keepAccessorsTogether" : null,
@@ -1347,8 +1347,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         }, {
           "groupName" : "Classes, Enums, and Records",
           "keepAccessorsTogether" : null,
@@ -1375,8 +1375,8 @@
               "nameMatcher" : null
             } ]
           },
-          "separator" : "NEW_LINE",
-          "orderingRules" : [ "ALPHA" ]
+          "separator" : null,
+          "orderingRules" : null
         } ],
         "selectorBlock" : {
           "excludes" : [ ],
@@ -1388,8 +1388,8 @@
             "nameMatcher" : null
           } ]
         },
-        "separator" : "NEW_LINE",
-        "orderingRules" : [ "ALPHA" ]
+        "separator" : null,
+        "orderingRules" : null
       } ],
       "selectorBlock" : {
         "excludes" : [ ],
@@ -1441,7 +1441,7 @@
         }
       } ]
     },
-    "separator" : "NONE",
+    "separator" : null,
     "orderingRules" : [ "PRESERVE" ]
   } ],
   "topLevelTypesOrdering" : {

--- a/docs/02-Configurator.md
+++ b/docs/02-Configurator.md
@@ -116,6 +116,17 @@ The merge is performed only for the **root member groups**, without recursive su
 
 This allows users to redefine only selected default root groups while keeping all untouched default groups and their original ordering.
 
+## Nested group inheritance semantics
+
+Inside a single `type-members-ordering` tree, nested groups inherit these options from their nearest parent when omitted:
+
+- `keepAccessorsTogether`
+- `separator`
+- `ordering-rules`
+
+If a child declares one of these options explicitly, that value overrides the inherited value for that child subtree.
+For `ordering-rules`, override is replace-based (the child list fully replaces inherited rules).
+
 ## Optional Configuration Sources Control
 
 For advanced usage, the configurator supports **optional control over which sources to include** when resolving the final configuration.

--- a/docs/config-dsl.md
+++ b/docs/config-dsl.md
@@ -140,6 +140,22 @@ Supported flags:
 
 * `keepAccessorsTogether`: Places getters/setters in the same group, even if named differently.
 
+### Group option inheritance (`type-members-ordering`)
+
+For nested member groups, the following options are inherited from the nearest parent that defines them:
+
+* `keepAccessorsTogether`
+* `separator`
+* `ordering-rules`
+
+Inheritance is resolved top-down in the group tree:
+
+* if a child omits an option, it inherits the parent's resolved value;
+* if a child defines an option explicitly, it overrides the inherited value for its subtree.
+
+For `ordering-rules`, an explicit child value fully replaces the inherited list.
+An empty `ordering-rules: []` is allowed and means “no explicit sort keys at this level”.
+
 ---
 
 ## 🔹 Example: Full Configuration

--- a/docs/default-rule-ordering-rule.md
+++ b/docs/default-rule-ordering-rule.md
@@ -19,6 +19,7 @@ Default Rule (fallback root group)
 │  └─ 2.2) Instance initializers — preserve/source order
 ├─ 3) Methods (including constructors)
 │  ├─ note: keepAccessorsTogether = ON (applied here; inherited by all subgroups)
+│  ├─ note: separator/order rules can also be inherited by subgroups when omitted
 │  ├─ 3.1) Public
 │  │  ├─ Static methods — sort: ALPHA
 │  │  ├─ Constructors — sort: ALPHA
@@ -103,6 +104,7 @@ When a member kind has no stable ALPHA key (e.g., initializer blocks), order is 
 ### Accessor co-location
 
 For the **Methods** subtree, `keepAccessorsTogether = ON` is applied at the group level so it is inherited by all nested method subgroups.
+The same inheritance mechanism applies to group `separator` and `ordering-rules` when nested groups omit them.
 
 ## Non-negotiable constraints
 


### PR DESCRIPTION
- [x] Investigate `OrderingRulesDeserializer` empty-list rejection
- [x] Remove the empty-list validation that blocks `ordering-rules: []` deserialization
- [x] Remove now-unnecessary `@SuppressWarnings("PMD.CyclomaticComplexity")` annotation
- [x] Fix PMD `NullAssignment` in `UnifiedMemberGroup` using `ofNullable(...).map(...).orElse(null)` pattern (consistent with `JHarmonizerMemberGroup`)
- [x] All 7 targeted tests pass; no new PMD/CodeQL issues introduced