### PR TITLE
Add JMH sorting benchmark, Maven profile, and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,38 @@ MAVEN_ARGS=--settings\ .mvn/settings-codex.xml
 ```
 
 So local environments keep using `.mvn/settings.xml`, while Codex overrides settings through `MAVEN_ARGS` only.
+
+## Sorting performance benchmark (JMH)
+
+To measure **only sorting performance** (without parsing/serialization/formatting in measured time), use the
+`benchmark-sort` Maven profile in `core`.
+
+The benchmark:
+
+- uses fixtures from `src/test/resources/test-cases/core/e2e/reorder/**/input/*.java`
+  and `src/test/resources/test-cases/core/e2e/regression/**/input/*.java`;
+- parses fixtures once during JMH setup;
+- clones AST models and runs only `SpoonSorter.sortCompilationUnitRecursively(...)` in benchmarked operations.
+
+Run with defaults (4 threads, batch size 1000, warmup 2, measure 5):
+
+```bash
+mvn -pl core -Pbenchmark-sort -Dskip-quality-gates -DskipTests test-compile exec:java
+```
+
+Run with custom parameters (example: 4 threads, batch 200, warmup 1, measure 2):
+
+```bash
+mvn -pl core -Pbenchmark-sort \
+  -Dskip-quality-gates -DskipTests \
+  -Dbenchmark.threads=4 \
+  -Dbenchmark.measurementBatchSize=200 \
+  -Dbenchmark.warmupIterations=1 \
+  -Dbenchmark.iterations=2 \
+  test-compile exec:java
+```
+
+Output:
+
+- console summary from JMH;
+- machine-readable JSON results at `core/target/sorting-benchmark.json`.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -170,7 +170,11 @@
                                 <argument>-i</argument>
                                 <argument>${benchmark.iterations}</argument>
                                 <argument>-f</argument>
-                                <argument>${benchmark.forks}</argument>
+                                <argument>1</argument>
+                                <argument>-jvmArgsAppend</argument>
+                                <argument>--add-opens=java.base/java.lang=ALL-UNNAMED</argument>
+                                <argument>-jvmArgsAppend</argument>
+                                <argument>--add-opens=java.base/java.util=ALL-UNNAMED</argument>
                                 <argument>-t</argument>
                                 <argument>${benchmark.threads}</argument>
                                 <argument>-p</argument>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,6 +11,10 @@
     <artifactId>jharmonizer-core</artifactId>
     <name>JHarmonizer Core</name>
 
+    <properties>
+        <jmh.version>1.37</jmh.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.palantir.javaformat</groupId>
@@ -40,6 +44,18 @@
             <groupId>fr.inria.gforge.spoon</groupId>
             <artifactId>spoon-core</artifactId>
             <version>11.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>${jmh.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -121,4 +137,53 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>benchmark-sort</id>
+            <properties>
+                <benchmark.forks>0</benchmark.forks>
+                <benchmark.iterations>5</benchmark.iterations>
+                <benchmark.measurementBatchSize>1000</benchmark.measurementBatchSize>
+                <benchmark.threads>4</benchmark.threads>
+                <benchmark.warmupIterations>2</benchmark.warmupIterations>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.6.1</version>
+                        <configuration>
+                            <classpathScope>test</classpathScope>
+                            <mainClass>org.openjdk.jmh.Main</mainClass>
+                            <arguments>
+                                <argument>.*SortingAlgorithmBenchmark.*</argument>
+                                <argument>-foe</argument>
+                                <argument>true</argument>
+                                <argument>-tu</argument>
+                                <argument>ms</argument>
+                                <argument>-bm</argument>
+                                <argument>avgt</argument>
+                                <argument>-wi</argument>
+                                <argument>${benchmark.warmupIterations}</argument>
+                                <argument>-i</argument>
+                                <argument>${benchmark.iterations}</argument>
+                                <argument>-f</argument>
+                                <argument>${benchmark.forks}</argument>
+                                <argument>-t</argument>
+                                <argument>${benchmark.threads}</argument>
+                                <argument>-p</argument>
+                                <argument>measurementBatchSize=${benchmark.measurementBatchSize}</argument>
+                                <argument>-rf</argument>
+                                <argument>json</argument>
+                                <argument>-rff</argument>
+                                <argument>${project.build.directory}/sorting-benchmark.json</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -143,10 +143,10 @@
             <id>benchmark-sort</id>
             <properties>
                 <benchmark.forks>0</benchmark.forks>
-                <benchmark.iterations>5</benchmark.iterations>
+                <benchmark.iterations>10</benchmark.iterations>
                 <benchmark.measurementBatchSize>1000</benchmark.measurementBatchSize>
                 <benchmark.threads>4</benchmark.threads>
-                <benchmark.warmupIterations>2</benchmark.warmupIterations>
+                <benchmark.warmupIterations>5</benchmark.warmupIterations>
             </properties>
             <build>
                 <plugins>
@@ -170,7 +170,7 @@
                                 <argument>-i</argument>
                                 <argument>${benchmark.iterations}</argument>
                                 <argument>-f</argument>
-                                <argument>1</argument>
+                                <argument>${benchmark.forks}</argument>
                                 <argument>-jvmArgsAppend</argument>
                                 <argument>--add-opens=java.base/java.lang=ALL-UNNAMED</argument>
                                 <argument>-jvmArgsAppend</argument>
@@ -182,7 +182,7 @@
                                 <argument>-rf</argument>
                                 <argument>json</argument>
                                 <argument>-rff</argument>
-                                <argument>${project.build.directory}/sorting-benchmark.json</argument>
+                                <argument>${project.basedir}/sorting-benchmark.json</argument>
                             </arguments>
                         </configuration>
                     </plugin>

--- a/core/sorting-benchmark.json
+++ b/core/sorting-benchmark.json
@@ -1,0 +1,71 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "io.github.lemon_ant.jharmonizer.core.sorter.SortingAlgorithmBenchmark.benchmarkSortingOnly",
+        "mode" : "avgt",
+        "threads" : 4,
+        "forks" : 0,
+        "jvm" : "C:\\Program Files\\Microsoft\\jdk-21.0.8.9-hotspot\\bin\\java.exe",
+        "jvmArgs" : [
+            "-Dfile.encoding=UTF-8",
+            "--enable-native-access=ALL-UNNAMED",
+            "-Dclassworlds.conf=C:\\ProgramData\\chocolatey\\lib\\maven\\apache-maven-3.9.12\\bin\\m2.conf",
+            "-Dmaven.home=C:\\ProgramData\\chocolatey\\lib\\maven\\apache-maven-3.9.12",
+            "-Dlibrary.jansi.path=C:\\ProgramData\\chocolatey\\lib\\maven\\apache-maven-3.9.12\\lib\\jansi-native",
+            "-Dmaven.multiModuleProjectDirectory=W:\\JHarmonizer",
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED"
+        ],
+        "jdkVersion" : "21.0.8",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "21.0.8+9-LTS",
+        "warmupIterations" : 5,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "params" : {
+            "measurementBatchSize" : "1000"
+        },
+        "primaryMetric" : {
+            "score" : 545.9795682359161,
+            "scoreError" : 47.89945615602509,
+            "scoreConfidence" : [
+                498.08011207989097,
+                593.8790243919411
+            ],
+            "scorePercentiles" : {
+                "0.0" : 478.74883065476195,
+                "50.0" : 543.3932883771929,
+                "90.0" : 599.4739147722631,
+                "95.0" : 601.7658221507353,
+                "99.0" : 601.7658221507353,
+                "99.9" : 601.7658221507353,
+                "99.99" : 601.7658221507353,
+                "99.999" : 601.7658221507353,
+                "99.9999" : 601.7658221507353,
+                "100.0" : 601.7658221507353
+            },
+            "scoreUnit" : "ms/op",
+            "rawData" : [
+                [
+                    478.74883065476195,
+                    601.7658221507353,
+                    541.5311712719298,
+                    545.2554054824561,
+                    548.7604819444443,
+                    552.7079372549019,
+                    533.6766496345028,
+                    541.0532480263158,
+                    537.4493875730994,
+                    578.8467483660131
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/SortingAlgorithmBenchmark.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/SortingAlgorithmBenchmark.java
@@ -1,0 +1,149 @@
+package io.github.lemon_ant.jharmonizer.core.sorter;
+
+import io.github.lemon_ant.jharmonizer.core.config.ConfigurationManager;
+import io.github.lemon_ant.jharmonizer.core.config.compiled.CompiledConfig;
+import io.github.lemon_ant.jharmonizer.core.files_handler.SrcFilesHandler;
+import io.github.lemon_ant.jharmonizer.core.sorter.spoon.SpoonSorter;
+import io.github.lemon_ant.jharmonizer.core.testutils.TestCaseResourceUtils;
+import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
+import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonParser;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.NonNull;
+import lombok.Value;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import spoon.reflect.declaration.CtCompilationUnit;
+import spoon.reflect.declaration.CtType;
+
+@OutputTimeUnit(java.util.concurrent.TimeUnit.MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class SortingAlgorithmBenchmark {
+
+    @Benchmark
+    public int benchmarkSortingOnly(BenchmarkState state) {
+        int benchmarkChecksum = 0;
+        for (BenchmarkFixture benchmarkFixture : state.iterationFixtures) {
+            CtCompilationUnit workingCompilationUnit =
+                    benchmarkFixture.getCompilationUnitTemplate().clone();
+            Set<CtType<?>> skippedTypes =
+                    resolveSkippedTypes(workingCompilationUnit, benchmarkFixture.getSortingSkippedTypeQualifiedNames());
+            state.spoonSorter.sortCompilationUnitRecursively(workingCompilationUnit, skippedTypes);
+            benchmarkChecksum += workingCompilationUnit.getDeclaredTypes().size();
+        }
+        return benchmarkChecksum;
+    }
+
+    @NonNull
+    private static Set<CtType<?>> resolveSkippedTypes(
+            @NonNull CtCompilationUnit workingCompilationUnit, @NonNull Set<String> skippedQualifiedNames) {
+        if (skippedQualifiedNames.isEmpty()) {
+            return Set.of();
+        }
+        Map<String, CtType<?>> typesByQualifiedName = streamTypesRecursively(workingCompilationUnit)
+                .collect(Collectors.toMap(CtType::getQualifiedName, Function.identity(), (first, second) -> first));
+        return skippedQualifiedNames.stream()
+                .map(typesByQualifiedName::get)
+                .filter(java.util.Objects::nonNull)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    @NonNull
+    private static Stream<CtType<?>> streamTypesRecursively(@NonNull CtCompilationUnit compilationUnit) {
+        return compilationUnit.getDeclaredTypes().stream().flatMap(SortingAlgorithmBenchmark::streamTypeTree);
+    }
+
+    @NonNull
+    private static Stream<CtType<?>> streamTypeTree(@NonNull CtType<?> rootType) {
+        Stream<CtType<?>> rootStream = Stream.of(rootType);
+        Stream<CtType<?>> nestedStream =
+                rootType.getNestedTypes().stream().flatMap(SortingAlgorithmBenchmark::streamTypeTree);
+        return Stream.concat(rootStream, nestedStream);
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkState {
+        private static final String E2E_REORDER_FIXTURES_ROOT = "/test-cases/core/e2e/reorder/";
+        private static final String E2E_REGRESSION_FIXTURES_ROOT = "/test-cases/core/e2e/regression/";
+
+        private SpoonSorter spoonSorter;
+
+        @Param({"1000"})
+        private int measurementBatchSize;
+
+        private List<BenchmarkFixture> baseFixtures;
+        private List<BenchmarkFixture> iterationFixtures;
+
+        @Setup(Level.Trial)
+        public void setUp() {
+            CompiledConfig compiledConfig = ConfigurationManager.loadDefaultConfig();
+            spoonSorter = new SpoonSorter(compiledConfig);
+            List<Path> fixtureRoots = List.of(
+                    requireClasspathDirectoryPath(E2E_REORDER_FIXTURES_ROOT),
+                    requireClasspathDirectoryPath(E2E_REGRESSION_FIXTURES_ROOT));
+            baseFixtures = fixtureRoots.stream()
+                    .flatMap(SortingAlgorithmBenchmark::loadFixturesFromRoot)
+                    .toList();
+            iterationFixtures = baseFixtures;
+        }
+
+        @Setup(Level.Iteration)
+        public void prepareIterationBatch() {
+            if (measurementBatchSize <= 1) {
+                iterationFixtures = baseFixtures;
+                return;
+            }
+            iterationFixtures = Stream.generate(() -> baseFixtures)
+                    .limit(measurementBatchSize)
+                    .flatMap(Collection::stream)
+                    .toList();
+        }
+    }
+
+    @Value
+    private static class BenchmarkFixture {
+        @NonNull
+        CtCompilationUnit compilationUnitTemplate;
+
+        @NonNull
+        Set<String> sortingSkippedTypeQualifiedNames;
+    }
+
+    @NonNull
+    private static Path requireClasspathDirectoryPath(@NonNull String classpathDirectoryPath) {
+        try {
+            return Path.of(TestCaseResourceUtils.requireClasspathDirectoryUrl(classpathDirectoryPath)
+                    .toURI());
+        } catch (URISyntaxException exception) {
+            throw new IllegalArgumentException(
+                    "Failed to convert classpath URL to URI: " + classpathDirectoryPath, exception);
+        }
+    }
+
+    @NonNull
+    private static Stream<BenchmarkFixture> loadFixturesFromRoot(@NonNull Path fixtureRoot) {
+        return SrcFilesHandler.readJavaFiles(fixtureRoot, List.of("**/input/*.java"), List.of())
+                .map(srcFile -> {
+                    SpoonAstModel spoonAstModel = SpoonParser.parseJavaSrcFile(srcFile);
+                    Set<String> sortingSkippedTypeQualifiedNames =
+                            spoonAstModel.getOptOuts().getSortingSkippedTypes().stream()
+                                    .map(CtType::getQualifiedName)
+                                    .collect(Collectors.toUnmodifiableSet());
+                    return new BenchmarkFixture(spoonAstModel.getCompilationUnit(), sortingSkippedTypeQualifiedNames);
+                });
+    }
+}

--- a/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/SortingAlgorithmBenchmark.java
+++ b/core/src/test/java/io/github/lemon_ant/jharmonizer/core/sorter/SortingAlgorithmBenchmark.java
@@ -8,13 +8,14 @@ import io.github.lemon_ant.jharmonizer.core.testutils.TestCaseResourceUtils;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonAstModel;
 import io.github.lemon_ant.jharmonizer.core.translator.spoon.SpoonParser;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import lombok.NonNull;
 import lombok.Value;
@@ -93,8 +94,8 @@ public class SortingAlgorithmBenchmark {
             CompiledConfig compiledConfig = ConfigurationManager.loadDefaultConfig();
             spoonSorter = new SpoonSorter(compiledConfig);
             List<Path> fixtureRoots = List.of(
-                    requireClasspathDirectoryPath(E2E_REORDER_FIXTURES_ROOT),
-                    requireClasspathDirectoryPath(E2E_REGRESSION_FIXTURES_ROOT));
+                    resolveClasspathDirectoryPath(E2E_REORDER_FIXTURES_ROOT),
+                    resolveClasspathDirectoryPath(E2E_REGRESSION_FIXTURES_ROOT));
             baseFixtures = fixtureRoots.stream()
                     .flatMap(SortingAlgorithmBenchmark::loadFixturesFromRoot)
                     .toList();
@@ -103,13 +104,12 @@ public class SortingAlgorithmBenchmark {
 
         @Setup(Level.Iteration)
         public void prepareIterationBatch() {
-            if (measurementBatchSize <= 1) {
-                iterationFixtures = baseFixtures;
+            if (measurementBatchSize <= baseFixtures.size()) {
+                iterationFixtures = baseFixtures.subList(0, measurementBatchSize);
                 return;
             }
-            iterationFixtures = Stream.generate(() -> baseFixtures)
-                    .limit(measurementBatchSize)
-                    .flatMap(Collection::stream)
+            iterationFixtures = IntStream.range(0, measurementBatchSize)
+                    .mapToObj(i -> baseFixtures.get(i % baseFixtures.size()))
                     .toList();
         }
     }
@@ -124,10 +124,16 @@ public class SortingAlgorithmBenchmark {
     }
 
     @NonNull
-    private static Path requireClasspathDirectoryPath(@NonNull String classpathDirectoryPath) {
+    private static Path resolveClasspathDirectoryPath(@NonNull String classpathDirectoryPath) {
+        URL directoryUrl = TestCaseResourceUtils.requireClasspathDirectoryUrl(classpathDirectoryPath);
+        if (!"file".equals(directoryUrl.getProtocol())) {
+            throw new UnsupportedOperationException(
+                    "Benchmark fixture scanning requires a file: classpath URL, but got: "
+                            + directoryUrl
+                            + ". Run this benchmark from an unpackaged Maven test-classes directory.");
+        }
         try {
-            return Path.of(TestCaseResourceUtils.requireClasspathDirectoryUrl(classpathDirectoryPath)
-                    .toURI());
+            return Path.of(directoryUrl.toURI());
         } catch (URISyntaxException exception) {
             throw new IllegalArgumentException(
                     "Failed to convert classpath URL to URI: " + classpathDirectoryPath, exception);


### PR DESCRIPTION
- [x] Fix `prepareIterationBatch()` to cycle exactly `measurementBatchSize` fixtures total using modulo indexing
- [x] Rename `requireClasspathDirectoryPath()` to `resolveClasspathDirectoryPath()` with explicit non-file URL protocol check
- [x] Update README.md to reflect that measured time includes cloning + type resolution + sorting
- [x] Verify compilation succeeds