### PR TITLE
Move opt-out directives higher in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,21 @@ different ordering rules for test classes, DTOs, annotated controllers, or other
 JHarmonizer's selector DSL provides that flexibility out of the box.
 See [docs/motivation.md](docs/motivation.md) for the full comparison.
 
+## Opt-out directives
+
+JHarmonizer supports two opt-out directives placed as source comments.
+
+```java
+// @jharmonizer:fully-off   // disable all harmonization for this file or type
+// @jharmonizer:sort-off    // disable sorting only; formatting still runs
+```
+
+Directive matching is case-insensitive. Both line (`//`) and block (`/* */`) comment forms are supported.
+Directives can be placed at **file scope** (in the compilation-unit preamble) or **type scope** (immediately
+before a type declaration).
+
+For the full reference — placement rules, scope semantics, and unsupported tokens — see [`docs/directives.md`](docs/directives.md).
+
 ## Quick Start
 
 The primary usage pattern is to integrate JHarmonizer into the Maven build so sources are automatically
@@ -180,21 +195,6 @@ The five most impactful planned features for everyday Java development:
 - **Git-aware changed-files processing** — limit sorting and checking to files that actually changed in Git (working tree vs. index, branch vs. merge-base), so large repositories stay fast in CI and pre-commit hooks.
 
 The full idea backlog is significantly longer — see [docs/TODO.md](docs/TODO.md) for the complete list, ordered from the most developer-visible features to the most internal improvements.
-
-## Opt-out directives
-
-JHarmonizer supports two opt-out directives placed as source comments.
-
-```java
-// @jharmonizer:fully-off   // disable all harmonization for this file or type
-// @jharmonizer:sort-off    // disable sorting only; formatting still runs
-```
-
-Directive matching is case-insensitive. Both line (`//`) and block (`/* */`) comment forms are supported.
-Directives can be placed at **file scope** (in the compilation-unit preamble) or **type scope** (immediately
-before a type declaration).
-
-For the full reference — placement rules, scope semantics, and unsupported tokens — see [`docs/directives.md`](docs/directives.md).
 
 ## Known limitations
 


### PR DESCRIPTION
### Motivation
- Make the README’s opt-out guidance more discoverable by placing the `Opt-out directives` section before `Quick Start` so file/type opt-out instructions appear earlier to readers.

### Description
- Moved the `Opt-out directives` section upward in `README.md` and removed the original duplicate block further down; the only modified file is `README.md`.

### Testing
- Ran `git diff --check` with no problems reported.
- Ran `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 MAVEN_ARGS= mvn -B -ntp verify` and the build completed successfully (`BUILD SUCCESS`) with the test suite passing (overall tests run: 508, failures: 0, errors: 0, skipped: 3).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185281f0e88325aa97725958f915ac)