### PR TITLE
docs: document Palantir formatter non-deterministic trailing-comment reflow and add SPDX headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ The following are intentionally unsupported and ignored with a warning:
 - `@jharmonizer:on`, `@jharmonizer:format-off`, `@jharmonizer:format-on`, and similar variants
 - directives inside method bodies or inside Javadoc
 
-## Known formatter edge case: non-deterministic trailing line-comment wrapping
+## Known formatter edge case: non-deterministic reflow across repeated runs
 
-Palantir formatter can produce non-idempotent output for some long trailing `//` comments attached to wrapped
-expressions. In observed cases this affects **both comment indentation and code layout** between consecutive runs.
+Palantir formatter can produce non-idempotent output for some long or heavily wrapped constructs. In observed
+cases this affects **both comment indentation and code layout** between consecutive runs; some cases involve
+trailing `//` comments attached to wrapped expressions, while others affect wrapped expressions more generally.
 
 Concrete examples:
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # JHarmonizer
 
 JHarmonizer is a Java source harmonization tool that keeps class member layout deterministic and readable.
@@ -76,6 +81,87 @@ The following are intentionally unsupported and ignored with a warning:
 - region-based `off/on` markers
 - `@jharmonizer:on`, `@jharmonizer:format-off`, `@jharmonizer:format-on`, and similar variants
 - directives inside method bodies or inside Javadoc
+
+## Known formatter edge case: non-deterministic trailing line-comment wrapping
+
+Palantir formatter can produce non-idempotent output for some long trailing `//` comments attached to wrapped
+expressions. In observed cases this affects **both comment indentation and code layout** between consecutive runs.
+
+Concrete examples:
+
+```java
+// pass 1
+assertEquals(
+    2L,
+    recovery.getMaxTransactionId()); // transaction ID is still 2 because that's what was written to the
+                                     // journal
+
+// pass 2
+assertEquals(
+    2L,
+    recovery.getMaxTransactionId()); // transaction ID is still 2 because that's what was written to the
+// journal
+```
+
+```java
+// pass 1
+factory.setShutdownQuietPeriod(
+        Duration
+                .ZERO); // Quiet period not necessary since sending threads will have completed before shutting
+                        // down event sender
+
+// pass 2
+factory.setShutdownQuietPeriod(
+        Duration.ZERO); // Quiet period not necessary since sending threads will have completed before shutting
+        // down event sender
+```
+
+
+```java
+// pass 1
+@WritesAttribute(
+        attribute = "http.headers.XXX",
+        description =
+                "Each of the HTTP Headers that is received in the request will be added as an attribute, prefixed"
+                        + " with \"http.headers.\" For example, if the request contains an HTTP Header named"
+                        + " \"x-my-header\", then the value will be added to an attribute named"
+                        + " \"http.headers.x-my-header\""),
+
+// pass 2
+@WritesAttribute(
+        attribute = "http.headers.XXX",
+        description =
+                "Each of the HTTP Headers that is received in the request will be added as an attribute, prefixed"
+                            + " with \"http.headers.\" For example, if the request contains an HTTP Header named"
+                            + " \"x-my-header\", then the value will be added to an attribute named"
+                            + " \"http.headers.x-my-header\""),
+```
+
+```java
+// pass 1
+@Around(
+        "within(org.apache.nifi.web.dao.ProcessGroupDAO+) && execution(void enableComponents(String,"
+                + " org.apache.nifi.controller.ScheduledState, java.util.Set<String>)) && args(groupId, state,"
+                + " componentIds)")
+public void enableComponentsAdvice(
+
+// pass 2
+@Around("within(org.apache.nifi.web.dao.ProcessGroupDAO+) && execution(void enableComponents(String,"
+        + " org.apache.nifi.controller.ScheduledState, java.util.Set<String>)) && args(groupId, state,"
+        + " componentIds)")
+public void enableComponentsAdvice(
+        ProceedingJoinPoint proceedingJoinPoint, String groupId, ScheduledState state, Set<String> componentIds)
+        throws Throwable {
+```
+
+This behavior is upstream in Palantir formatter and not introduced by JHarmonizer.
+
+Workarounds:
+
+1. For inline comments: avoid long trailing `//` comments; move long notes to a standalone line (or short block comment) above the statement.
+2. For long annotation/string concatenations: prefer extracting long literals/expressions into named constants (or helper variables/methods) so formatter has fewer fragile wrap points.
+3. Keep annotation argument values and fluent/pointcut expressions shorter per line where practical to reduce wrap oscillation risk.
+4. If the file still oscillates between formatter runs, use `@jharmonizer:sort-off` (keeps formatting but disables sorting) or `@jharmonizer:fully-off` (disables harmonization) as a temporary mitigation.
 
 ## Maven/archetype template placeholders (`package ${package};`)
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Workarounds:
 1. For inline comments: avoid long trailing `//` comments; move long notes to a standalone line (or short block comment) above the statement.
 2. For long annotation/string concatenations: prefer extracting long literals/expressions into named constants (or helper variables/methods) so formatter has fewer fragile wrap points.
 3. Keep annotation argument values and fluent/pointcut expressions shorter per line where practical to reduce wrap oscillation risk.
-4. If the file still oscillates between formatter runs, use `@jharmonizer:sort-off` (keeps formatting but disables sorting) or `@jharmonizer:fully-off` (disables harmonization) as a temporary mitigation.
+4. If the file still oscillates between formatter runs, use `// @jharmonizer:sort-off` (keeps formatting but disables sorting) or `// @jharmonizer:fully-off` (disables harmonization) as a temporary mitigation.
 
 ## Maven/archetype template placeholders (`package ${package};`)
 

--- a/docs/05-Formatter.md
+++ b/docs/05-Formatter.md
@@ -75,7 +75,7 @@ This wrapper is essential to finalize formatted, readable Java source code that 
 Palantir Java Formatter has known edge cases where formatting is **not idempotent** for some wrapped constructs,
 including long trailing `//` comments on wrapped expressions.
 
-Observed behavior (matches the attached screenshots):
+Observed behavior:
 
 1. First formatter pass can wrap a long trailing comment and indent the continued comment line under the original
    comment token.

--- a/docs/05-Formatter.md
+++ b/docs/05-Formatter.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
 #  Formatter Wrapper
 
 ## Purpose
@@ -64,6 +69,101 @@ These parameters must be passed through the `Configuration` model and injected i
 ## Summary
 
 This wrapper is essential to finalize formatted, readable Java source code that adheres to a unified style. It should be executed only **after** AST transformation and serialization are complete.
+
+## Known limitation: non-deterministic line-comment reflow in Palantir formatter
+
+Palantir Java Formatter has a known edge case where formatting is **not idempotent** for some long trailing
+`//` comments on wrapped expressions.
+
+Observed behavior (matches the attached screenshots):
+
+1. First formatter pass can wrap a long trailing comment and indent the continued comment line under the original
+   comment token.
+2. Second formatter pass can realign that continued comment line under a wrapped code fragment.
+3. In more complex cases, the second pass can also reflow adjacent code differently (for example collapsing and
+   then re-expanding chained or wrapped invocations around the same trailing comment area).
+4. The resulting source differs between runs even when code semantics do not change.
+
+Concrete examples:
+
+```java
+// pass 1
+assertEquals(
+    2L,
+    recovery.getMaxTransactionId()); // transaction ID is still 2 because that's what was written to the
+                                     // journal
+
+// pass 2
+assertEquals(
+    2L,
+    recovery.getMaxTransactionId()); // transaction ID is still 2 because that's what was written to the
+// journal
+```
+
+```java
+// pass 1
+factory.setShutdownQuietPeriod(
+        Duration
+                .ZERO); // Quiet period not necessary since sending threads will have completed before shutting
+                        // down event sender
+
+// pass 2
+factory.setShutdownQuietPeriod(
+        Duration.ZERO); // Quiet period not necessary since sending threads will have completed before shutting
+        // down event sender
+```
+
+
+```java
+// pass 1
+@WritesAttribute(
+        attribute = "http.headers.XXX",
+        description =
+                "Each of the HTTP Headers that is received in the request will be added as an attribute, prefixed"
+                        + " with \"http.headers.\" For example, if the request contains an HTTP Header named"
+                        + " \"x-my-header\", then the value will be added to an attribute named"
+                        + " \"http.headers.x-my-header\""),
+
+// pass 2
+@WritesAttribute(
+        attribute = "http.headers.XXX",
+        description =
+                "Each of the HTTP Headers that is received in the request will be added as an attribute, prefixed"
+                            + " with \"http.headers.\" For example, if the request contains an HTTP Header named"
+                            + " \"x-my-header\", then the value will be added to an attribute named"
+                            + " \"http.headers.x-my-header\""),
+```
+
+```java
+// pass 1
+@Around(
+        "within(org.apache.nifi.web.dao.ProcessGroupDAO+) && execution(void enableComponents(String,"
+                + " org.apache.nifi.controller.ScheduledState, java.util.Set<String>)) && args(groupId, state,"
+                + " componentIds)")
+public void enableComponentsAdvice(
+
+// pass 2
+@Around("within(org.apache.nifi.web.dao.ProcessGroupDAO+) && execution(void enableComponents(String,"
+        + " org.apache.nifi.controller.ScheduledState, java.util.Set<String>)) && args(groupId, state,"
+        + " componentIds)")
+public void enableComponentsAdvice(
+        ProceedingJoinPoint proceedingJoinPoint, String groupId, ScheduledState state, Set<String> componentIds)
+        throws Throwable {
+```
+
+This behavior originates in the upstream formatter engine and is **not** caused by JHarmonizer sorting or rendering.
+JHarmonizer delegates formatting to Palantir formatter as-is.
+
+Practical guidance for users:
+
+- For inline comments: avoid long trailing `//` comments; move long notes to a standalone line (or short block comment)
+  above the statement.
+- For long annotation/string concatenations: prefer extracting long literals/expressions into named constants (or helper
+  variables/methods) so formatter has fewer fragile wrap points.
+- Keep annotation argument values and fluent/pointcut expressions shorter per line where practical to reduce wrap
+  oscillation risk.
+- If a file still oscillates between formatter runs, use `// @jharmonizer:sort-off` (keeps formatting but disables
+  sorting) or `// @jharmonizer:fully-off` (disables harmonization) as a temporary mitigation.
 
 ## Known limitation: template placeholders are not Java grammar
 

--- a/docs/05-Formatter.md
+++ b/docs/05-Formatter.md
@@ -70,10 +70,10 @@ These parameters must be passed through the `Configuration` model and injected i
 
 This wrapper is essential to finalize formatted, readable Java source code that adheres to a unified style. It should be executed only **after** AST transformation and serialization are complete.
 
-## Known limitation: non-deterministic line-comment reflow in Palantir formatter
+## Known limitation: non-deterministic wrapping and reflow in Palantir formatter
 
-Palantir Java Formatter has a known edge case where formatting is **not idempotent** for some long trailing
-`//` comments on wrapped expressions.
+Palantir Java Formatter has known edge cases where formatting is **not idempotent** for some wrapped constructs,
+including long trailing `//` comments on wrapped expressions.
 
 Observed behavior (matches the attached screenshots):
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # JHarmonizer — backlog of design & performance ideas
 
 This file is a living backlog of ideas that we intentionally postpone until **after** the first working version
@@ -1090,5 +1095,29 @@ because the return value of "spoon.reflect.reference.CtFieldReference.getDeclari
 - [ ] Create upstream Spoon issue with minimal reproducer from regression `03-string-selector-anonymous-chain-overflow`.
 - [ ] Attach captured stack trace and note no-classpath/e2e context where recursion occurs.
 - [ ] Revisit local `CtNewClass` guard scope after upstream fix is available.
+
+---
+
+
+### 6. Open upstream Palantir formatter issue for non-deterministic trailing comment/code reflow
+
+#### Status
+- [ ] Not filed yet
+- [ ] Collect minimal reproducer from the observed two-pass formatting diffs
+- [ ] File upstream issue in Palantir Java Formatter tracker
+
+#### Why this exists
+In specific wrapped-expression scenarios with long trailing `//` comments, one formatting run and the next
+formatting run can produce different output:
+- wrapped comment continuation line indentation can change;
+- adjacent wrapped code layout can also change between passes.
+
+This is an upstream formatter idempotency issue, not a JHarmonizer sorting/rendering issue, but we should track the
+upstream ticket and link it from our documentation once created.
+
+#### Follow-up actions
+- [ ] Create minimal Java snippets that reproduce both comment-reflow and code-reflow variants.
+- [ ] Open issue in `palantir/palantir-java-format` with exact formatter version and reproducers.
+- [ ] Add the upstream issue link to `docs/05-Formatter.md` and `README.md` after filing.
 
 ---


### PR DESCRIPTION
### Motivation
- Clarify a known upstream Palantir Java Formatter idempotency issue that can produce non-deterministic formatting for long trailing `//` comments and wrapped expressions across consecutive formatter runs. 
- Add SPDX headers to top-level documentation files and track an action item to file an upstream issue so the behavior is monitored and reproducible examples are captured.

### Description
- Add a new section to `README.md` titled "Known formatter edge case: non-deterministic trailing line-comment wrapping" that documents the issue, shows concrete reproducer examples, and lists practical workarounds. 
- Add a matching explanatory section to `docs/05-Formatter.md` describing the non-deterministic line-comment reflow, its observed behavior, and guidance to users. 
- Insert SPDX header blocks into `README.md`, `docs/05-Formatter.md`, and `docs/TODO.md`. 
- Add a new TODO entry in `docs/TODO.md` to open an upstream `palantir/palantir-java-format` issue with steps to collect reproducers and link back to the docs after filing.

### Testing
- This is a documentation-only change, so no automated unit or integration tests were required or run. 
- The repository build and test matrix were not executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e64b8fb7508325ab109bce5ba823cd)