### PR TITLE
Remove benchmark section from root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,6 @@ See [`docs/known-limitations.md`](docs/known-limitations.md) for details and wor
 mvn clean verify
 ```
 
-## Sorting performance benchmark (JMH)
-
-JHarmonizer includes a JMH benchmark that measures the sorting algorithm in isolation (without parsing,
-serialization, or formatting overhead). Activate with the `benchmark-sort` Maven profile.
-
-See [`docs/benchmark.md`](docs/benchmark.md) for usage instructions and output format.
-
 ## 📖 Documentation
 
 - [Javadoc (latest)](https://javadoc.io/doc/io.github.lemon-ant/jharmonizer-core)


### PR DESCRIPTION
### Motivation
- The JMH sorting benchmark is highly implementation-specific and not relevant to most users visiting the project landing page, so the brief paragraph in the root `README.md` was removed while preserving the full benchmark documentation in `docs/benchmark.md`.

### Description
- Removed the "Sorting performance benchmark (JMH)" section from the repository root `README.md` and left `docs/benchmark.md` unchanged so detailed benchmark instructions remain available.

### Testing
- Ran the full build and test suite with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 MAVEN_ARGS= mvn -B -ntp verify`, which completed successfully (`BUILD SUCCESS`) and the automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184ea8ff848325b5f83e6df3deb316)