### PR TITLE
Docs: relocate opt-out directives in README and remove SPDX headers from reconfiguration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,6 @@ different ordering rules for test classes, DTOs, annotated controllers, or other
 JHarmonizer's selector DSL provides that flexibility out of the box.
 See [docs/motivation.md](docs/motivation.md) for the full comparison.
 
-## Opt-out directives
-
-JHarmonizer supports two opt-out directives placed as source comments.
-
-```java
-// @jharmonizer:fully-off   // disable all harmonization for this file or type
-// @jharmonizer:sort-off    // disable sorting only; formatting still runs
-```
-
-Directive matching is case-insensitive. Both line (`//`) and block (`/* */`) comment forms are supported.
-Directives can be placed at **file scope** (in the compilation-unit preamble) or **type scope** (immediately
-before a type declaration).
-
-For the full reference — placement rules, scope semantics, and unsupported tokens — see [`docs/directives.md`](docs/directives.md).
-
 ## Quick Start
 
 The primary usage pattern is to integrate JHarmonizer into the Maven build so sources are automatically
@@ -147,6 +132,21 @@ java -jar jharmonizer-cli-1.0.1.jar reorder --base-dir src/main/java
 ```
 
 See [`cli/README.md`](cli/README.md) for full command-line usage, all options, exit codes, and CI integration examples.
+
+## Opt-out directives
+
+JHarmonizer supports two opt-out directives placed as source comments.
+
+```java
+// @jharmonizer:fully-off   // disable all harmonization for this file or type
+// @jharmonizer:sort-off    // disable sorting only; formatting still runs
+```
+
+Directive matching is case-insensitive. Both line (`//`) and block (`/* */`) comment forms are supported.
+Directives can be placed at **file scope** (in the compilation-unit preamble) or **type scope** (immediately
+before a type declaration).
+
+For the full reference — placement rules, scope semantics, and unsupported tokens — see [`docs/directives.md`](docs/directives.md).
 
 ## ⭐ Ways to support this project
 

--- a/docs/reconfiguration.md
+++ b/docs/reconfiguration.md
@@ -54,8 +54,6 @@ mvn jharmonizer:reorder -Djharmonizer.configFile=JHarmonizer.yaml
 ### Disable backups and detailed statistics
 
 ```yaml
-# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 backups-enabled: false
 processing-statistics-mode: DISABLED
 ```
@@ -63,8 +61,6 @@ processing-statistics-mode: DISABLED
 ### Change only formatting behavior
 
 ```yaml
-# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 formatting:
   fix-imports: true
   blank-line-between-fields: true
@@ -79,8 +75,6 @@ collects Spring controller classes and sorts their methods by visibility and nam
 while all other classes continue to use the embedded default rules.
 
 ```yaml
-# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 type-members-ordering:
   - name: Spring Controllers
     includes:
@@ -107,8 +101,6 @@ same name as a default root group, the custom group replaces that default group 
 its original position.
 
 ```yaml
-# SPDX-FileCopyrightText: 2026 Anton Lem <antonlem78@gmail.com>
-# SPDX-License-Identifier: Apache-2.0
 type-members-ordering:
   - name: Default Rule
     includes: ~.*


### PR DESCRIPTION
### Motivation

- Improve README flow by placing the opt-out directives next to the CLI instructions where users look for usage examples. 
- Remove redundant SPDX comment lines from YAML examples to keep snippets concise and focused on configuration keys.

### Description

- Moved the "Opt-out directives" section within `README.md` to appear after the CLI usage subsection. 
- Stripped `# SPDX-FileCopyrightText` and `# SPDX-License-Identifier` comment lines from example overlays in `docs/reconfiguration.md`. 
- No source code or runtime behavior was changed; this PR only updates documentation.

### Testing

- Executed the project verification build with `mvn -DskipTests=false verify` and the build completed successfully. 
- Visually inspected the modified Markdown snippets to ensure formatting and rendering remained correct.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de2d95cd48325aa226e2dd202c831)