### PR TITLE
Document formatter dependency update in changelog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ SPDX-License-Identifier: Apache-2.0
 
 - Prefer the smallest complete change that solves the reviewed problem.
 - Keep changes surgical and avoid unrelated cleanup.
+- Record every dependency addition or update, functional change, and new feature in `CHANGELOG.md` in the same task.
 - Licensing policy is mandatory for all tracked files.
   - Every tracked text/source/config/documentation file must include SPDX metadata.
   - Required SPDX lines:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ This file defines repository-wide conventions for coding agents working in this 
 
 - Prefer the smallest complete change that solves the reviewed problem.
 - Keep changes surgical and avoid unrelated cleanup.
+- Record every dependency addition or update, functional change, and new feature in `CHANGELOG.md` in the same task.
 - Licensing policy is mandatory for all tracked files in this repository.
   - Every tracked text/source/config/documentation file must include SPDX metadata.
   - Required file-level SPDX lines:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Updated Palantir Java Formatter dependency to 2.91.0.
+
 ## [1.0.1] — 2026-05-07
 
 ### Added
@@ -34,4 +40,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/benchmark.md` — JMH sorting benchmark usage.
 - GitHub Actions Verify workflow (`.github/workflows/verify.yml`) that builds and tests every push and pull request.
 
+[Unreleased]: https://github.com/lemon-ant/JHarmonizer/compare/v1.0.1...HEAD
 [1.0.1]: https://github.com/lemon-ant/JHarmonizer/releases/tag/v1.0.1


### PR DESCRIPTION
### Motivation

- Зафиксировать обновление зависимости Palantir Java Formatter на `2.91.0` в `CHANGELOG.md` чтобы релизная история отражала изменение форматтера. 
- Внедрить репозиторную конвенцию, требующую фиксировать любые добавления/обновления зависимостей, изменения функционала и новые фичи в `CHANGELOG.md` в рамках той же задачи. 
- Поддержать согласованность автоматических ассистентов, обновив `.github/copilot-instructions.md` вместе с `AGENTS.md`.

### Description

- Добавлен раздел `Unreleased` в `CHANGELOG.md` с записью: `- Updated Palantir Java Formatter dependency to 2.91.0.` и соответствующей ссылкой сравнения `[Unreleased]`. (`CHANGELOG.md`).
- В `AGENTS.md` добавлено правило: `Record every dependency addition or update, functional change, and new feature in \`CHANGELOG.md\` in the same task.` (`AGENTS.md`).
- Синхронизировано то же правило в `.github/copilot-instructions.md` чтобы Copilot и агенты имели единый набор инструкций (`.github/copilot-instructions.md`).
- Изменения закоммичены и оформлен PR с заголовком `Document formatter dependency update in changelog`.

### Testing

- Выполнен полный сборочный прогон `mvn -B -ntp verify` при `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2` и пустом `MAVEN_ARGS` и сборка завершилась успешно (`BUILD SUCCESS`) со всеми модульными и интеграционными тестами пройденными. 
- Первичная попытка `mvn -B -ntp verify` провалилась из-за окруженческой `MAVEN_ARGS` указывавшей на отсутствующий `.mvn/settings-codex.xml`, затем повтор выполнен с корректными переменными окружения и прошёл успешно. 
- Линт/проверки инфраструктуры: `git diff --check` и проверка изменений (`git diff --stat`) показали только ожидаемые правки трёх файлов (`CHANGELOG.md`, `AGENTS.md`, `.github/copilot-instructions.md`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1bce2afe58832599404da98d3abaf9)