### PR TITLE
Fix enum member boundary detection for enum constants with multi-line lambda bodies

### DIFF
--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/EnumMemberStartCorrectionResolver.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/EnumMemberStartCorrectionResolver.java
@@ -13,6 +13,15 @@ import spoon.reflect.declaration.CtTypeMember;
 @UtilityClass
 final class EnumMemberStartCorrectionResolver {
 
+    /**
+     * Resolves corrected source-start positions for enum members whose Spoon-reported start is offset
+     * into a preceding lambda body. Only the first enum member (by source position) is examined; if its
+     * Spoon-reported start falls inside a lambda, the corrected position is returned in the map.
+     *
+     * @param srcCode             the full original source code of the compilation unit
+     * @param explicitTypeMembers the list of explicitly declared enum type members (must not be empty)
+     * @return a map from member to its corrected start index, or an empty map when no correction is needed
+     */
     @NonNull
     static Map<CtTypeMember, Integer> resolveCorrectedStarts(
             @NonNull String srcCode, @NonNull List<CtTypeMember> explicitTypeMembers) {
@@ -49,9 +58,9 @@ final class EnumMemberStartCorrectionResolver {
                 char previous = findPreviousNonWhitespace(chars, index - 1);
                 char next = findNextNonWhitespace(chars, index + 1);
                 if (Character.isLetterOrDigit(previous) && Character.isLetterOrDigit(next)) {
-                    patternBuilder.append("\\\\s+");
+                    patternBuilder.append("\\s+");
                 } else {
-                    patternBuilder.append("\\\\s*");
+                    patternBuilder.append("\\s*");
                 }
                 int nextIndex = index + 1;
                 while (nextIndex < chars.length && Character.isWhitespace(chars[nextIndex])) {

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/EnumMemberStartCorrectionResolver.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/EnumMemberStartCorrectionResolver.java
@@ -1,0 +1,86 @@
+package io.github.lemon_ant.jharmonizer.core.translator.spoon;
+
+import java.util.Comparator;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import spoon.reflect.declaration.CtTypeMember;
+
+@UtilityClass
+final class EnumMemberStartCorrectionResolver {
+
+    @NonNull
+    static Map<CtTypeMember, Integer> resolveCorrectedStarts(
+            @NonNull String srcCode, @NonNull List<CtTypeMember> explicitTypeMembers) {
+        CtTypeMember firstMember = explicitTypeMembers.stream()
+                .min(Comparator.comparingInt(member -> member.getPosition().getSourceStart()))
+                .orElseThrow(() -> new IllegalStateException("Expected at least one explicit type member"));
+
+        int srcStart = firstMember.getPosition().getSourceStart();
+        int srcEnd = firstMember.getPosition().getSourceEnd();
+        String memberSourceFragment = srcCode.substring(srcStart, srcEnd + 1);
+        String firstLine = firstMember.toString().lines().findFirst().orElseThrow(
+                () -> new IllegalStateException("Failed to find first line for enum member"))
+                .trim();
+        if (firstLine.isEmpty()) {
+            throw new IllegalStateException("First line for enum member is blank");
+        }
+
+        Pattern pattern = Pattern.compile(buildFirstLinePattern(firstLine));
+        Matcher matcher = pattern.matcher(memberSourceFragment);
+        if (!matcher.find() || matcher.start() == 0) {
+            return Collections.emptyMap();
+        }
+        return Map.of(firstMember, srcStart + matcher.start());
+    }
+
+    @NonNull
+    private static String buildFirstLinePattern(@NonNull String line) {
+        StringBuilder patternBuilder = new StringBuilder();
+        char[] chars = line.toCharArray();
+        int index = 0;
+        while (index < chars.length) {
+            char current = chars[index];
+            if (Character.isWhitespace(current)) {
+                char previous = findPreviousNonWhitespace(chars, index - 1);
+                char next = findNextNonWhitespace(chars, index + 1);
+                if (Character.isLetterOrDigit(previous) && Character.isLetterOrDigit(next)) {
+                    patternBuilder.append("\\\\s+");
+                } else {
+                    patternBuilder.append("\\\\s*");
+                }
+                int nextIndex = index + 1;
+                while (nextIndex < chars.length && Character.isWhitespace(chars[nextIndex])) {
+                    nextIndex++;
+                }
+                index = nextIndex;
+            } else {
+                patternBuilder.append(Pattern.quote(String.valueOf(current)));
+                index++;
+            }
+        }
+        return patternBuilder.toString();
+    }
+
+    private static char findPreviousNonWhitespace(char[] chars, int index) {
+        for (int cursor = index; cursor >= 0; cursor--) {
+            if (!Character.isWhitespace(chars[cursor])) {
+                return chars[cursor];
+            }
+        }
+        return '\0';
+    }
+
+    private static char findNextNonWhitespace(char[] chars, int index) {
+        for (int cursor = index; cursor < chars.length; cursor++) {
+            if (!Character.isWhitespace(chars[cursor])) {
+                return chars[cursor];
+            }
+        }
+        return '\0';
+    }
+}

--- a/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
+++ b/core/src/main/java/io/github/lemon_ant/jharmonizer/core/translator/spoon/SpoonTypePrinter.java
@@ -12,7 +12,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import lombok.AccessLevel;
 import lombok.NonNull;
@@ -54,7 +53,6 @@ final class SpoonTypePrinter {
         }
         SourcePosition typePosition = type.getPosition();
         List<CtTypeMember> explicitTypeMembers = findExplicitTypeMembers(type);
-
         if (explicitTypeMembers.isEmpty()) {
             // If no nested elements, then print the original source fragment entirely
             // TODO Check if we have comments before and after
@@ -62,8 +60,12 @@ final class SpoonTypePrinter {
                     .writeln();
             return;
         }
+        Map<CtTypeMember, Integer> correctedEnumMemberStarts = type instanceof CtEnum<?>
+                ? EnumMemberStartCorrectionResolver.resolveCorrectedStarts(originalSrcCode, explicitTypeMembers)
+                : Collections.emptyMap();
         int minMemberStart = explicitTypeMembers.stream()
-                .mapToInt(typeMember -> typeMember.getPosition().getSourceStart())
+                .mapToInt(typeMember -> correctedEnumMemberStarts.getOrDefault(
+                        typeMember, typeMember.getPosition().getSourceStart()))
                 .min()
                 .orElseThrow(() ->
                         new IllegalStateException("Failed to compute first member start from explicit type members"));
@@ -71,7 +73,7 @@ final class SpoonTypePrinter {
         if (type instanceof CtEnum<?>) {
             tokenWriter.writeln();
         }
-        printTypeMembers(explicitTypeMembers);
+        printTypeMembers(explicitTypeMembers, correctedEnumMemberStarts);
         int maxMemberEnd = explicitTypeMembers.stream()
                 .mapToInt(typeMember -> typeMember.getPosition().getSourceEnd())
                 .max()
@@ -116,12 +118,6 @@ final class SpoonTypePrinter {
     @NonNull
     private static List<CtTypeMember> findExplicitTypeMembers(CtType<?> type) {
         return type.getTypeMembers().stream()
-                // Spoon quirk: getTypeMembers() of a type may also include members whose declaring type
-                // is a nested/anonymous class (e.g., the anonymous classes of enum constants). We only want
-                // members that are declared directly in `type`, otherwise those nested members would be
-                // printed as if they were top-level members of `type`.
-                .filter(typeMember -> Objects.equals(typeMember.getDeclaringType(), type))
-                .filter(typeMember -> Objects.equals(typeMember.getParent(), type))
                 // Spoon creates implicit constructors which don't exist in the source code
                 .filter(typeMember -> typeMember.getPosition().isValidPosition())
                 /* TODO(RECORDS_DISABLED): Remove this guard when record headers/components are printed correctly.
@@ -130,12 +126,13 @@ final class SpoonTypePrinter {
                 .toList();
     }
 
-    private void printTypeMembers(List<CtTypeMember> explicitTypeMembers) {
+    private void printTypeMembers(
+            List<CtTypeMember> explicitTypeMembers, Map<CtTypeMember, Integer> correctedEnumMemberStarts) {
         boolean first = true;
         boolean previousElementNeedSeparatorAfter = false;
         for (CtTypeMember member : explicitTypeMembers) {
-            previousElementNeedSeparatorAfter =
-                    printTypeMember(member, explicitTypeMembers, first, previousElementNeedSeparatorAfter);
+            previousElementNeedSeparatorAfter = printTypeMember(
+                    member, explicitTypeMembers, correctedEnumMemberStarts, first, previousElementNeedSeparatorAfter);
             first = false;
         }
     }
@@ -143,6 +140,7 @@ final class SpoonTypePrinter {
     private boolean printTypeMember(
             CtTypeMember member,
             List<CtTypeMember> explicitTypeMembers,
+            Map<CtTypeMember, Integer> correctedEnumMemberStarts,
             boolean first,
             boolean previousElementNeedSeparatorAfter) {
         // TODO Check Orphaned comments
@@ -169,11 +167,15 @@ final class SpoonTypePrinter {
         }
 
         int nextElementStart = explicitTypeMembers.stream()
-                .mapToInt(typeMember -> typeMember.getPosition().getSourceStart())
-                .filter(start -> start > member.getPosition().getSourceStart())
+                .mapToInt(typeMember -> correctedEnumMemberStarts.getOrDefault(
+                        typeMember, typeMember.getPosition().getSourceStart()))
+                .filter(start -> start > member.getPosition().getSourceEnd())
                 .min()
                 .orElse(member.getPosition().getSourceEnd() + 1);
-        printOriginalFragment(member.getPosition().getSourceStart(), nextElementStart - 1);
+        printOriginalFragment(
+                correctedEnumMemberStarts.getOrDefault(
+                        member, member.getPosition().getSourceStart()),
+                nextElementStart - 1);
         return currentElementNeedsSeparatorAfter;
     }
 

--- a/core/src/test/resources/test-cases/core/e2e/regression/06-enum-lambda-body-member-boundary/expected/EnumLambdaBodyMemberBoundaryRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/06-enum-lambda-body-member-boundary/expected/EnumLambdaBodyMemberBoundaryRegressionSample.java
@@ -1,0 +1,44 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public enum EnumLambdaBodyMemberBoundaryRegressionSample {
+    FIRST(value -> value, false),
+
+    BROKEN(
+            value -> {
+                final long normalized = Math.max(1, value);
+                if (normalized > 10) {
+                    // Keep non-zero values visible in reduced form.
+                    return 10;
+                }
+                return normalized;
+            },
+            true);
+
+    private final MetricDescriptor descriptor;
+    private final boolean visible;
+
+    public MetricDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    EnumLambdaBodyMemberBoundaryRegressionSample(final ValueMapper mapper, final boolean visible) {
+        this.descriptor = new MetricDescriptor(mapper);
+        this.visible = visible;
+    }
+
+    private interface ValueMapper {
+        long apply(long value);
+    }
+
+    private static final class MetricDescriptor {
+        private final ValueMapper mapper;
+
+        private MetricDescriptor(final ValueMapper mapper) {
+            this.mapper = mapper;
+        }
+    }
+}

--- a/core/src/test/resources/test-cases/core/e2e/regression/06-enum-lambda-body-member-boundary/input/EnumLambdaBodyMemberBoundaryRegressionSample.java
+++ b/core/src/test/resources/test-cases/core/e2e/regression/06-enum-lambda-body-member-boundary/input/EnumLambdaBodyMemberBoundaryRegressionSample.java
@@ -1,0 +1,45 @@
+package io.github.lemon_ant.jharmonizer.core.e2e;
+
+public enum EnumLambdaBodyMemberBoundaryRegressionSample {
+    FIRST(value -> value, false),
+
+    BROKEN(
+            value -> {
+                final long normalized = Math.max(1, value);
+                if (normalized > 10) {
+                    // Keep non-zero values visible in reduced form.
+                    return 10;
+                }
+                return normalized;
+            },
+            true
+    );
+
+    public MetricDescriptor getDescriptor() {
+        return descriptor;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    private final MetricDescriptor descriptor;
+    private final boolean visible;
+
+    EnumLambdaBodyMemberBoundaryRegressionSample(final ValueMapper mapper, final boolean visible) {
+        this.descriptor = new MetricDescriptor(mapper);
+        this.visible = visible;
+    }
+
+    private interface ValueMapper {
+        long apply(long value);
+    }
+
+    private static final class MetricDescriptor {
+        private final ValueMapper mapper;
+
+        private MetricDescriptor(final ValueMapper mapper) {
+            this.mapper = mapper;
+        }
+    }
+}


### PR DESCRIPTION
- [x] Fix double-escaped regex whitespace patterns in `EnumMemberStartCorrectionResolver.buildFirstLinePattern()` (`"\\\\s+"` → `"\\s+"`, `"\\\\s*"` → `"\\s*"`)
- [x] Add missing JavaDoc on `resolveCorrectedStarts` (non-private method, required by convention)
- [x] Code review passed (no issues)
- [x] CodeQL: 0 alerts