### PR TITLE
Документировать переконфигурирование через YAML DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,30 @@ mvn jharmonizer:check-all        # report all violations
 mvn jharmonizer:check-fast   # fail fast on first violation
 ```
 
+### Reconfigure with the YAML DSL
+
+For Maven projects, create `jharmonizer.yml` in the project root next to `pom.xml` and put only the
+rules you want to override there. The Maven plugin loads that file automatically and merges it over the
+embedded defaults; if the file is absent, the defaults are used as-is.
+
+```yaml
+# jharmonizer.yml
+backups-enabled: false
+processing-statistics-mode: DISABLED
+
+type-members-ordering:
+  - name: Spring Controllers
+    includes:
+      - '@Controller'
+      - '@RestController'
+    ordering-rules: [ visibility-desc, alpha ]
+```
+
+Use `<configFile>` or `-Djharmonizer.configFile=...` if your project keeps the overlay under another name,
+for example `JHarmonizer.yaml`. See the [quick reconfiguration guide](docs/reconfiguration.md) for how
+Maven and CLI overlays are loaded and merged, and the [configuration DSL reference](docs/config-dsl.md) for
+all selector tokens, ordering rules, and YAML fields.
+
 ### CLI
 
 JHarmonizer is also available as a standalone CLI fat JAR for use outside of Maven.

--- a/cli/README.md
+++ b/cli/README.md
@@ -121,7 +121,7 @@ All commands share the same set of options (inherited from `BaseCommand`):
 | `--verbose` | `-v` | no | Enable DEBUG-level logging |
 | `--config` | `-c` | no | Path to custom YAML configuration file merged over defaults |
 | `--no-backup` | `-B` | no | Disable `.bak` file creation even if enabled in config |
-| `--no-statistics` | `-S` | no | Disable final processing statistics output |
+| `--statistics-mode` | `-s` | no | Processing statistics output mode: `FULL`, `MINIMAL`, or `DISABLED` |
 
 Glob patterns follow the `java.nio.file.PathMatcher` `glob:` syntax,
 e.g. `**/*.java`, `**/generated/**`.

--- a/docs/02-Configurator.md
+++ b/docs/02-Configurator.md
@@ -139,10 +139,10 @@ Overlays are merged with `UnifiedConfigMerger.merge(baseline, overlay)`. Behavio
 `AbstractJHarmonizerMojo` and `BaseCommand` (CLI) build a `FlexibleUnifiedConfig` from
 their own command-line / Mojo parameters and merge it on top of the file-loaded overlay:
 
-| Parameter (Mojo / CLI)                                               | Field overridden in overlay         |
-|----------------------------------------------------------------------|-------------------------------------|
-| `jharmonizer.backupsEnabled` / `--no-backup`                         | `backupsEnabled`                    |
-| `jharmonizer.printProcessingStatistics` / `--no-statistics`          | `printProcessingStatistics`         |
+| Parameter (Mojo / CLI)                                         | Field overridden in overlay  |
+|----------------------------------------------------------------|------------------------------|
+| `jharmonizer.backupsEnabled` / `--no-backup`                   | `backupsEnabled`             |
+| `jharmonizer.processingStatisticsMode` / `--statistics-mode`   | `processingStatisticsMode`   |
 
 When neither file overlay nor parameter overlay is present, the embedded default is used
 as-is.
@@ -156,11 +156,12 @@ as-is.
   `includes`/`excludes` is compiled into a single predicate over `MemberDescriptor`.
 - `TopLevelTypesOrderingCompiler.compileTopLevelTypesOrdering(...)` compiles the
   top-level types ordering rules.
-- `formatting`, `backupsEnabled`, `printProcessingStatistics`, and `headerLine` are passed
+- `formatting`, `backupsEnabled`, `processingStatisticsMode`, and `headerLine` are passed
   through unchanged.
 
 `CompiledConfig` is the immutable runtime model handed to the rest of the pipeline.
 
 ## Reference
 
+For user-facing reconfiguration workflows, see [`reconfiguration.md`](reconfiguration.md).
 For the YAML schema accepted by the loader, see [`config-dsl.md`](config-dsl.md).

--- a/docs/06-Processor.md
+++ b/docs/06-Processor.md
@@ -86,10 +86,10 @@ Each step is timed individually and the timing flows into `FlowProcessingStats`.
 
 ## Statistics output
 
-When `print-processing-statistics: true` (default), the run finishes by calling
-`ProcessingStatisticsPrintService.render(...)` on the aggregated statistic and logging
-it at `INFO`. When statistics are disabled, only a one-line debug summary plus a list
-of files with unexpected errors is logged.
+When `processing-statistics-mode` is `FULL` or `MINIMAL` (default), the run finishes
+by calling `ProcessingStatisticsPrintService.render(...)` on the aggregated statistic
+and logging it at `INFO`. When the mode is `DISABLED`, only a one-line debug summary
+plus a list of files with unexpected errors is logged.
 
 ## Backups
 

--- a/docs/08-CliRunner.md
+++ b/docs/08-CliRunner.md
@@ -37,15 +37,15 @@ The CLI is aimed at:
 
 ## Shared options (from `BaseCommand`)
 
-| Option            | Short | Description                                                                                       |
-|-------------------|-------|---------------------------------------------------------------------------------------------------|
-| `--base-dir`      | `-b`  | Base directory containing Java source files. Defaults to the current directory when not provided. |
-| `--include`       | `-i`  | Glob patterns for files to include. Repeat the option or pass a comma-separated list.             |
-| `--exclude`       | `-e`  | Glob patterns for files to exclude. Repeat the option or pass a comma-separated list.             |
-| `--verbose`       | `-v`  | Enable DEBUG-level logging and switch to a verbose log pattern.                                   |
-| `--config`        | `-c`  | Path to a YAML configuration file merged over the embedded defaults.                              |
-| `--no-backup`     | `-B`  | Disable `.bak` file creation even when backups are enabled in configuration.                      |
-| `--no-statistics` | `-S`  | Disable the final processing statistics report output.                                            |
+| Option              | Short | Description                                                                                       |
+|---------------------|-------|---------------------------------------------------------------------------------------------------|
+| `--base-dir`        | `-b`  | Base directory containing Java source files. Defaults to the current directory when not provided. |
+| `--include`         | `-i`  | Glob patterns for files to include. Repeat the option or pass a comma-separated list.             |
+| `--exclude`         | `-e`  | Glob patterns for files to exclude. Repeat the option or pass a comma-separated list.             |
+| `--verbose`         | `-v`  | Enable DEBUG-level logging and switch to a verbose log pattern.                                   |
+| `--config`          | `-c`  | Path to a YAML configuration file merged over the embedded defaults.                              |
+| `--no-backup`       | `-B`  | Disable `.bak` file creation even when backups are enabled in configuration.                      |
+| `--statistics-mode` | `-s`  | Processing statistics output mode: `FULL`, `MINIMAL`, or `DISABLED`.                             |
 
 Glob patterns follow `java.nio.file.PathMatcher` `glob:` syntax (e.g. `**/*.java`).
 

--- a/docs/09-Maven-plugin.md
+++ b/docs/09-Maven-plugin.md
@@ -47,6 +47,10 @@ in-house parallel directory walker,
 [`io.github.lemon-ant:glob-path-finder`](https://github.com/lemon-ant/glob-path-finder),
 which streams matching paths in parallel.
 
+For a quick project-level override, place `jharmonizer.yml` in the Maven project root.
+The plugin loads that default path automatically when the file exists. See the
+[reconfiguration guide](reconfiguration.md) for overlay examples and merge semantics.
+
 ## Sample usage
 
 ### Auto-reorder on every build

--- a/docs/config-dsl.md
+++ b/docs/config-dsl.md
@@ -19,14 +19,14 @@ from the defaults; root member groups are merged by name (see
 ```yaml
 formatting: { ... }
 backups-enabled: true
-print-processing-statistics: true
+processing-statistics-mode: MINIMAL
 header-line: { ... }
 top-level-types-ordering: { ... }
 type-members-ordering:
   - { ... }
 ```
 
-All seven keys are required in a strict (non-flexible) configuration; in flexible/overlay
+All six top-level keys are required in a strict (non-flexible) configuration; in flexible/overlay
 configurations any of them may be omitted and inherited from the baseline.
 
 ## `formatting`
@@ -43,9 +43,9 @@ configurations any of them may be omitted and inherited from the baseline.
 
 `boolean`. When `true`, `reorder` writes a `<file>.bak` copy of every modified source.
 
-## `print-processing-statistics`
+## `processing-statistics-mode`
 
-`boolean`. When `true`, a final processing-statistics report is printed at the end of a run.
+`FULL`, `MINIMAL`, or `DISABLED`. Controls how much processing-statistics output is printed at the end of a run.
 
 ## `header-line`
 

--- a/docs/reconfiguration.md
+++ b/docs/reconfiguration.md
@@ -1,0 +1,175 @@
+<!--
+SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reconfiguring JHarmonizer
+
+JHarmonizer is designed to start with useful embedded defaults and then accept a
+small YAML overlay for project-specific rules. You usually do **not** need to copy
+the full default configuration: put only the settings or root member groups you
+want to change into your own file.
+
+For the complete YAML syntax, selector tokens, ordering rules, and separator values,
+see the [configuration DSL reference](config-dsl.md).
+
+## Fast path for Maven projects
+
+For Maven, the quickest setup is to create a `jharmonizer.yml` file in the project
+root, next to `pom.xml`:
+
+```text
+my-project/
+├── pom.xml
+├── jharmonizer.yml
+└── src/
+```
+
+The Maven plugin checks `${project.basedir}/jharmonizer.yml` by default. If the file
+exists, it is loaded automatically and merged over the built-in defaults. If it does
+not exist, the plugin simply uses the embedded default configuration.
+
+If your repository uses another file name, for example `JHarmonizer.yaml`, point the
+plugin at it explicitly:
+
+```xml
+<plugin>
+    <groupId>io.github.lemon-ant.jharmonizer</groupId>
+    <artifactId>jharmonizer-maven-plugin</artifactId>
+    <version>1.0.1</version>
+    <configuration>
+        <configFile>${project.basedir}/JHarmonizer.yaml</configFile>
+    </configuration>
+</plugin>
+```
+
+You can also override the path for a single run:
+
+```bash
+mvn jharmonizer:reorder -Djharmonizer.configFile=JHarmonizer.yaml
+```
+
+## Minimal overlay examples
+
+### Disable backups and detailed statistics
+
+```yaml
+# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+backups-enabled: false
+processing-statistics-mode: DISABLED
+```
+
+### Change only formatting behavior
+
+```yaml
+# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+formatting:
+  fix-imports: true
+  blank-line-between-fields: true
+```
+
+Omitted formatting keys keep their default values.
+
+### Add a project-specific root member group
+
+The following overlay inserts a new root group before the default root groups. It
+collects Spring controller classes and sorts their methods by visibility and name,
+while all other classes continue to use the embedded default rules.
+
+```yaml
+# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+type-members-ordering:
+  - name: Spring Controllers
+    includes:
+      - '@Controller'
+      - '@RestController'
+    ordering-rules: [ visibility-desc, alpha ]
+    separator: new-line
+    groups:
+      - name: Fields
+        includes: field
+      - name: Constructors
+        includes: constructor
+      - name: Request Handlers
+        includes:
+          - '@~.*Mapping$'
+      - name: Other Methods
+        includes: method
+```
+
+### Replace one default root group
+
+Root member groups are merged by `name`. If an overlay defines a root group with the
+same name as a default root group, the custom group replaces that default group in
+its original position.
+
+```yaml
+# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+type-members-ordering:
+  - name: Default Rule
+    includes: ~.*
+    ordering-rules: preserve
+    groups:
+      - name: Constants
+        includes: [ field, static, final ]
+        ordering-rules: alpha
+      - name: Fields
+        includes: field
+        ordering-rules: [ visibility-desc, alpha ]
+      - name: Constructors
+        includes: constructor
+      - name: Methods
+        includes: method
+        ordering-rules: [ visibility-desc, alpha ]
+      - name: Nested Types
+        includes:
+          - class
+          - interface
+          - enum
+          - annotation
+          - record
+        ordering-rules: alpha
+```
+
+## How overlay merging works
+
+JHarmonizer builds the active configuration in layers:
+
+1. Load the embedded `default-config.yml` from `jharmonizer-core`.
+2. Load the optional YAML overlay (`jharmonizer.yml` in Maven by default, or the
+   path passed through Maven/CLI parameters).
+3. Merge the overlay over the defaults.
+4. Apply explicit Maven/CLI parameter overrides, such as `backupsEnabled` and
+   `processingStatisticsMode`.
+5. Compile the merged configuration into the runtime model used by the sorter and
+   formatter.
+
+Merge rules are intentionally simple:
+
+- scalar values such as `backups-enabled` and `processing-statistics-mode` replace
+  the default only when present;
+- nested blocks such as `formatting`, `header-line`, and `top-level-types-ordering`
+  are merged field by field;
+- `type-members-ordering` root groups are merged by `name`;
+- a custom root group with an existing default name replaces that full root group;
+- a custom root group with a new name is inserted before all default root groups;
+- nested `groups:` are not merged recursively: replacing a root group replaces its
+  whole subtree.
+
+These rules make small overlays safe: you can tune one setting, add one special group,
+or replace one named root group without duplicating the whole default configuration.
+
+## CLI equivalent
+
+The CLI uses the same overlay format, but it does not auto-discover a root file. Pass
+the configuration path explicitly:
+
+```bash
+java -jar jharmonizer-cli-1.0.1.jar reorder --base-dir src/main/java --config jharmonizer.yml
+```
+
+See [`cli/README.md`](../cli/README.md) for all CLI options and exit codes.

--- a/maven-plugin/README.md
+++ b/maven-plugin/README.md
@@ -81,6 +81,7 @@ trees with glob include/exclude patterns and additional filters.
 
 For the full reference (parameter descriptions, profile snippet, log levels,
 backup behavior), see [`docs/09-Maven-plugin.md`](../docs/09-Maven-plugin.md).
+For quick YAML overlay examples, see [`docs/reconfiguration.md`](../docs/reconfiguration.md).
 
 ## How it dispatches
 


### PR DESCRIPTION
### Motivation

- Сделать в README быстрый рецепт переконфигурирования JHarmonizer через DSL для Maven-проектов (разместить `jharmonizer.yml` в корне и показать минимальный пример). 
- Поставить подробный пользовательский гайд с примерами оверлеев, разъяснить семантику слияния (merge) и поведение плагинов/CLI при наличии пользовательской конфигурации. 
- Привести в соответствие справочную документацию и опции CLI/Maven с актуальным параметром статистики `processing-statistics-mode` (вместо устаревшего булевого `print-processing-statistics` / `--no-statistics`).

### Description

- Добавлен подробный гайд `docs/reconfiguration.md` с авто-дискавери Maven (`${project.basedir}/jharmonizer.yml`), явным указанием альтернативного имени, примерами минимальных оверлеев и описанием правил слияния (merge). 
- В `README.md` добавлен краткий раздел `Reconfigure with the YAML DSL` с примитивным `jharmonizer.yml` примером и ссылкой на новый гайд. 
- Обновлён DSL reference: `docs/config-dsl.md` заменил `print-processing-statistics` на `processing-statistics-mode` (значения `FULL` / `MINIMAL` / `DISABLED`) и скорректировал число top-level ключей для строгой конфигурации. 
- Синхронизированы справочные места и пользовательские подсказки: `docs/02-Configurator.md`, `docs/06-Processor.md`, `docs/08-CliRunner.md`, `docs/09-Maven-plugin.md`, `cli/README.md`, `maven-plugin/README.md` — в том числе переименование CLI-флага в `--statistics-mode` (`-s`) и обновление ссылок на новый гайд. 
- Ключевые измененные файлы: `README.md`, `docs/reconfiguration.md` (новый), `docs/config-dsl.md`, `docs/02-Configurator.md`, `docs/06-Processor.md`, `docs/08-CliRunner.md`, `docs/09-Maven-plugin.md`, `cli/README.md`, `maven-plugin/README.md`.

### Testing

- Выполнена полная сборка и тестовый прогон Maven: `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 MAVEN_ARGS= mvn -B -ntp verify`, сборка и тесты завершились успешно (`BUILD SUCCESS`; модульные и интеграционные тесты прогнаны). 
- Отдельный запуск `mvn` без временного обнуления `MAVEN_ARGS` сначала не прошёл из-за отсутствующего `.mvn/settings-codex.xml` в среде (пометка: окружение CI/локальная машина может переопределять `MAVEN_ARGS`). 
- Локальная валидация текстовых изменений: `git diff --check` и `git diff --cached --check` не выявили проблем (OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a010cdaac808325a81cb21389f02c99)