### PR TITLE
Bump palantir-java-format to 2.91.0 and update Jackson BOM rationale

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@ SPDX-License-Identifier: Apache-2.0
         -->
         <mockito.agent.argLine>"-javaagent:${maven.repo.local}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar"</mockito.agent.argLine>
         <mockito.version>5.23.0</mockito.version>
-        <palantir-java-format.version>2.90.0</palantir-java-format.version>
+        <palantir-java-format.version>2.91.0</palantir-java-format.version>
         <pmd.version>7.24.0</pmd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>
@@ -111,12 +111,11 @@ SPDX-License-Identifier: Apache-2.0
                 <scope>import</scope>
             </dependency>
             <!--
-                Temporary transitive vulnerability workaround: palantir-java-format 2.90.0 still resolves Jackson
-                modules to 2.21.1, which is behind this project's patched Jackson line.
-                Import the BOM here so all Jackson modules stay pinned to ${jackson.version} until that upstream
-                dependency tree is updated and no longer forces an older Jackson version. Remove this override once
-                palantir-java-format (or any other direct dependency that brings Jackson transitively) stops resolving
-                below ${jackson.version}.
+                Temporary transitive vulnerability workaround: at least one transitive dependency path still resolves
+                Jackson modules below this project's patched Jackson 2.21.3 line.
+                Import the BOM here so all Jackson modules stay pinned to 2.21.3 until that upstream dependency tree
+                is updated and no longer forces an older Jackson version. Remove this override once all direct
+                dependency trees stop resolving Jackson below 2.21.3.
             -->
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>


### PR DESCRIPTION
### Motivation
- Update the formatting plugin to `palantir-java-format.version` `2.91.0` and clarify the temporary Jackson BOM override rationale to reference the patched Jackson `2.21.3` line for a transitive vulnerability workaround.

### Description
- Change `palantir-java-format.version` from `2.90.0` to `2.91.0` and revise the surrounding comment to explain that at least one transitive dependency still resolves Jackson below `2.21.3`, so the BOM import keeps Jackson modules pinned to the patched line.

### Testing
- No automated tests were run because this is a POM-only metadata change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1438c4b19883258af2130f1de9e2b3)